### PR TITLE
fix: images enhancement

### DIFF
--- a/.changeset/hungry-garlics-sniff.md
+++ b/.changeset/hungry-garlics-sniff.md
@@ -1,0 +1,5 @@
+---
+"apeu": patch
+---
+
+Adds missing cover on individual pages (posts, guides and projects).

--- a/.changeset/real-flowers-exercise.md
+++ b/.changeset/real-flowers-exercise.md
@@ -1,0 +1,7 @@
+---
+"apeu": patch
+---
+
+Fixes images performance by using picture and srcset.
+
+This enables the experimental `responsiveImages` feature of Astro in addition to wrapping all images in a picture element to provide multiple sources. This also adds a `srcset` attribute to images to try to please a bit more Lighthouse.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -23,10 +23,16 @@ export default defineConfig({
   }),
   experimental: {
     contentIntellisense: true,
+    responsiveImages: true,
   },
   i18n: {
     defaultLocale: CONFIG.LANGUAGES.DEFAULT,
     locales: [...CONFIG.LANGUAGES.AVAILABLE],
+  },
+  image: {
+    experimentalLayout: "responsive",
+    experimentalObjectFit: "cover",
+    experimentalObjectPosition: "top",
   },
   integrations: [
     componentsStories({

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "@commitlint/cli": "^19.6.1",
     "@commitlint/config-conventional": "^19.6.0",
     "@cspell/dict-fr-fr": "^2.2.5",
+    "@csstools/postcss-cascade-layers": "^5.0.1",
     "@csstools/postcss-global-data": "^3.0.0",
     "@eslint/js": "^9.18.0",
     "@types/eslint__js": "^8.42.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,6 +151,9 @@ importers:
       '@cspell/dict-fr-fr':
         specifier: ^2.2.5
         version: 2.2.5
+      '@csstools/postcss-cascade-layers':
+        specifier: ^5.0.1
+        version: 5.0.1(postcss@8.5.1)
       '@csstools/postcss-global-data':
         specifier: ^3.0.0
         version: 3.0.0(postcss@8.5.1)

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,3 +1,4 @@
+import postcssCascadeLayers from "@csstools/postcss-cascade-layers";
 import postcssGlobalData from "@csstools/postcss-global-data";
 import autoprefixer from "autoprefixer";
 import postcssPresetEnv from "postcss-preset-env";
@@ -5,10 +6,14 @@ import postcssPresetEnv from "postcss-preset-env";
 /** @type {import('postcss-load-config').Config} */
 const postCssConfig = {
   plugins: [
+    /* Disabling onRevertLayerKeyword doesn't seem to do anything... */
+    postcssCascadeLayers({ onRevertLayerKeyword: false }),
     postcssGlobalData({
       files: ["src/styles/postcss/media-queries.css"],
     }),
-    postcssPresetEnv(),
+    postcssPresetEnv({
+      features: { "cascade-layers": { onRevertLayerKeyword: false } },
+    }),
     autoprefixer(),
   ],
 };

--- a/src/components/atoms/figure/figure.astro
+++ b/src/components/atoms/figure/figure.astro
@@ -25,9 +25,6 @@ const {
 
 <style>
   .figure {
-    display: flex;
-    flex-flow: column wrap;
-    place-content: center;
     padding: var(--spacing-xs);
     position: relative;
     z-index: 1;
@@ -43,7 +40,7 @@ const {
     }
 
     &:where([data-full-width="false"]) {
-      width: fit-content;
+      max-width: fit-content;
     }
 
     &::before,
@@ -63,7 +60,7 @@ const {
     }
 
     &::after {
-      inset: calc(var(--spacing-xs) - var(--border-size-sm));
+      inset: calc(var(--spacing-xs) - var(--border-size-md));
       background: var(--color-regular);
       border: var(--border-size-sm) solid var(--color-border-dark);
       box-shadow: var(--shadow-raised-to-top-left),
@@ -83,18 +80,6 @@ const {
       }
     }
 
-    &:where([data-full-width="true"]) > :global(img) {
-      flex: 1;
-      width: 100%;
-      object-fit: cover;
-    }
-
-    &:where([data-full-width="false"]) > :global(img) {
-      flex: 1;
-      object-fit: contain;
-      height: auto;
-    }
-
     & > :global(*) {
       max-width: 100%;
 
@@ -107,6 +92,19 @@ const {
         border-end-start-radius: inherit;
         border-end-end-radius: inherit;
       }
+
+      & > :global(*) {
+        border-radius: inherit;
+      }
+    }
+
+    &:where([data-full-width="true"]) :global(:is(picture, img)) {
+      width: 100%;
+      max-height: unset;
+    }
+
+    &:where([data-full-width="false"]) > :global(picture) {
+      max-width: fit-content;
     }
 
     & > :global(* img) {

--- a/src/components/atoms/figure/figure.stories.astro
+++ b/src/components/atoms/figure/figure.stories.astro
@@ -1,8 +1,8 @@
 ---
 import type { ComponentProps } from "astro/types";
-import { Image as AstroImg } from "astro:assets";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import Heading from "../heading/heading.astro";
+import Img from "../img/img.astro";
 import FigureComponent from "./figure.astro";
 
 const title = "Figure";
@@ -34,7 +34,7 @@ const seo: ComponentProps<typeof PageLayout>["seo"] = {
     </p>
     <Heading as="h2">Without figcaption</Heading>
     <FigureComponent>
-      <AstroImg
+      <Img
         alt="Any image"
         src="https://picsum.photos/640/480"
         width={640}
@@ -45,7 +45,7 @@ const seo: ComponentProps<typeof PageLayout>["seo"] = {
     <Heading as="h3">At the top</Heading>
     <FigureComponent>
       <figcaption>An image used as example</figcaption>
-      <AstroImg
+      <Img
         alt="Any image"
         src="https://picsum.photos/640/480"
         width={640}
@@ -54,7 +54,7 @@ const seo: ComponentProps<typeof PageLayout>["seo"] = {
     </FigureComponent>
     <Heading as="h3">At the bottom</Heading>
     <FigureComponent>
-      <AstroImg
+      <Img
         alt="Any image"
         src="https://picsum.photos/640/480"
         width={640}
@@ -64,7 +64,7 @@ const seo: ComponentProps<typeof PageLayout>["seo"] = {
     </FigureComponent>
     <Heading as="h2">Horizontally centered</Heading>
     <FigureComponent isCentered>
-      <AstroImg
+      <Img
         alt="Any image"
         src="https://picsum.photos/640/480"
         width={640}
@@ -73,7 +73,7 @@ const seo: ComponentProps<typeof PageLayout>["seo"] = {
     </FigureComponent>
     <Heading as="h2">Full width</Heading>
     <FigureComponent isFullWidth>
-      <AstroImg
+      <Img
         alt="Any image"
         src="https://picsum.photos/640/480"
         width={640}

--- a/src/components/atoms/img/img.astro
+++ b/src/components/atoms/img/img.astro
@@ -1,31 +1,52 @@
 ---
-import type { HTMLAttributes } from "astro/types";
-import { getImage } from "astro:assets";
-import type { Img as LocalOrRemoteImg } from "../../../types/data";
+import type { ComponentProps } from "astro/types";
+import { Picture as AstroPicture, getImage } from "astro:assets";
 import Link from "../link/link.astro";
 
-type Props = Omit<HTMLAttributes<"img">, "height" | "src" | "width"> &
-  Omit<LocalOrRemoteImg, "height" | "width"> & {
-    /**
-     * Should only be used with Remark/Rehype. It is an internal helper to wrap
-     * images with a link pointing to the same file.
-     *
-     * @see src/lib/rehype/rehype-images.ts
-     */
-    "data-clickable"?: `${boolean}` | null | undefined;
-    height?: number | undefined;
-    inferSize?: boolean | null | undefined;
-    width?: number | undefined;
-  };
+/* Without Pick, Typescript gives me an error when using the component. Not
+ * sure which property is conflicting with exactOptionalPropertyTypes... */
+type PictureProps = Pick<
+  ComponentProps<typeof AstroPicture>,
+  | "alt"
+  | "class"
+  | "class:list"
+  | "decoding"
+  | "densities"
+  | "fit"
+  | "format"
+  | "formats"
+  | "layout"
+  | "loading"
+  | "pictureAttributes"
+  | "position"
+  | "quality"
+  | "src"
+  | "style"
+  | "widths"
+>;
+
+type Props = PictureProps & {
+  /**
+   * Should only be used with Remark/Rehype. It is an internal helper to wrap
+   * images with a link pointing to the same file.
+   *
+   * @see src/lib/rehype/rehype-images.ts
+   */
+  "data-clickable"?: `${boolean}` | null | undefined;
+  height?: number | undefined;
+  inferSize?: boolean | null | undefined;
+  width?: number | undefined;
+};
 
 const {
   alt,
   "data-clickable": isClickable,
-  class: className,
   densities,
   format,
+  formats = ["avif", "webp"],
   height,
   inferSize,
+  pictureAttributes,
   quality,
   src,
   width,
@@ -43,36 +64,36 @@ const img = await getImage({
   width,
   widths,
 });
-const imgAttrs = { ...img.attributes, ...attrs };
+const mergedAttrs = { ...img.attributes, ...attrs };
+const Wrapper = isClickable ? Link : Fragment;
 ---
 
-{
-  isClickable === "true" ? (
-    <Link href={img.src}>
-      <img
-        {...imgAttrs}
-        alt={alt}
-        class:list={["img", className]}
-        src={img.src}
-      />
-    </Link>
-  ) : (
-    <img
-      {...imgAttrs}
-      alt={alt}
-      class:list={["img", className]}
-      src={img.src}
-    />
-  )
-}
+<Wrapper href={img.src}>
+  {/* @ts-expect-error ts(2375) -- Not sure where the issue comes from... */}
+  <AstroPicture
+    {...mergedAttrs}
+    alt={alt}
+    pictureAttributes={{
+      ...pictureAttributes,
+      "class:list": ["picture", pictureAttributes?.class],
+    }}
+    src={img.src}
+  />
+</Wrapper>
 
 <style>
-  .img {
+  img {
     display: block;
+    max-width: 100%;
+    /* Astro's responsiveImages feature adds `width: 100%`` to images which is
+     * messing up with some of my images. It seems the only way to revert this
+     * is by adding `revert-layer`. Unfortunately, postcss logs a warning
+     * regarding onRevertLayerKeyword... */
+    width: revert-layer;
   }
 
-  :global(:where([data-theme="dark"])) .img {
-    filter: brightness(0.85) contrast(1.05);
+  :global(:where([data-theme="dark"])) .picture {
+    filter: brightness(0.9) contrast(1.025);
 
     &:active {
       filter: none;

--- a/src/components/molecules/card/card.astro
+++ b/src/components/molecules/card/card.astro
@@ -61,7 +61,7 @@ const { as = "article", class: className, ...attrs } = Astro.props;
 <style>
   .card {
     display: flex;
-    flex-flow: column wrap;
+    flex-flow: column nowrap;
 
     @container (width > 55em) {
       display: grid;
@@ -79,6 +79,9 @@ const { as = "article", class: className, ...attrs } = Astro.props;
   }
 
   .card-header {
+    display: flex;
+    flex-flow: column nowrap;
+
     @container (width > 55em) {
       display: contents;
     }
@@ -131,7 +134,7 @@ const { as = "article", class: className, ...attrs } = Astro.props;
   .card .card-footer {
     justify-content: space-between;
     gap: var(--spacing-md);
-    margin: auto clamp(var(--spacing-md), 2.5dvi, var(--spacing-xl)) 0;
+    margin-inline: clamp(var(--spacing-md), 2.5dvi, var(--spacing-xl));
     padding: clamp(var(--spacing-md), 1dvi, var(--spacing-lg)) 0
       clamp(var(--spacing-md), 1.5dvi, var(--spacing-xl));
     border-block-start: var(--border-size-sm) solid var(--color-border);
@@ -151,6 +154,8 @@ const { as = "article", class: className, ...attrs } = Astro.props;
   /* We need to increase specificity because of inconsistencies between
    * dev/build modes. */
   .card .card-body {
+    flex: 1;
+
     &:where(:not(:first-child)) {
       padding-block-start: 0;
     }
@@ -161,31 +166,25 @@ const { as = "article", class: className, ...attrs } = Astro.props;
   }
 
   .card-cover {
+    align-self: center;
     margin: var(--spacing-sm) var(--spacing-sm) 0;
-    padding: var(--spacing-3xs);
 
     @container (width > 55em) {
       grid-column: 1;
       grid-row: 1 / span 3;
+      align-self: unset;
       margin-block-end: var(--spacing-sm);
-      position: relative;
     }
 
-    & > :global(img) {
-      display: block;
-      width: 100%;
+    & :global(img) {
       max-width: 100%;
-      max-height: calc(var(--one-px-in-rem) * 200);
-      margin-inline: auto;
-      object-fit: cover;
-      border-radius: var(--border-radii-md);
+      max-height: calc(var(--one-px-in-rem) * 220);
+      border-radius: inherit;
+      box-shadow: var(--shadow-raised-to-top-left);
 
       @container (width > 55em) {
         height: 100%;
-        max-width: calc(100% - var(--spacing-3xs) * 2);
-        max-height: calc(100% - var(--spacing-3xs) * 2);
-        /* Prevent the grid to grow because of the cover size. */
-        position: absolute;
+        max-height: 100%;
       }
     }
   }

--- a/src/components/molecules/card/card.stories.astro
+++ b/src/components/molecules/card/card.stories.astro
@@ -1,9 +1,9 @@
 ---
 import type { ComponentProps } from "astro/types";
-import { Image as AstroImg } from "astro:assets";
 import Box from "../../atoms/box/box.astro";
 import Button from "../../atoms/button/button.astro";
 import Heading from "../../atoms/heading/heading.astro";
+import Img from "../../atoms/img/img.astro";
 import Link from "../../atoms/link/link.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import CardComponent from "./card.astro";
@@ -152,7 +152,7 @@ const seo: ComponentProps<typeof PageLayout>["seo"] = {
       <Heading>With title, body and cover</Heading>
     </Box>
     <CardComponent>
-      <AstroImg
+      <Img
         alt="The card cover"
         height={480}
         slot="cover"
@@ -179,7 +179,7 @@ const seo: ComponentProps<typeof PageLayout>["seo"] = {
       <Heading>With title, body, cover and meta</Heading>
     </Box>
     <CardComponent>
-      <AstroImg
+      <Img
         alt="The card cover"
         height={480}
         slot="cover"
@@ -208,7 +208,7 @@ const seo: ComponentProps<typeof PageLayout>["seo"] = {
     </Box>
     <CardComponent>
       <span slot="frontmatter">Category</span>
-      <AstroImg
+      <Img
         alt="The card cover"
         height={480}
         slot="cover"
@@ -237,7 +237,7 @@ const seo: ComponentProps<typeof PageLayout>["seo"] = {
       <Heading>With linked heading without cta</Heading>
     </Box>
     <CardComponent>
-      <AstroImg
+      <Img
         alt="The card cover"
         height={480}
         slot="cover"
@@ -268,7 +268,7 @@ const seo: ComponentProps<typeof PageLayout>["seo"] = {
     </Box>
     <CardComponent>
       <span slot="frontmatter">Category</span>
-      <AstroImg
+      <Img
         alt="The card cover"
         height={480}
         slot="cover"

--- a/src/components/organisms/collection-card/collection-card.astro
+++ b/src/components/organisms/collection-card/collection-card.astro
@@ -1,7 +1,6 @@
 ---
 import { Icon } from "astro-icon/components";
 import type { ComponentProps } from "astro/types";
-import { Image as AstroImg } from "astro:assets";
 import type {
   Blog,
   BlogPostPreview,
@@ -21,6 +20,7 @@ import { isString } from "../../../utils/type-checks";
 import Button from "../../atoms/button/button.astro";
 import DescriptionList from "../../atoms/description-list/description-list.astro";
 import Heading from "../../atoms/heading/heading.astro";
+import Img from "../../atoms/img/img.astro";
 import Link from "../../atoms/link/link.astro";
 import Card from "../../molecules/card/card.astro";
 import CollectionMeta from "../collection-meta/collection-meta.astro";
@@ -174,7 +174,7 @@ const isQuote = "isQuote" in entry ? entry.isQuote : false;
   }
   {
     "cover" in entry && entry.cover ? (
-      <AstroImg {...entry.cover} slot={entry.cover ? "cover" : ""} />
+      <Img {...entry.cover} slot={entry.cover ? "cover" : ""} />
     ) : null
   }
   <Heading

--- a/src/components/organisms/identity-card/identity-card.astro
+++ b/src/components/organisms/identity-card/identity-card.astro
@@ -30,10 +30,7 @@ const { translate } = useI18n(Astro.currentLocale);
         })}
         class="identity-card-avatar"
       >
-        {/* Can't figure out what is the issue... Typescript does not
-         * complain with Img but it does with Omit<Img, 'alt'>... so:
-         * @ts-expect-error */}
-        <Img {...author.avatar} alt="" />
+        <Img {...author.avatar} alt="" loading="eager" />
       </Figure>
     ) : null
   }
@@ -104,10 +101,6 @@ const { translate } = useI18n(Astro.currentLocale);
   }
 
   .identity-card-avatar {
-    max-width: clamp(
-      calc(var(--one-px-in-rem * 140)),
-      10dvi,
-      calc(var(--one-px-in-rem * 200))
-    );
+    min-width: calc(var(--one-px-in-rem * 200));
   }
 </style>

--- a/src/components/organisms/page/page.astro
+++ b/src/components/organisms/page/page.astro
@@ -1,18 +1,19 @@
 ---
 import type { MarkdownHeading } from "astro";
 import { Icon } from "astro-icon/components";
-import type { ComponentProps, HTMLAttributes } from "astro/types";
-import { Image as AstroImg } from "astro:assets";
+import type { HTMLAttributes } from "astro/types";
+import type { Img as ImgType } from "../../../types/data";
 import { useI18n } from "../../../utils/i18n";
 import { buildToc } from "../../../utils/toc";
 import Box from "../../atoms/box/box.astro";
 import Button from "../../atoms/button/button.astro";
 import Heading from "../../atoms/heading/heading.astro";
+import Img from "../../atoms/img/img.astro";
 import Collapsible from "../../molecules/collapsible/collapsible.astro";
 import TableOfContents from "../table-of-contents/table-of-contents.astro";
 
 type Props = HTMLAttributes<"article"> & {
-  cover?: ComponentProps<typeof AstroImg> | null | undefined;
+  cover?: ImgType | null | undefined;
   feed?: string | URL | null | undefined;
   heading?: string | null | undefined;
   isIndex?: boolean | null | undefined;
@@ -63,9 +64,7 @@ const { translate } = useI18n(Astro.currentLocale);
             ) : null}
           </Box>
         ) : null}
-        {cover ? (
-          <AstroImg {...cover} class="page-cover" loading="eager" />
-        ) : null}
+        {cover ? <Img {...cover} class="page-cover" loading="eager" /> : null}
         {Astro.slots.has("meta") ? (
           <div class="page-meta">
             <slot name="meta" />
@@ -195,16 +194,17 @@ const { translate } = useI18n(Astro.currentLocale);
 
   .page-cover {
     display: block;
-    width: 100%;
     height: 100%;
     max-width: 100%;
     max-height: calc(var(--one-px-in-rem) * 250);
-    object-fit: cover;
   }
 
   :where(.page:has(.page-meta)) .page-cover {
+    border-block-end: var(--border-size-sm) solid var(--color-border);
+
     @container (width >= calc(55em / 1.5)) {
       grid-column: 1;
+      border-block-end: none;
       border-inline-end: var(--border-size-sm) solid var(--color-border);
     }
   }
@@ -217,6 +217,7 @@ const { translate } = useI18n(Astro.currentLocale);
   :where(.page:has(.page-cover)) .page-meta {
     @container (width >= calc(55em / 1.5)) {
       grid-column: 2;
+      align-self: center;
       text-align: start;
     }
   }

--- a/src/pages/[slug].astro
+++ b/src/pages/[slug].astro
@@ -43,6 +43,7 @@ const graphs: ComponentProps<typeof PageLayout>["graphs"] = [
 
 <PageLayout
   breadcrumb={breadcrumb}
+  cover={page.cover}
   description={page.description}
   graphs={graphs}
   seo={page.seo}

--- a/src/pages/blog/articles/[slug].astro
+++ b/src/pages/blog/articles/[slug].astro
@@ -39,6 +39,7 @@ const graphs: ComponentProps<typeof PageLayout>["graphs"] = [
 
 <PageLayout
   breadcrumb={breadcrumb}
+  cover={page.cover}
   description={page.description}
   graphs={graphs}
   seo={page.seo}

--- a/src/pages/blog/categories/[slug]/index.astro
+++ b/src/pages/blog/categories/[slug]/index.astro
@@ -56,6 +56,7 @@ const getCTA = (
 
 <PageLayout
   breadcrumb={breadcrumb}
+  cover={page.cover}
   description={page.description}
   feed={`${page.route}/feed.xml`}
   graphs={graphs}

--- a/src/pages/en/[slug].astro
+++ b/src/pages/en/[slug].astro
@@ -43,6 +43,7 @@ const graphs: ComponentProps<typeof PageLayout>["graphs"] = [
 
 <PageLayout
   breadcrumb={breadcrumb}
+  cover={page.cover}
   description={page.description}
   graphs={graphs}
   seo={page.seo}

--- a/src/pages/en/blog/categories/[slug]/index.astro
+++ b/src/pages/en/blog/categories/[slug]/index.astro
@@ -56,6 +56,7 @@ const getCTA = (
 
 <PageLayout
   breadcrumb={breadcrumb}
+  cover={page.cover}
   description={page.description}
   feed={`${page.route}/feed.xml`}
   graphs={graphs}

--- a/src/pages/en/blog/posts/[slug].astro
+++ b/src/pages/en/blog/posts/[slug].astro
@@ -39,6 +39,7 @@ const graphs: ComponentProps<typeof PageLayout>["graphs"] = [
 
 <PageLayout
   breadcrumb={breadcrumb}
+  cover={page.cover}
   description={page.description}
   graphs={graphs}
   seo={page.seo}

--- a/src/pages/en/guides/[slug].astro
+++ b/src/pages/en/guides/[slug].astro
@@ -40,6 +40,7 @@ const graphs: ComponentProps<typeof PageLayout>["graphs"] = [
 
 <PageLayout
   breadcrumb={breadcrumb}
+  cover={page.cover}
   description={page.description}
   graphs={graphs}
   seo={page.seo}

--- a/src/pages/en/projects/[slug].astro
+++ b/src/pages/en/projects/[slug].astro
@@ -38,6 +38,7 @@ const graphs: ComponentProps<typeof PageLayout>["graphs"] = [
 
 <PageLayout
   breadcrumb={breadcrumb}
+  cover={page.cover}
   description={page.description}
   graphs={graphs}
   seo={page.seo}

--- a/src/pages/en/tags/[slug]/index.astro
+++ b/src/pages/en/tags/[slug]/index.astro
@@ -78,6 +78,7 @@ const getCTA = (
 
 <PageLayout
   breadcrumb={breadcrumb}
+  cover={page.cover}
   description={page.description}
   feed={`${page.route}/feed.xml`}
   graphs={graphs}

--- a/src/pages/etiquettes/[slug]/index.astro
+++ b/src/pages/etiquettes/[slug]/index.astro
@@ -78,6 +78,7 @@ const getCTA = (
 
 <PageLayout
   breadcrumb={breadcrumb}
+  cover={page.cover}
   description={page.description}
   feed={`${page.route}/feed.xml`}
   graphs={graphs}

--- a/src/pages/guides/[slug].astro
+++ b/src/pages/guides/[slug].astro
@@ -40,6 +40,7 @@ const graphs: ComponentProps<typeof PageLayout>["graphs"] = [
 
 <PageLayout
   breadcrumb={breadcrumb}
+  cover={page.cover}
   description={page.description}
   graphs={graphs}
   seo={page.seo}

--- a/src/pages/projets/[slug].astro
+++ b/src/pages/projets/[slug].astro
@@ -38,6 +38,7 @@ const graphs: ComponentProps<typeof PageLayout>["graphs"] = [
 
 <PageLayout
   breadcrumb={breadcrumb}
+  cover={page.cover}
   description={page.description}
   graphs={graphs}
   seo={page.seo}

--- a/src/styles/base/typography.css
+++ b/src/styles/base/typography.css
@@ -52,12 +52,17 @@ a {
     --link-icon: var(--download-icon) "\0000a0" var(--external-icon);
   }
 
-  &:has(img, svg) {
+  &:has(> img, > svg) {
     display: inline-block;
+    vertical-align: middle;
 
     & > :is(img, svg) {
       vertical-align: middle;
     }
+  }
+
+  &:has(> picture) {
+    display: block;
   }
 
   & > img {

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -74,7 +74,14 @@ export type HTTPStatus = {
   TEXT: string;
 };
 
-export type Img = LocalImageProps | RemoteImageProps;
+export type Img = Omit<
+  LocalImageProps | RemoteImageProps,
+  | "width"
+  | "height"
+> & {
+  height?: number | undefined;
+  width?: number | undefined;
+};
 
 export type BlogMetaData = Omit<
   CollectionEntry<"blogroll">["data"]["meta"],

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -76,8 +76,7 @@ export type HTTPStatus = {
 
 export type Img = Omit<
   LocalImageProps | RemoteImageProps,
-  | "width"
-  | "height"
+  "width" | "height"
 > & {
   height?: number | undefined;
   width?: number | undefined;


### PR DESCRIPTION
## Changes

* Adds missing individual page's cover (guides, projects, posts and dynamic pages)
* Improves the performance by wrapping images in a picture element (multiple sources, srcset)
* Enables the `responsiveImages` feature of Astro.
* Adds `postcss-cascade-layers` as dev dependencies (although the `onRevertLayerKeyword` setting doesn't seem to work as expected...)

## Tests

Manually, and existing tests should still passed.

## Docs

Adds changesets.