### PR TITLE
fix: avoid pages that link to themselves

### DIFF
--- a/.changeset/unlucky-ducks-exist.md
+++ b/.changeset/unlucky-ducks-exist.md
@@ -1,0 +1,7 @@
+---
+"apeu": patch
+---
+
+Removes links pointing to the current page.
+
+Some pages (tags, categories) was linking to themselves. This removes those useless links.

--- a/src/pages/blog/categories/[slug]/index.astro
+++ b/src/pages/blog/categories/[slug]/index.astro
@@ -37,13 +37,17 @@ const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
 const graphs: ComponentProps<typeof PageLayout>["graphs"] = [
   await getWebPageGraph({ ...page, breadcrumb }),
 ];
-const { entries: relatedPosts, total: totalPosts } = await queryCollection(
-  "blogPosts",
-  {
-    orderBy: { key: "publishedOn", order: "DESC" },
-    where: { categories: [page.id] },
-  },
-);
+const { entries, total: totalPosts } = await queryCollection("blogPosts", {
+  orderBy: { key: "publishedOn", order: "DESC" },
+  where: { categories: [page.id] },
+});
+const relatedPosts = entries.map(({ meta, ...post }) => {
+  const { category, ...remainingMeta } = meta;
+  return {
+    ...post,
+    meta: remainingMeta,
+  };
+});
 const getCTA = (
   title: string,
 ): ComponentProps<typeof CollectionCard>["cta"] => {

--- a/src/pages/en/blog/categories/[slug]/index.astro
+++ b/src/pages/en/blog/categories/[slug]/index.astro
@@ -37,13 +37,17 @@ const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
 const graphs: ComponentProps<typeof PageLayout>["graphs"] = [
   await getWebPageGraph({ ...page, breadcrumb }),
 ];
-const { entries: relatedPosts, total: totalPosts } = await queryCollection(
-  "blogPosts",
-  {
-    orderBy: { key: "publishedOn", order: "DESC" },
-    where: { categories: [page.id] },
-  },
-);
+const { entries, total: totalPosts } = await queryCollection("blogPosts", {
+  orderBy: { key: "publishedOn", order: "DESC" },
+  where: { categories: [page.id] },
+});
+const relatedPosts = entries.map(({ meta, ...post }) => {
+  const { category, ...remainingMeta } = meta;
+  return {
+    ...post,
+    meta: remainingMeta,
+  };
+});
 const getCTA = (
   title: string,
 ): ComponentProps<typeof CollectionCard>["cta"] => {

--- a/src/pages/en/tags/[slug]/index.astro
+++ b/src/pages/en/tags/[slug]/index.astro
@@ -8,6 +8,7 @@ import CollectionMeta from "../../../../components/organisms/collection-meta/col
 import PageLayout from "../../../../components/templates/page-layout/page-layout.astro";
 import { queryCollection } from "../../../../lib/astro/collections";
 import { getWebPageGraph } from "../../../../lib/schema-dts/graphs/webpage-graph";
+import type { TaxonomyLink } from "../../../../types/data";
 import { useI18n } from "../../../../utils/i18n";
 
 export const getStaticPaths = (async () => {
@@ -74,6 +75,7 @@ const getCTA = (
       return null;
   }
 };
+const removeCurrentTag = (tag: TaxonomyLink) => tag.route !== page.route;
 ---
 
 <PageLayout
@@ -118,6 +120,10 @@ const getCTA = (
                   },
                 }
               : {}),
+            meta: {
+              ...entry.meta,
+              tags: entry.meta.tags?.filter(removeCurrentTag),
+            },
           }}
           showCollection
         />

--- a/src/pages/etiquettes/[slug]/index.astro
+++ b/src/pages/etiquettes/[slug]/index.astro
@@ -8,6 +8,7 @@ import CollectionMeta from "../../../components/organisms/collection-meta/collec
 import PageLayout from "../../../components/templates/page-layout/page-layout.astro";
 import { queryCollection } from "../../../lib/astro/collections";
 import { getWebPageGraph } from "../../../lib/schema-dts/graphs/webpage-graph";
+import type { TaxonomyLink } from "../../../types/data";
 import { useI18n } from "../../../utils/i18n";
 
 export const getStaticPaths = (async () => {
@@ -74,6 +75,7 @@ const getCTA = (
       return null;
   }
 };
+const removeCurrentTag = (tag: TaxonomyLink) => tag.route !== page.route;
 ---
 
 <PageLayout
@@ -118,6 +120,10 @@ const getCTA = (
                   },
                 }
               : {}),
+            meta: {
+              ...entry.meta,
+              tags: entry.meta.tags?.filter(removeCurrentTag),
+            },
           }}
           showCollection
         />


### PR DESCRIPTION
## Changes

Filters the links displayed on taxonomies pages. A link targeting the current page is useless, so they should be removed when displaying the categories/tags lists.

## Tests

Existing tests should still pass.

## Docs

Changeset added.