### PR TITLE
fix: callouts styles

### DIFF
--- a/.changeset/plenty-crabs-return.md
+++ b/.changeset/plenty-crabs-return.md
@@ -1,0 +1,5 @@
+---
+"apeu": patch
+---
+
+Fixes a style issue in callouts where the last child could add an extra margin.

--- a/.changeset/thick-rules-begin.md
+++ b/.changeset/thick-rules-begin.md
@@ -1,0 +1,5 @@
+---
+"apeu": patch
+---
+
+Fixes a style issue in callouts where a long heading was not correctly aligned with the icon.

--- a/src/components/atoms/callout/callout.astro
+++ b/src/components/atoms/callout/callout.astro
@@ -48,7 +48,7 @@ const heading = label || defaultLabel[type];
 
 <style>
   .callout {
-    padding: var(--spacing-xs) var(--spacing-sm);
+    padding: var(--spacing-xs) var(--spacing-sm) var(--spacing-sm);
     border: var(--border-size-md) solid;
     border-inline-start-width: var(--border-size-xl);
     border-radius: var(--border-radii-md);
@@ -103,5 +103,9 @@ const heading = label || defaultLabel[type];
     svg {
       flex: 0 0 auto;
     }
+  }
+
+  .callout > :global(*:last-child:not(:only-child)) {
+    margin-block-end: 0;
   }
 </style>

--- a/src/components/atoms/callout/callout.astro
+++ b/src/components/atoms/callout/callout.astro
@@ -92,7 +92,6 @@ const heading = label || defaultLabel[type];
 
   .callout-heading {
     display: flex;
-    flex-flow: row wrap;
     align-items: center;
     gap: var(--spacing-2xs);
     margin: 0 0 var(--spacing-sm);
@@ -100,5 +99,9 @@ const heading = label || defaultLabel[type];
     border-block-end: var(--border-size-sm) solid currentcolor;
     font-size: var(--font-size-lg);
     font-weight: var(--font-weight-bold);
+
+    svg {
+      flex: 0 0 auto;
+    }
   }
 </style>

--- a/src/components/atoms/callout/callout.stories.astro
+++ b/src/components/atoms/callout/callout.stories.astro
@@ -41,7 +41,10 @@ const seo: ComponentProps<typeof PageLayout>["seo"] = {
     <Heading as="h3">Warning</Heading>
     <CalloutComponent type="warning"> The contents. </CalloutComponent>
     <Heading as="h2">With a custom label</Heading>
-    <CalloutComponent label="The custom label" type="critical">
+    <CalloutComponent
+      label="A custom label a bit long for small devices"
+      type="critical"
+    >
       The contents.
     </CalloutComponent>
   </Fragment>


### PR DESCRIPTION
## Changes

* Fixes the icon/heading alignment when the heading is a bit long (the icon should not be on top)
* Prevents the last child to add an extra margin inside the callout (Markdown renders children wrapped in a paragraph...)
* Adjust the callout padding

## Tests

Manually

## Docs

Changesets added