### PR TITLE
fix: add missing `item` property in ListItem graph

### DIFF
--- a/.changeset/stupid-dogs-pull.md
+++ b/.changeset/stupid-dogs-pull.md
@@ -1,0 +1,5 @@
+---
+"apeu": patch
+---
+
+Fixes the BreadcrumbList format used in Schema.org structured data.

--- a/src/lib/schema-dts/graphs/breadcrumb-list-graph.test.ts
+++ b/src/lib/schema-dts/graphs/breadcrumb-list-graph.test.ts
@@ -19,15 +19,19 @@ describe("get-breadcrumb-list-graph", () => {
         "@type": "BreadcrumbList",
         "itemListElement": [
           {
-            "@id": "/magni",
             "@type": "ListItem",
-            "name": "magni",
+            "item": {
+              "@id": "/magni",
+              "name": "magni",
+            },
             "position": 1,
           },
           {
-            "@id": "/quasi",
             "@type": "ListItem",
-            "name": "quasi",
+            "item": {
+              "@id": "/quasi",
+              "name": "quasi",
+            },
             "position": 2,
           },
         ],

--- a/src/lib/schema-dts/graphs/list-item-graph.test.ts
+++ b/src/lib/schema-dts/graphs/list-item-graph.test.ts
@@ -11,9 +11,11 @@ describe("get-list-item-graph", () => {
 
     expect(graph).toMatchInlineSnapshot(`
       {
-        "@id": "optio",
         "@type": "ListItem",
-        "name": "magni",
+        "item": {
+          "@id": "optio",
+          "name": "magni",
+        },
         "position": 2,
       }
     `);

--- a/src/lib/schema-dts/graphs/list-item-graph.ts
+++ b/src/lib/schema-dts/graphs/list-item-graph.ts
@@ -13,8 +13,10 @@ export const getListItemGraph = ({
 }: ListItemGraphData): ListItem => {
   return {
     "@type": "ListItem",
-    "@id": id,
-    name: label,
+    item: {
+      "@id": id,
+      name: label,
+    },
     position,
   };
 };

--- a/src/lib/schema-dts/graphs/webpage-graph.test.ts
+++ b/src/lib/schema-dts/graphs/webpage-graph.test.ts
@@ -171,15 +171,19 @@ describe("get-webpage-graph", () => {
           "@type": "BreadcrumbList",
           "itemListElement": [
             {
-              "@id": "/qui",
               "@type": "ListItem",
-              "name": "qui",
+              "item": {
+                "@id": "/qui",
+                "name": "qui",
+              },
               "position": 1,
             },
             {
-              "@id": "/molestiae",
               "@type": "ListItem",
-              "name": "molestiae",
+              "item": {
+                "@id": "/molestiae",
+                "name": "molestiae",
+              },
               "position": 2,
             },
           ],


### PR DESCRIPTION
## Changes

The `name` and `@id` was misplaced inside the `ListItem` graph, they should be put in an `item` property. So the `BreadcrumbList` graph was not valid...

## Tests

Updated some tests, others should still pass.

## Docs

Adds changeset