### PR TITLE
fix: improve the use of covers in content collections

### DIFF
--- a/.changeset/cyan-ways-juggle.md
+++ b/.changeset/cyan-ways-juggle.md
@@ -1,0 +1,7 @@
+---
+"apeu": patch
+---
+
+Enables the customization of the cover position for content collections that supports a cover.
+
+A new `position` property is available in the `cover` object for content collections accepting a cover. The value should match the tokens supported by the CSS `object-position` property (only strings like `top`, `left`, etc. are supported).

--- a/.changeset/dry-steaks-report.md
+++ b/.changeset/dry-steaks-report.md
@@ -1,0 +1,7 @@
+---
+"apeu": patch
+---
+
+Removes alt text for decorative images.
+
+The collections entries using a `cover` no longer accepts an `alt` property to define the alternative text of the images. Those are purely decorative so they shouldn't be announced to screen readers.

--- a/.changeset/shiny-birds-sing.md
+++ b/.changeset/shiny-birds-sing.md
@@ -1,0 +1,5 @@
+---
+"apeu": patch
+---
+
+Readjusts the cover dimensions.

--- a/src/components/atoms/img/img.astro
+++ b/src/components/atoms/img/img.astro
@@ -66,6 +66,10 @@ const img = await getImage({
 });
 const mergedAttrs = { ...img.attributes, ...attrs };
 const Wrapper = isClickable ? Link : Fragment;
+/* When used in class:list it seems the picture class is overridden... */
+const pictureClass = pictureAttributes?.class
+  ? `picture ${pictureAttributes.class}`
+  : "picture";
 ---
 
 <Wrapper href={img.src}>
@@ -75,7 +79,7 @@ const Wrapper = isClickable ? Link : Fragment;
     alt={alt}
     pictureAttributes={{
       ...pictureAttributes,
-      "class:list": ["picture", pictureAttributes?.class],
+      class: pictureClass,
     }}
     src={img.src}
   />

--- a/src/components/molecules/card/card.astro
+++ b/src/components/molecules/card/card.astro
@@ -167,18 +167,21 @@ const { as = "article", class: className, ...attrs } = Astro.props;
 
   .card-cover {
     align-self: center;
+    max-width: calc(100% - 2 * var(--spacing-md));
     margin: var(--spacing-sm) var(--spacing-sm) 0;
+    /* aspect-ratio: 2 / 1; */
 
     @container (width > 55em) {
       grid-column: 1;
       grid-row: 1 / span 3;
       align-self: unset;
-      margin-block-end: var(--spacing-sm);
+      max-width: 100%;
+      margin: var(--spacing-sm) 0 var(--spacing-sm) var(--spacing-sm);
     }
 
     & :global(img) {
       max-width: 100%;
-      max-height: calc(var(--one-px-in-rem) * 220);
+      max-height: calc(var(--one-px-in-rem) * 240);
       border-radius: inherit;
       box-shadow: var(--shadow-raised-to-top-left);
 

--- a/src/components/organisms/collection-card/collection-card.astro
+++ b/src/components/organisms/collection-card/collection-card.astro
@@ -174,7 +174,7 @@ const isQuote = "isQuote" in entry ? entry.isQuote : false;
   }
   {
     "cover" in entry && entry.cover ? (
-      <Img {...entry.cover} slot={entry.cover ? "cover" : ""} />
+      <Img {...entry.cover} alt="" slot={entry.cover ? "cover" : ""} />
     ) : null
   }
   <Heading

--- a/src/components/organisms/collection-card/collection-card.test.ts
+++ b/src/components/organisms/collection-card/collection-card.test.ts
@@ -122,7 +122,8 @@ describe("CollectionCard", () => {
     const result = await container.renderToString(CollectionCard, { props });
 
     expect(result).toContain("test-image.jpg");
-    expect(result).toContain('alt="Test Image"');
+    // Decorative image, so the alt should be replaced
+    expect(result).not.toContain('alt="Test Image"');
     expect(result).toContain('width="640"');
     expect(result).toContain('height="480"');
   });

--- a/src/components/organisms/page/page.astro
+++ b/src/components/organisms/page/page.astro
@@ -13,7 +13,7 @@ import Collapsible from "../../molecules/collapsible/collapsible.astro";
 import TableOfContents from "../table-of-contents/table-of-contents.astro";
 
 type Props = HTMLAttributes<"article"> & {
-  cover?: ImgType | null | undefined;
+  cover?: Omit<ImgType, "alt"> | null | undefined;
   feed?: string | URL | null | undefined;
   heading?: string | null | undefined;
   isIndex?: boolean | null | undefined;
@@ -64,7 +64,9 @@ const { translate } = useI18n(Astro.currentLocale);
             ) : null}
           </Box>
         ) : null}
-        {cover ? <Img {...cover} class="page-cover" loading="eager" /> : null}
+        {cover ? (
+          <Img {...cover} alt="" class="page-cover" loading="eager" />
+        ) : null}
         {Astro.slots.has("meta") ? (
           <div class="page-meta">
             <slot name="meta" />

--- a/src/components/organisms/page/page.astro
+++ b/src/components/organisms/page/page.astro
@@ -65,7 +65,12 @@ const { translate } = useI18n(Astro.currentLocale);
           </Box>
         ) : null}
         {cover ? (
-          <Img {...cover} alt="" class="page-cover" loading="eager" />
+          <Img
+            {...cover}
+            alt=""
+            loading="eager"
+            pictureAttributes={{ class: "page-cover" }}
+          />
         ) : null}
         {Astro.slots.has("meta") ? (
           <div class="page-meta">
@@ -198,7 +203,14 @@ const { translate } = useI18n(Astro.currentLocale);
     display: block;
     height: 100%;
     max-width: 100%;
-    max-height: calc(var(--one-px-in-rem) * 250);
+
+    & :global(img) {
+      max-height: calc(var(--one-px-in-rem) * 250);
+
+      @container (width >= calc(55em / 1.5)) {
+        max-height: calc(var(--one-px-in-rem) * 375);
+      }
+    }
   }
 
   :where(.page:has(.page-meta)) .page-cover {

--- a/src/components/organisms/page/page.test.ts
+++ b/src/components/organisms/page/page.test.ts
@@ -62,7 +62,6 @@ describe("Page", () => {
   it<LocalTestContext>("can render a cover", async ({ container }) => {
     const props = {
       cover: {
-        alt: "et ut debitis",
         height: 480,
         src: "https://picsum.photos/640/480",
         width: 640,
@@ -73,9 +72,8 @@ describe("Page", () => {
       props,
     });
 
-    expect.assertions(2);
+    expect.assertions(1);
 
-    expect(result).toContain(props.cover.alt);
     expect(result).toContain(props.cover.src);
   });
 

--- a/src/components/organisms/page/stories/page-with-everything-except-disconnected-body.stories.astro
+++ b/src/components/organisms/page/stories/page-with-everything-except-disconnected-body.stories.astro
@@ -6,7 +6,6 @@ import PageComponent from "../page.astro";
 const title = "Page with everything except disconnected body";
 
 const cover: ComponentProps<typeof PageComponent>["cover"] = {
-  alt: "A cover example",
   height: 480,
   src: "https://picsum.photos/640/480",
   width: 640,

--- a/src/components/organisms/page/stories/page-with-everything.stories.astro
+++ b/src/components/organisms/page/stories/page-with-everything.stories.astro
@@ -7,7 +7,6 @@ import PageComponent from "../page.astro";
 const title = "Page with everything";
 
 const cover: ComponentProps<typeof PageComponent>["cover"] = {
-  alt: "A cover example",
   height: 480,
   src: "https://picsum.photos/640/480",
   width: 640,

--- a/src/components/organisms/page/stories/page-with-title-cover-body.stories.astro
+++ b/src/components/organisms/page/stories/page-with-title-cover-body.stories.astro
@@ -6,7 +6,6 @@ import PageComponent from "../page.astro";
 const title = "Page with title, cover and body";
 
 const cover: ComponentProps<typeof PageComponent>["cover"] = {
-  alt: "A cover example",
   height: 480,
   src: "https://picsum.photos/640/480",
   width: 640,

--- a/src/components/organisms/page/stories/page-with-title-cover-meta-body.stories.astro
+++ b/src/components/organisms/page/stories/page-with-title-cover-meta-body.stories.astro
@@ -6,7 +6,6 @@ import PageComponent from "../page.astro";
 const title = "Page with title, cover, meta, and body";
 
 const cover: ComponentProps<typeof PageComponent>["cover"] = {
-  alt: "A cover example",
   height: 480,
   src: "https://picsum.photos/640/480",
   width: 640,

--- a/src/lib/astro/collections/formatters/blog-posts.test.ts
+++ b/src/lib/astro/collections/formatters/blog-posts.test.ts
@@ -11,6 +11,7 @@ describe("get-blog-post-preview", () => {
     expect(result).toMatchInlineSnapshot(`
       {
         "collection": "blogPosts",
+        "cover": null,
         "description": "The blog post description.",
         "id": "en/my-awesome-post",
         "locale": "en",
@@ -38,6 +39,7 @@ describe("get-blog-post", () => {
       {
         "Content": [Function],
         "collection": "blogPosts",
+        "cover": null,
         "description": "The blog post description.",
         "hasContent": false,
         "headings": [],

--- a/src/lib/astro/collections/formatters/blog-posts.ts
+++ b/src/lib/astro/collections/formatters/blog-posts.ts
@@ -12,7 +12,7 @@ import {
 export const getBlogPostPreview = async (
   post: CollectionEntry<"blogPosts">,
 ): Promise<BlogPostPreview> => {
-  const { locale, meta, seo, slug, ...postData } = post.data;
+  const { cover, locale, meta, seo, slug, ...postData } = post.data;
   const { authors, category, isDraft, tags, ...postMeta } = meta;
   const resolvedCategory = await getCategoryFromReference(category);
   const resolvedTags = await getTagsFromReferences(tags);
@@ -25,6 +25,12 @@ export const getBlogPostPreview = async (
   return {
     ...postData,
     collection: post.collection,
+    cover: cover
+      ? {
+          ...(cover.position ? { position: cover.position } : {}),
+          src: cover.src,
+        }
+      : null,
     id: post.id,
     locale,
     meta: {

--- a/src/lib/astro/collections/formatters/guides.test.ts
+++ b/src/lib/astro/collections/formatters/guides.test.ts
@@ -11,6 +11,7 @@ describe("get-guide-preview", () => {
     expect(result).toMatchInlineSnapshot(`
       {
         "collection": "guides",
+        "cover": null,
         "description": "The guide description.",
         "id": "en/in-depth-guide",
         "locale": "en",
@@ -37,6 +38,7 @@ describe("get-guide", () => {
       {
         "Content": [Function],
         "collection": "guides",
+        "cover": null,
         "description": "The guide description.",
         "hasContent": false,
         "headings": [],

--- a/src/lib/astro/collections/formatters/guides.ts
+++ b/src/lib/astro/collections/formatters/guides.ts
@@ -11,7 +11,7 @@ import {
 export const getGuidePreview = async (
   guide: CollectionEntry<"guides">,
 ): Promise<GuidePreview> => {
-  const { locale, meta, seo, slug, ...remainingData } = guide.data;
+  const { cover, locale, meta, seo, slug, ...remainingData } = guide.data;
   const { authors, isDraft, tags, ...remainingMeta } = meta;
   const resolvedTags = await getTagsFromReferences(tags);
   const { remarkPluginFrontmatter } = await render(guide);
@@ -22,6 +22,12 @@ export const getGuidePreview = async (
 
   return {
     ...remainingData,
+    cover: cover
+      ? {
+          ...(cover.position ? { position: cover.position } : {}),
+          src: cover.src,
+        }
+      : null,
     collection: guide.collection,
     id: guide.id,
     locale,

--- a/src/lib/astro/collections/formatters/pages.test.ts
+++ b/src/lib/astro/collections/formatters/pages.test.ts
@@ -11,6 +11,7 @@ describe("get-page-preview", () => {
     expect(result).toMatchInlineSnapshot(`
       {
         "collection": "pages",
+        "cover": null,
         "description": "The page description.",
         "id": "en/generic-page",
         "locale": "en",
@@ -37,6 +38,7 @@ describe("get-page", () => {
       {
         "Content": [Function],
         "collection": "pages",
+        "cover": null,
         "description": "The page description.",
         "hasContent": false,
         "headings": [],

--- a/src/lib/astro/collections/formatters/pages.ts
+++ b/src/lib/astro/collections/formatters/pages.ts
@@ -6,7 +6,7 @@ import { resolveTranslations } from "./utils";
 export const getPagePreview = async (
   page: CollectionEntry<"pages">,
 ): Promise<PagePreview> => {
-  const { locale, meta, seo, slug, ...remainingData } = page.data;
+  const { cover, locale, meta, seo, slug, ...remainingData } = page.data;
   const { remarkPluginFrontmatter } = await render(page);
   const { readingTime } = getMetaFromRemarkPluginFrontmatter(
     remarkPluginFrontmatter,
@@ -15,6 +15,12 @@ export const getPagePreview = async (
 
   return {
     ...remainingData,
+    cover: cover
+      ? {
+          ...(cover.position ? { position: cover.position } : {}),
+          src: cover.src,
+        }
+      : null,
     collection: page.collection,
     id: page.id,
     locale,

--- a/src/lib/astro/collections/formatters/projects.test.ts
+++ b/src/lib/astro/collections/formatters/projects.test.ts
@@ -11,6 +11,7 @@ describe("get-project-preview", () => {
     expect(result).toMatchInlineSnapshot(`
       {
         "collection": "projects",
+        "cover": null,
         "description": "The project description.",
         "id": "revolutionary-project",
         "locale": "en",
@@ -40,6 +41,7 @@ describe("get-project", () => {
       {
         "Content": [Function],
         "collection": "projects",
+        "cover": null,
         "description": "The project description.",
         "hasContent": false,
         "headings": [],

--- a/src/lib/astro/collections/formatters/projects.ts
+++ b/src/lib/astro/collections/formatters/projects.ts
@@ -6,7 +6,7 @@ import { getTagsFromReferences, resolveTranslations } from "./utils";
 export const getProjectPreview = async (
   project: CollectionEntry<"projects">,
 ): Promise<ProjectPreview> => {
-  const { locale, meta, seo, slug, ...remainingData } = project.data;
+  const { cover, locale, meta, seo, slug, ...remainingData } = project.data;
   const { isDraft, tags, ...remainingMeta } = meta;
   const resolvedTags = await getTagsFromReferences(tags);
   const { remarkPluginFrontmatter } = await render(project);
@@ -17,6 +17,12 @@ export const getProjectPreview = async (
 
   return {
     ...remainingData,
+    cover: cover
+      ? {
+          ...(cover.position ? { position: cover.position } : {}),
+          src: cover.src,
+        }
+      : null,
     collection: project.collection,
     id: project.id,
     locale,

--- a/src/lib/astro/collections/formatters/taxonomies.test.ts
+++ b/src/lib/astro/collections/formatters/taxonomies.test.ts
@@ -34,7 +34,7 @@ describe("get-taxonomy-preview", () => {
     expect(getTaxonomyPreview(blogCategoryFixture)).toMatchInlineSnapshot(`
       {
         "collection": "blogCategories",
-        "cover": undefined,
+        "cover": null,
         "description": "The category description.",
         "id": "en/micro-blog",
         "locale": "en",
@@ -52,7 +52,7 @@ describe("get-taxonomy-preview", () => {
     expect(getTaxonomyPreview(tagFixture)).toMatchInlineSnapshot(`
       {
         "collection": "tags",
-        "cover": undefined,
+        "cover": null,
         "description": "The tag description.",
         "id": "catchall-tag",
         "locale": "en",
@@ -77,7 +77,7 @@ describe("get-taxonomy", () => {
       {
         "Content": [Function],
         "collection": "blogCategories",
-        "cover": undefined,
+        "cover": null,
         "description": "The category description.",
         "hasContent": false,
         "headings": [],
@@ -108,7 +108,7 @@ describe("get-taxonomy", () => {
       {
         "Content": [Function],
         "collection": "tags",
-        "cover": undefined,
+        "cover": null,
         "description": "The tag description.",
         "hasContent": false,
         "headings": [],

--- a/src/lib/astro/collections/formatters/taxonomies.ts
+++ b/src/lib/astro/collections/formatters/taxonomies.ts
@@ -25,7 +25,12 @@ export const getTaxonomyPreview = ({
   const { isDraft, ...meta } = rawMeta;
 
   return {
-    cover,
+    cover: cover
+      ? {
+          ...(cover.position ? { position: cover.position } : {}),
+          src: cover.src,
+        }
+      : null,
     collection,
     description,
     id,

--- a/src/lib/astro/collections/schema/blog-categories.test.ts
+++ b/src/lib/astro/collections/schema/blog-categories.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { createImageMock } from "../../../../../tests/mocks/schema";
 import { CONFIG } from "../../../../utils/constants";
 import { blogCategories } from "./blog-categories";
 
@@ -12,6 +13,8 @@ vi.mock("../../../../utils/dates", async (importOriginal) => {
     applyTimezone: vi.fn((date) => date), // Mocked to return the input date
   };
 });
+
+const mockImage = createImageMock();
 
 describe("blogCategories", () => {
   it("should include the meta in the transformed output", async () => {
@@ -30,7 +33,7 @@ describe("blogCategories", () => {
     if (typeof blogCategories.schema !== "function")
       throw new Error("The schema is not callable");
 
-    const parsedSchema = blogCategories.schema({ image: vi.fn() });
+    const parsedSchema = blogCategories.schema({ image: mockImage });
     const result = await parsedSchema.safeParseAsync(category);
 
     expect.assertions(4);
@@ -57,7 +60,7 @@ describe("blogCategories", () => {
     if (typeof blogCategories.schema !== "function")
       throw new Error("The schema is not callable");
 
-    const parsedSchema = blogCategories.schema({ image: vi.fn() });
+    const parsedSchema = blogCategories.schema({ image: mockImage });
     const result = await parsedSchema.safeParseAsync(category);
 
     expect.assertions(4);

--- a/src/lib/astro/collections/schema/blog-categories.ts
+++ b/src/lib/astro/collections/schema/blog-categories.ts
@@ -8,12 +8,7 @@ export const blogCategories = defineCollection({
   schema: ({ image }) =>
     contentsBaseSchema
       .extend({
-        cover: z
-          .object({
-            alt: z.string(),
-            src: image(),
-          })
-          .optional(),
+        cover: image().optional(),
         i18n: z
           .record(
             z.string().refine(isAvailableLanguage),
@@ -24,6 +19,8 @@ export const blogCategories = defineCollection({
       .transform(({ isDraft, publishedOn, updatedOn, ...category }) => {
         return {
           ...category,
+          // `<Image />` component expect the src to be the full object.
+          ...(category.cover ? { cover: { src: category.cover } } : {}),
           meta: {
             isDraft,
             publishedOn,

--- a/src/lib/astro/collections/schema/blog-categories.ts
+++ b/src/lib/astro/collections/schema/blog-categories.ts
@@ -1,14 +1,14 @@
 import { defineCollection, reference, z } from "astro:content";
 import { isAvailableLanguage } from "../../../../utils/i18n";
 import { globLoader } from "../../loaders/glob-loader";
-import { contentsBaseSchema } from "./partials";
+import { contentsBaseSchema, coverSchema } from "./partials";
 
 export const blogCategories = defineCollection({
   loader: globLoader("blog.categories"),
   schema: ({ image }) =>
     contentsBaseSchema
       .extend({
-        cover: image().optional(),
+        cover: coverSchema(image).optional(),
         i18n: z
           .record(
             z.string().refine(isAvailableLanguage),
@@ -19,8 +19,6 @@ export const blogCategories = defineCollection({
       .transform(({ isDraft, publishedOn, updatedOn, ...category }) => {
         return {
           ...category,
-          // `<Image />` component expect the src to be the full object.
-          ...(category.cover ? { cover: { src: category.cover } } : {}),
           meta: {
             isDraft,
             publishedOn,

--- a/src/lib/astro/collections/schema/blog-posts.test.ts
+++ b/src/lib/astro/collections/schema/blog-posts.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
-import { z } from "zod";
+import { createReferenceMock } from "../../../../../tests/mocks/references";
+import { createImageMock } from "../../../../../tests/mocks/schema";
 import { CONFIG } from "../../../../utils/constants";
 import { blogPosts } from "./blog-posts";
 
@@ -14,16 +15,6 @@ vi.mock("../../../../utils/dates", async (importOriginal) => {
   };
 });
 
-function createReferenceMock(collection: string) {
-  return z.string().transform((slug) => ({
-    collection,
-    slug,
-    data: {
-      name: `Mock ${collection} ${slug}`,
-    },
-  }));
-}
-
 vi.mock("astro:content", async () => {
   const actual = await vi.importActual("astro:content");
   return {
@@ -31,6 +22,8 @@ vi.mock("astro:content", async () => {
     reference: vi.fn((collection: string) => createReferenceMock(collection)),
   };
 });
+
+const mockImage = createImageMock();
 
 describe("blogPosts", () => {
   it("should include the meta in the transformed output", async () => {
@@ -51,7 +44,7 @@ describe("blogPosts", () => {
     if (typeof blogPosts.schema !== "function")
       throw new Error("The schema is not callable");
 
-    const parsedSchema = blogPosts.schema({ image: vi.fn() });
+    const parsedSchema = blogPosts.schema({ image: mockImage });
     const result = await parsedSchema.safeParseAsync(post);
 
     expect.assertions(4);
@@ -80,7 +73,7 @@ describe("blogPosts", () => {
     if (typeof blogPosts.schema !== "function")
       throw new Error("The schema is not callable");
 
-    const parsedSchema = blogPosts.schema({ image: vi.fn() });
+    const parsedSchema = blogPosts.schema({ image: mockImage });
     const result = await parsedSchema.safeParseAsync(post);
 
     expect.assertions(4);

--- a/src/lib/astro/collections/schema/blog-posts.ts
+++ b/src/lib/astro/collections/schema/blog-posts.ts
@@ -1,7 +1,7 @@
 import { defineCollection, reference, z } from "astro:content";
 import { isAvailableLanguage } from "../../../../utils/i18n";
 import { globLoader } from "../../loaders/glob-loader";
-import { contentsBaseSchema } from "./partials";
+import { contentsBaseSchema, coverSchema } from "./partials";
 
 export const blogPosts = defineCollection({
   loader: globLoader("blog.posts"),
@@ -10,7 +10,7 @@ export const blogPosts = defineCollection({
       .extend({
         authors: z.array(reference("authors")),
         category: reference("blogCategories"),
-        cover: image().optional(),
+        cover: coverSchema(image).optional(),
         i18n: z
           .record(
             z.string().refine(isAvailableLanguage),
@@ -31,8 +31,6 @@ export const blogPosts = defineCollection({
         }) => {
           return {
             ...post,
-            // `<Image />` component expect the src to be the full object.
-            ...(post.cover ? { cover: { src: post.cover } } : {}),
             meta: {
               authors,
               category,

--- a/src/lib/astro/collections/schema/blog-posts.ts
+++ b/src/lib/astro/collections/schema/blog-posts.ts
@@ -10,12 +10,7 @@ export const blogPosts = defineCollection({
       .extend({
         authors: z.array(reference("authors")),
         category: reference("blogCategories"),
-        cover: z
-          .object({
-            alt: z.string(),
-            src: image(),
-          })
-          .optional(),
+        cover: image().optional(),
         i18n: z
           .record(
             z.string().refine(isAvailableLanguage),
@@ -36,6 +31,8 @@ export const blogPosts = defineCollection({
         }) => {
           return {
             ...post,
+            // `<Image />` component expect the src to be the full object.
+            ...(post.cover ? { cover: { src: post.cover } } : {}),
             meta: {
               authors,
               category,

--- a/src/lib/astro/collections/schema/guides.test.ts
+++ b/src/lib/astro/collections/schema/guides.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
-import { z } from "zod";
+import { createReferenceMock } from "../../../../../tests/mocks/references";
+import { createImageMock } from "../../../../../tests/mocks/schema";
 import { CONFIG } from "../../../../utils/constants";
 import { guides } from "./guides";
 
@@ -14,16 +15,6 @@ vi.mock("../../../../utils/dates", async (importOriginal) => {
   };
 });
 
-function createReferenceMock(collection: string) {
-  return z.string().transform((slug) => ({
-    collection,
-    slug,
-    data: {
-      name: `Mock ${collection} ${slug}`,
-    },
-  }));
-}
-
 vi.mock("astro:content", async () => {
   const actual = await vi.importActual("astro:content");
   return {
@@ -31,6 +22,8 @@ vi.mock("astro:content", async () => {
     reference: vi.fn((collection: string) => createReferenceMock(collection)),
   };
 });
+
+const mockImage = createImageMock();
 
 describe("guides", () => {
   it("should include the meta in the transformed output", async () => {
@@ -50,7 +43,7 @@ describe("guides", () => {
     if (typeof guides.schema !== "function")
       throw new Error("The schema is not callable");
 
-    const parsedSchema = guides.schema({ image: vi.fn() });
+    const parsedSchema = guides.schema({ image: mockImage });
     const result = await parsedSchema.safeParseAsync(guide);
 
     expect.assertions(4);
@@ -78,7 +71,7 @@ describe("guides", () => {
     if (typeof guides.schema !== "function")
       throw new Error("The schema is not callable");
 
-    const parsedSchema = guides.schema({ image: vi.fn() });
+    const parsedSchema = guides.schema({ image: mockImage });
     const result = await parsedSchema.safeParseAsync(guide);
 
     expect.assertions(4);

--- a/src/lib/astro/collections/schema/guides.ts
+++ b/src/lib/astro/collections/schema/guides.ts
@@ -9,12 +9,7 @@ export const guides = defineCollection({
     contentsBaseSchema
       .extend({
         authors: z.array(reference("authors")),
-        cover: z
-          .object({
-            alt: z.string(),
-            src: image(),
-          })
-          .optional(),
+        cover: image().optional(),
         i18n: z
           .record(z.string().refine(isAvailableLanguage), reference("guides"))
           .optional(),
@@ -24,6 +19,8 @@ export const guides = defineCollection({
         ({ authors, isDraft, publishedOn, tags, updatedOn, ...guide }) => {
           return {
             ...guide,
+            // `<Image />` component expect the src to be the full object.
+            ...(guide.cover ? { cover: { src: guide.cover } } : {}),
             meta: {
               authors,
               isDraft,

--- a/src/lib/astro/collections/schema/guides.ts
+++ b/src/lib/astro/collections/schema/guides.ts
@@ -1,7 +1,7 @@
 import { defineCollection, reference, z } from "astro:content";
 import { isAvailableLanguage } from "../../../../utils/i18n";
 import { globLoader } from "../../loaders/glob-loader";
-import { contentsBaseSchema } from "./partials";
+import { contentsBaseSchema, coverSchema } from "./partials";
 
 export const guides = defineCollection({
   loader: globLoader("guides"),
@@ -9,7 +9,7 @@ export const guides = defineCollection({
     contentsBaseSchema
       .extend({
         authors: z.array(reference("authors")),
-        cover: image().optional(),
+        cover: coverSchema(image).optional(),
         i18n: z
           .record(z.string().refine(isAvailableLanguage), reference("guides"))
           .optional(),
@@ -19,8 +19,6 @@ export const guides = defineCollection({
         ({ authors, isDraft, publishedOn, tags, updatedOn, ...guide }) => {
           return {
             ...guide,
-            // `<Image />` component expect the src to be the full object.
-            ...(guide.cover ? { cover: { src: guide.cover } } : {}),
             meta: {
               authors,
               isDraft,

--- a/src/lib/astro/collections/schema/pages.test.ts
+++ b/src/lib/astro/collections/schema/pages.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { createImageMock } from "../../../../../tests/mocks/schema";
 import { CONFIG } from "../../../../utils/constants";
 import { pages } from "./pages";
 
@@ -12,6 +13,8 @@ vi.mock("../../../../utils/dates", async (importOriginal) => {
     applyTimezone: vi.fn((date) => date), // Mocked to return the input date
   };
 });
+
+const mockImage = createImageMock();
 
 describe("pages", () => {
   it("should include the meta in the transformed output", () => {
@@ -30,7 +33,7 @@ describe("pages", () => {
     if (typeof pages.schema !== "function")
       throw new Error("The schema is not callable");
 
-    const parsedSchema = pages.schema({ image: vi.fn() });
+    const parsedSchema = pages.schema({ image: mockImage });
     const result = parsedSchema.safeParse(page);
 
     expect(result.success).toBe(true);
@@ -55,7 +58,7 @@ describe("pages", () => {
     if (typeof pages.schema !== "function")
       throw new Error("The schema is not callable");
 
-    const parsedSchema = pages.schema({ image: vi.fn() });
+    const parsedSchema = pages.schema({ image: mockImage });
     const result = parsedSchema.safeParse(page);
 
     expect(result.success).toBe(true);

--- a/src/lib/astro/collections/schema/pages.ts
+++ b/src/lib/astro/collections/schema/pages.ts
@@ -1,14 +1,14 @@
 import { defineCollection, reference, z } from "astro:content";
 import { isAvailableLanguage } from "../../../../utils/i18n";
 import { globLoader } from "../../loaders/glob-loader";
-import { contentsBaseSchema } from "./partials";
+import { contentsBaseSchema, coverSchema } from "./partials";
 
 export const pages = defineCollection({
   loader: globLoader("pages"),
   schema: ({ image }) =>
     contentsBaseSchema
       .extend({
-        cover: image().optional(),
+        cover: coverSchema(image).optional(),
         i18n: z
           .record(z.string().refine(isAvailableLanguage), reference("pages"))
           .optional(),
@@ -16,8 +16,6 @@ export const pages = defineCollection({
       .transform(({ isDraft, publishedOn, updatedOn, ...page }) => {
         return {
           ...page,
-          // `<Image />` component expect the src to be the full object.
-          ...(page.cover ? { cover: { src: page.cover } } : {}),
           meta: {
             isDraft,
             publishedOn,

--- a/src/lib/astro/collections/schema/pages.ts
+++ b/src/lib/astro/collections/schema/pages.ts
@@ -8,12 +8,7 @@ export const pages = defineCollection({
   schema: ({ image }) =>
     contentsBaseSchema
       .extend({
-        cover: z
-          .object({
-            alt: z.string(),
-            src: image(),
-          })
-          .optional(),
+        cover: image().optional(),
         i18n: z
           .record(z.string().refine(isAvailableLanguage), reference("pages"))
           .optional(),
@@ -21,6 +16,8 @@ export const pages = defineCollection({
       .transform(({ isDraft, publishedOn, updatedOn, ...page }) => {
         return {
           ...page,
+          // `<Image />` component expect the src to be the full object.
+          ...(page.cover ? { cover: { src: page.cover } } : {}),
           meta: {
             isDraft,
             publishedOn,

--- a/src/lib/astro/collections/schema/partials.ts
+++ b/src/lib/astro/collections/schema/partials.ts
@@ -1,7 +1,34 @@
+import type { ImageFunction } from "astro:content";
 import { z } from "astro:schema";
 import { CONFIG } from "../../../../utils/constants";
 import { applyTimezone } from "../../../../utils/dates";
 import { isAvailableLanguage } from "../../../../utils/i18n";
+
+const objectPosition = z.enum([
+  "top",
+  "top center",
+  "center top",
+  "bottom",
+  "bottom center",
+  "center bottom",
+  "left",
+  "left center",
+  "center left",
+  "right",
+  "right center",
+  "center right",
+  "center",
+  "top left",
+  "top right",
+  "bottom left",
+  "bottom right",
+]);
+
+export const coverSchema = (image: ImageFunction) =>
+  z.object({
+    src: image(),
+    position: objectPosition.optional(),
+  });
 
 const dateSchema = z.coerce.date().transform((date) => {
   return applyTimezone(date, { lang: "fr-FR", timezone: CONFIG.TIMEZONE });

--- a/src/lib/astro/collections/schema/projects.test.ts
+++ b/src/lib/astro/collections/schema/projects.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { createImageMock } from "../../../../../tests/mocks/schema";
 import { CONFIG } from "../../../../utils/constants";
 import { projects } from "./projects";
 
@@ -12,6 +13,8 @@ vi.mock("../../../../utils/dates", async (importOriginal) => {
     applyTimezone: vi.fn((date) => date), // Mocked to return the input date
   };
 });
+
+const mockImage = createImageMock();
 
 describe("projects", () => {
   it("should include the meta in the transformed output", async () => {
@@ -31,7 +34,7 @@ describe("projects", () => {
     if (typeof projects.schema !== "function")
       throw new Error("The schema is not callable");
 
-    const parsedSchema = projects.schema({ image: vi.fn() });
+    const parsedSchema = projects.schema({ image: mockImage });
     const result = await parsedSchema.safeParseAsync(project);
 
     expect.assertions(4);
@@ -59,7 +62,7 @@ describe("projects", () => {
     if (typeof projects.schema !== "function")
       throw new Error("The schema is not callable");
 
-    const parsedSchema = projects.schema({ image: vi.fn() });
+    const parsedSchema = projects.schema({ image: mockImage });
     const result = await parsedSchema.safeParseAsync(project);
 
     expect.assertions(5);

--- a/src/lib/astro/collections/schema/projects.ts
+++ b/src/lib/astro/collections/schema/projects.ts
@@ -1,7 +1,7 @@
 import { defineCollection, reference, z } from "astro:content";
 import { isAvailableLanguage } from "../../../../utils/i18n";
 import { globLoader } from "../../loaders/glob-loader";
-import { contentsBaseSchema } from "./partials";
+import { contentsBaseSchema, coverSchema } from "./partials";
 
 export const projects = defineCollection({
   loader: globLoader("projects"),
@@ -9,7 +9,7 @@ export const projects = defineCollection({
     contentsBaseSchema
       .extend({
         isArchived: z.boolean().optional().default(false),
-        cover: image().optional(),
+        cover: coverSchema(image).optional(),
         i18n: z
           .record(z.string().refine(isAvailableLanguage), reference("projects"))
           .optional(),
@@ -39,8 +39,6 @@ export const projects = defineCollection({
         }) => {
           return {
             ...project,
-            // `<Image />` component expect the src to be the full object.
-            ...(project.cover ? { cover: { src: project.cover } } : {}),
             meta: {
               isArchived,
               isDraft,

--- a/src/lib/astro/collections/schema/projects.ts
+++ b/src/lib/astro/collections/schema/projects.ts
@@ -9,12 +9,7 @@ export const projects = defineCollection({
     contentsBaseSchema
       .extend({
         isArchived: z.boolean().optional().default(false),
-        cover: z
-          .object({
-            alt: z.string(),
-            src: image(),
-          })
-          .optional(),
+        cover: image().optional(),
         i18n: z
           .record(z.string().refine(isAvailableLanguage), reference("projects"))
           .optional(),
@@ -44,6 +39,8 @@ export const projects = defineCollection({
         }) => {
           return {
             ...project,
+            // `<Image />` component expect the src to be the full object.
+            ...(project.cover ? { cover: { src: project.cover } } : {}),
             meta: {
               isArchived,
               isDraft,

--- a/src/lib/astro/collections/schema/tags.test.ts
+++ b/src/lib/astro/collections/schema/tags.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { createImageMock } from "../../../../../tests/mocks/schema";
 import { CONFIG } from "../../../../utils/constants";
 import { tags } from "./tags";
 
@@ -12,6 +13,8 @@ vi.mock("../../../../utils/dates", async (importOriginal) => {
     applyTimezone: vi.fn((date) => date), // Mocked to return the input date
   };
 });
+
+const mockImage = createImageMock();
 
 describe("tags", () => {
   it("should include the meta in the transformed output", async () => {
@@ -30,7 +33,7 @@ describe("tags", () => {
     if (typeof tags.schema !== "function")
       throw new Error("The schema is not callable");
 
-    const parsedSchema = tags.schema({ image: vi.fn() });
+    const parsedSchema = tags.schema({ image: mockImage });
     const result = await parsedSchema.safeParseAsync(tag);
 
     expect.assertions(4);
@@ -57,7 +60,7 @@ describe("tags", () => {
     if (typeof tags.schema !== "function")
       throw new Error("The schema is not callable");
 
-    const parsedSchema = tags.schema({ image: vi.fn() });
+    const parsedSchema = tags.schema({ image: mockImage });
     const result = await parsedSchema.safeParseAsync(tag);
 
     expect.assertions(4);

--- a/src/lib/astro/collections/schema/tags.ts
+++ b/src/lib/astro/collections/schema/tags.ts
@@ -1,14 +1,14 @@
 import { defineCollection, reference, z } from "astro:content";
 import { isAvailableLanguage } from "../../../../utils/i18n";
 import { globLoader } from "../../loaders/glob-loader";
-import { contentsBaseSchema } from "./partials";
+import { contentsBaseSchema, coverSchema } from "./partials";
 
 export const tags = defineCollection({
   loader: globLoader("tags"),
   schema: ({ image }) =>
     contentsBaseSchema
       .extend({
-        cover: image().optional(),
+        cover: coverSchema(image).optional(),
         i18n: z
           .record(z.string().refine(isAvailableLanguage), reference("tags"))
           .optional(),
@@ -16,8 +16,6 @@ export const tags = defineCollection({
       .transform(({ isDraft, publishedOn, updatedOn, ...tag }) => {
         return {
           ...tag,
-          // `<Image />` component expect the src to be the full object.
-          ...(tag.cover ? { cover: { src: tag.cover } } : {}),
           meta: {
             isDraft,
             publishedOn,

--- a/src/lib/astro/collections/schema/tags.ts
+++ b/src/lib/astro/collections/schema/tags.ts
@@ -8,12 +8,7 @@ export const tags = defineCollection({
   schema: ({ image }) =>
     contentsBaseSchema
       .extend({
-        cover: z
-          .object({
-            alt: z.string(),
-            src: image(),
-          })
-          .optional(),
+        cover: image().optional(),
         i18n: z
           .record(z.string().refine(isAvailableLanguage), reference("tags"))
           .optional(),
@@ -21,6 +16,8 @@ export const tags = defineCollection({
       .transform(({ isDraft, publishedOn, updatedOn, ...tag }) => {
         return {
           ...tag,
+          // `<Image />` component expect the src to be the full object.
+          ...(tag.cover ? { cover: { src: tag.cover } } : {}),
           meta: {
             isDraft,
             publishedOn,

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -48,7 +48,7 @@ export type SEO = {
 
 export type Author = Pick<CollectionEntry<"authors">, "collection" | "id"> &
   Omit<CollectionEntry<"authors">["data"], "avatar"> & {
-    avatar?: Omit<Img, "alt"> | null | undefined;
+    avatar?: Img | null | undefined;
   };
 
 export type AuthorLink = Pick<Author, "isWebsiteOwner" | "name" | "website">;
@@ -76,8 +76,9 @@ export type HTTPStatus = {
 
 export type Img = Omit<
   LocalImageProps | RemoteImageProps,
-  "width" | "height"
+  "alt" | "width" | "height"
 > & {
+  alt?: string | null | undefined;
   height?: number | undefined;
   width?: number | undefined;
 };

--- a/tests/mocks/references.ts
+++ b/tests/mocks/references.ts
@@ -1,0 +1,11 @@
+import { z } from "astro:content";
+
+export function createReferenceMock(collection: string) {
+  return z.string().transform((slug) => ({
+    collection,
+    slug,
+    data: {
+      name: `Mock ${collection} ${slug}`,
+    },
+  }));
+}

--- a/tests/mocks/schema.ts
+++ b/tests/mocks/schema.ts
@@ -1,0 +1,14 @@
+import type { ImageFunction } from "astro:content";
+
+export function createImageMock(): ImageFunction {
+  return (() => ({
+    _parse: () => ({ success: true }),
+    parse: () => ({}),
+    safeParse: () => ({ success: true, data: {} }),
+    optional: () => ({
+      _parse: () => ({ success: true }),
+      parse: () => ({}),
+      safeParse: () => ({ success: true, data: {} }),
+    }),
+  })) as unknown as ImageFunction;
+}


### PR DESCRIPTION
## Changes

* Replaces the alt text for decorative images with an empty string.
* Removes the `alt` property inside content collections `cover`.
* Adds a new `position` property inside content collections `cover` to customize the cover position.
* Readjusts the cover dimensions on cards and pages

## Tests

Existing tests should still pass. I had to do some adjustments:
* redefine the mock for the `image` helper when declaring content collections schema,
* update a test relying on an alt text,
* add `cover: null` is some snapshots

## Docs

Changesets added.