### PR TITLE
fix: prevent og images path to contain a trailing slash

### DIFF
--- a/.changeset/hip-jobs-visit.md
+++ b/.changeset/hip-jobs-visit.md
@@ -1,0 +1,5 @@
+---
+"apeu": patch
+---
+
+Fixes an issue where OG images could be malformed because of a trailing slash in the path.

--- a/src/utils/open-graph.ts
+++ b/src/utils/open-graph.ts
@@ -1,5 +1,6 @@
 import type { MimeTypeImage } from "../types/mime-type";
 import { isDefaultLanguage, useI18n } from "./i18n";
+import { removeTrailingSlash } from "./strings";
 import { getWebsiteUrl } from "./url";
 
 type GetOpenGraphImgConfig = {
@@ -15,7 +16,8 @@ export const getOpenGraphImg = ({ locale, slug }: GetOpenGraphImgConfig) => {
   return {
     height: 630,
     type: "image/png" satisfies MimeTypeImage,
-    url: new URL(`/og/${ogImgPath}.png`, getWebsiteUrl()).href,
+    url: new URL(`/og/${removeTrailingSlash(ogImgPath)}.png`, getWebsiteUrl())
+      .href,
     width: 1200,
   } as const;
 };

--- a/src/utils/strings.test.ts
+++ b/src/utils/strings.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { capitalizeFirstLetter } from "./strings";
+import { capitalizeFirstLetter, removeTrailingSlash } from "./strings";
 
 describe("capitalize-first-letter", () => {
   it("returns a capitalized string", () => {
@@ -7,5 +7,28 @@ describe("capitalize-first-letter", () => {
     const result = capitalizeFirstLetter(input);
 
     expect(result).toMatchInlineSnapshot(`"Maiores"`);
+  });
+});
+
+describe("remove-trailing-slashes", () => {
+  it("can remove a single slash at the end of a string", () => {
+    const expectedStr = "dolores";
+    const result = removeTrailingSlash(`${expectedStr}/`);
+
+    expect(result).toBe(expectedStr);
+  });
+
+  it("can remove a multiple slashes at the end of a string", () => {
+    const expectedStr = "dolores";
+    const result = removeTrailingSlash(`${expectedStr}////`);
+
+    expect(result).toBe(expectedStr);
+  });
+
+  it("returns the same string if there are no slashes at the end", () => {
+    const expectedStr = "dolores";
+    const result = removeTrailingSlash(expectedStr);
+
+    expect(result).toBe(expectedStr);
   });
 });

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -12,3 +12,14 @@ export const toLowerCase = <T extends string>(str: T) =>
 
 export const toUpperCase = <T extends string>(str: T) =>
   str.toUpperCase() as Uppercase<T>;
+
+/**
+ * Remove the trailing slash from a string.
+ *
+ * @param {string} str - A string.
+ * @returns {string} The string without trailing slash.
+ */
+export const removeTrailingSlash = (str: string): string => {
+  if (!str.endsWith("/")) return str;
+  return str.replace(/\/+$/g, "");
+};


### PR DESCRIPTION
## Changes

Well, I should configure my server to deal with trailing slashes. But in the meantime, it's better to make sure the path doesn't contain a trailing slash when defining OG images.

## Tests

Add a new test to be sure trailing slashes are removed.

## Docs

Changeset added.