### PR TITLE
fix: code blocks styles

### DIFF
--- a/.changeset/early-pears-happen.md
+++ b/.changeset/early-pears-happen.md
@@ -1,0 +1,5 @@
+---
+"apeu": patch
+---
+
+Fixes a style issue in code blocks preventing the line numbers and prompts to stay sticky while scrolling horizontally.

--- a/.changeset/long-ears-play.md
+++ b/.changeset/long-ears-play.md
@@ -1,0 +1,7 @@
+---
+"apeu": patch
+---
+
+Fixes a style issue when using diff notation inside code blocks.
+
+This fixes an issue where the lines marked as diff were not taking the full width of their parent, so the background was not displayed correctly.

--- a/.changeset/olive-kings-carry.md
+++ b/.changeset/olive-kings-carry.md
@@ -1,0 +1,5 @@
+---
+"apeu": patch
+---
+
+Fixes the text alignment inside code blocks' caption.

--- a/src/components/molecules/code-block/code-block.astro
+++ b/src/components/molecules/code-block/code-block.astro
@@ -164,6 +164,7 @@ const cssVars = getCSSVars({
   .code-block .code-block-caption {
     display: flex;
     align-items: center;
+    text-align: start;
 
     @container (width >= 568px) {
       border-inline-end: var(--border-size-sm) solid var(--color-border);

--- a/src/components/molecules/code-block/code-block.astro
+++ b/src/components/molecules/code-block/code-block.astro
@@ -206,8 +206,15 @@ const cssVars = getCSSVars({
 
     & :global(:is(code, .line)) {
       display: inline-block;
-      width: 100%;
       font-family: var(--font-family-mono);
+    }
+
+    & :global(code) {
+      min-width: 100%;
+    }
+
+    & :global(.line) {
+      width: 100%;
     }
   }
 


### PR DESCRIPTION
## Changes

* Fixes the sticky gutter (line numbers/prompt) while scrolling horizontally
* Fixes the background of lines marked as diff
* Fixes the text alignment in the code block's caption

## Tests

Manually

## Docs

Changeset added.