### PR TITLE
fix: remove notes from global feed

### DIFF
--- a/.changeset/breezy-oranges-change.md
+++ b/.changeset/breezy-oranges-change.md
@@ -1,0 +1,7 @@
+---
+"apeu": patch
+---
+
+Removes the notes from the global feed.
+
+I'm using them as "personal" notes so I think they shouldn't be in the feed. If someone wants to subscribe to my notes, it's still possible using the individual feed.

--- a/src/pages/en/feed.xml.ts
+++ b/src/pages/en/feed.xml.ts
@@ -12,7 +12,7 @@ export const GET: APIRoute = async ({ currentLocale, site, url }) => {
   if (!site) throw new MissingSiteConfigError();
   const { locale, translate } = useI18n(currentLocale);
   const { entries } = await queryCollection(
-    ["blogPosts", "blogroll", "bookmarks", "guides", "notes", "projects"],
+    ["blogPosts", "blogroll", "bookmarks", "guides", "projects"],
     {
       format: "full",
       orderBy: { key: "publishedOn", order: "ASC" },

--- a/src/pages/feed.xml.ts
+++ b/src/pages/feed.xml.ts
@@ -12,7 +12,7 @@ export const GET: APIRoute = async ({ currentLocale, site, url }) => {
   if (!site) throw new MissingSiteConfigError();
   const { locale, translate } = useI18n(currentLocale);
   const { entries } = await queryCollection(
-    ["blogPosts", "blogroll", "bookmarks", "guides", "notes", "projects"],
+    ["blogPosts", "blogroll", "bookmarks", "guides", "projects"],
     {
       format: "full",
       orderBy: { key: "publishedOn", order: "ASC" },

--- a/src/utils/feeds.ts
+++ b/src/utils/feeds.ts
@@ -93,7 +93,12 @@ const createNodeTransformer = () => {
     if (node.name === "a" && node.attributes?.href) {
       node.attributes.href = makeAbsoluteUrl(node.attributes.href);
     } else if (node.name === "img" && node.attributes?.src) {
-      node.attributes.src = makeAbsoluteUrl(node.attributes.src);
+      if (node.attributes?.src)
+        node.attributes.src = makeAbsoluteUrl(node.attributes.src);
+      if (node.attributes?.srcset) {
+        const sources = node.attributes.srcset.split(", ");
+        node.attributes.srcset = sources.map(makeAbsoluteUrl).join(", ");
+      }
     } else if (node.name === "callout") {
       transformCalloutToDiv(node);
     }


### PR DESCRIPTION
## Changes

* Removes the notes entries from the global feed since I'm using them as "personal" notes... If someone wants to subscribe, it's still possible using the separate feed.
* Uses absolute URL in `srcset` (introduced by #63)

## Tests

Manually

## Docs

Add a changeset only for the notes removal.