### PR TITLE
fix: content collections custom path

### DIFF
--- a/.changeset/thin-feet-return.md
+++ b/.changeset/thin-feet-return.md
@@ -1,0 +1,5 @@
+---
+"apeu": patch
+---
+
+Fixes an issue where CONTENT_PATH was no longer defined when using this project as a Git submodule.

--- a/src/lib/astro/loaders/glob-loader.ts
+++ b/src/lib/astro/loaders/glob-loader.ts
@@ -7,7 +7,10 @@ import {
   type AvailableLanguage,
 } from "../../../utils/i18n";
 
-const CONTENT_DIR: string = import.meta.env?.CONTENT_PATH ?? "./content";
+/* This is not a supported usage, so it could break. Currently `import.meta.
+ * env` doesn't work anymore when using a path outside the project's root (ie.
+ * when I'm using a Git submodules). Using `process.env` seems to fix that. */
+const CONTENT_DIR: string = process.env?.CONTENT_PATH ?? "./content";
 
 const getLocalesPattern = () => {
   if (CONFIG.LANGUAGES.AVAILABLE.length > 1)


### PR DESCRIPTION
## Changes

Using `import.meta.env` to retrieve `CONTENT_PATH` while using a Git submodule and a path outside the project's root no longer works. It seems that switching to `process.env` fixes this issue.

## Tests

Manually.

## Docs

Changeset added.