### PR TITLE
refactor: improve theme management

### DIFF
--- a/.changeset/empty-parts-doubt.md
+++ b/.changeset/empty-parts-doubt.md
@@ -1,0 +1,7 @@
+---
+"apeu": minor
+---
+
+Prefixes local storage variables to avoid conflicts in dev mode.
+
+If you have already define a theme for the website or for the code blocks, you'll need to configure it again because of the prefix change.

--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -21,3 +21,4 @@ stylelint
 tsconfigs
 tseslint
 unstub
+vitest

--- a/src/components/molecules/theme-setting/theme-setting.astro
+++ b/src/components/molecules/theme-setting/theme-setting.astro
@@ -121,7 +121,6 @@ const defaultValue =
     isValidSettingsKey,
     settings,
     SHIKI_SETTING_KEY,
-    THEME_DEFAULT,
     THEME_SETTING_KEY,
     type Settings,
   } from "../../../services/stores/settings";
@@ -135,23 +134,26 @@ const defaultValue =
     #isSwitch = false;
     #settingKey: keyof Settings = THEME_SETTING_KEY;
     #switchBtn: HTMLButtonElement | null = null;
-    #theme: Theme = THEME_DEFAULT;
+    #unsubscribe: (() => void) | null = null;
 
     constructor() {
       super();
       this.handleUpdate = this.handleUpdate.bind(this);
-      this.listenSettings = this.listenSettings.bind(this);
     }
 
     connectedCallback() {
       this.#isSwitch = this.dataset.variant === "switch";
       this.#switchBtn = this.querySelector("button");
-      this.#theme = settings.get().theme;
 
-      if (isValidSettingsKey(this.dataset.setting))
+      if (isValidSettingsKey(this.dataset.setting)) {
         this.#settingKey = this.dataset.setting;
+      }
 
-      settings.subscribe(this.listenSettings);
+      this.#unsubscribe = settings.subscribe(
+        (newSettings: Readonly<Settings>) => {
+          this.#updateSelectedTheme(newSettings);
+        }
+      );
 
       if (this.#isSwitch) {
         this.#switchBtn?.addEventListener("click", this.handleUpdate, {
@@ -170,10 +172,11 @@ const defaultValue =
       } else {
         this.removeEventListener("change", this.handleUpdate);
       }
-    }
 
-    #isCurrentTheme(theme: Theme): boolean {
-      return theme === this.#theme;
+      // Unsubscribe from store
+      if (this.#unsubscribe) {
+        this.#unsubscribe();
+      }
     }
 
     #updateSwitchValue(newSettings: Readonly<Settings>) {
@@ -202,20 +205,6 @@ const defaultValue =
       else this.#updateToggleValue(newSettings);
     }
 
-    listenSettings(
-      newSettings: Readonly<Settings>,
-      _oldSettings: Readonly<Settings> | undefined,
-      changedKey: keyof Settings | undefined
-    ) {
-      const newTheme = newSettings[this.#settingKey];
-      const isCurrentSetting = changedKey === this.#settingKey;
-
-      if (isCurrentSetting && this.#isCurrentTheme(newTheme)) return;
-
-      this.#theme = newTheme;
-      this.#updateSelectedTheme(newSettings);
-    }
-
     #getSelectedToggleTheme(option: HTMLInputElement): Theme | null {
       if (isValidTheme(option.value)) return option.value;
       return null;
@@ -225,22 +214,26 @@ const defaultValue =
       return btn.ariaChecked === "true" ? "light" : "dark";
     }
 
+    handleUpdate(e: Event) {
+      e.stopImmediatePropagation();
+
+      const newTheme = this.#getNewThemeFromEvent(e);
+
+      if (newTheme === null) return;
+
+      settings.setKey(this.#settingKey, newTheme);
+    }
+
     #getNewThemeFromEvent(e: Event): Theme | null {
       if (this.#isSwitch && e.currentTarget instanceof HTMLButtonElement) {
         return this.#getUnselectedSwitchTheme(e.currentTarget);
       }
+
       if (e.target instanceof HTMLInputElement) {
         return this.#getSelectedToggleTheme(e.target);
       }
+
       return null;
-    }
-
-    handleUpdate(e: Event) {
-      e.stopImmediatePropagation();
-      const newTheme = this.#getNewThemeFromEvent(e);
-
-      if (newTheme && !this.#isCurrentTheme(newTheme))
-        settings.setKey(this.#settingKey, newTheme);
     }
   }
 

--- a/src/components/providers/theme-provider.astro
+++ b/src/components/providers/theme-provider.astro
@@ -6,65 +6,41 @@
 
 <script>
   import {
-    settings,
-    SHIKI_SETTING_KEY,
+    activeTheme,
+    activeShikiTheme,
     THEME_SETTING_KEY,
-    type Settings,
+    SHIKI_SETTING_KEY,
   } from "../../services/stores/settings";
-  import type { Theme } from "../../types/tokens";
-  import { resolveCurrentColorScheme } from "../../utils/themes";
 
-  function resolveTheme(theme: Theme, key: keyof Settings) {
-    if (key === SHIKI_SETTING_KEY && theme === "auto")
-      return settings.get().theme;
+  function updateThemes() {
+    const mainTheme = activeTheme.get();
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- window can be undefined, at least while running Vitest.
+    globalThis.window?.document.documentElement.setAttribute(
+      `data-${THEME_SETTING_KEY}`,
+      mainTheme
+    );
+    document.documentElement.style.colorScheme = mainTheme;
 
-    return theme;
+    const codeTheme = activeShikiTheme.get();
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- window can be undefined, at least while running Vitest.
+    globalThis.window?.document.documentElement.setAttribute(
+      `data-${SHIKI_SETTING_KEY}`,
+      codeTheme
+    );
   }
 
-  function updateThemeAttrsOnDocument(theme: Theme, key: keyof Settings) {
-    const resolvedTheme = resolveTheme(theme, key);
-    const colorScheme = resolveCurrentColorScheme(resolvedTheme);
+  const prefersColorScheme = window.matchMedia("(prefers-color-scheme: dark)");
+  prefersColorScheme.addEventListener("change", updateThemes);
 
-    window.document.documentElement.setAttribute(`data-${key}`, colorScheme);
+  const mainThemeUnsubscribe = activeTheme.subscribe(updateThemes);
+  const codeThemeUnsubscribe = activeShikiTheme.subscribe(updateThemes);
 
-    if (key === THEME_SETTING_KEY)
-      window.document.documentElement.style.colorScheme = colorScheme;
-  }
+  updateThemes();
 
-  function listenSettings(
-    newSettings: Readonly<Settings>,
-    _oldSettings: Readonly<Settings> | undefined,
-    changedKey: keyof Settings | undefined
-  ): void {
-    if (!changedKey || typeof window === "undefined") return;
-
-    updateThemeAttrsOnDocument(newSettings[changedKey], changedKey);
-
-    if (changedKey === THEME_SETTING_KEY && newSettings.shiki === "auto")
-      updateThemeAttrsOnDocument(newSettings.theme, SHIKI_SETTING_KEY);
-  }
-
-  function handlePreferDarkSchemeChange(e: MediaQueryListEvent) {
-    const currentSettings = settings.get();
-    const resolvedTheme = e.matches ? "dark" : "light";
-
-    if (currentSettings.shiki === "auto")
-      updateThemeAttrsOnDocument(resolvedTheme, SHIKI_SETTING_KEY);
-
-    if (currentSettings.theme === "auto")
-      updateThemeAttrsOnDocument(resolvedTheme, THEME_SETTING_KEY);
-  }
-
-  window
-    .matchMedia("(prefers-color-scheme: dark)")
-    .addEventListener("change", handlePreferDarkSchemeChange);
-
-  settings.subscribe(listenSettings);
-
+  // Clean up event listeners when the component is destroyed
   document.addEventListener("astro:before-swap", () => {
-    window
-      .matchMedia("(prefers-color-scheme: dark)")
-      .removeEventListener("change", handlePreferDarkSchemeChange);
-    settings.off();
+    prefersColorScheme.removeEventListener("change", updateThemes);
+    mainThemeUnsubscribe();
+    codeThemeUnsubscribe();
   });
 </script>

--- a/src/components/utilities/global-theme-init.astro
+++ b/src/components/utilities/global-theme-init.astro
@@ -5,7 +5,7 @@
 {/* This is intentionally inlined to avoid Flash Of Unstyled Content. */}
 <script is:inline>
   !(function () {
-    const e = localStorage.getItem("settings:theme"),
+    const e = localStorage.getItem("apeu-settings:theme"),
       t = "string" == typeof e ? JSON.parse(e) : void 0,
       o = window.matchMedia("(prefers-color-scheme: dark)").matches
         ? "dark"

--- a/src/components/utilities/shiki-theme-init.astro
+++ b/src/components/utilities/shiki-theme-init.astro
@@ -6,7 +6,7 @@
 {/* prettier-ignore */}
 <script is:inline>
   !(function () {
-    const e = localStorage.getItem("settings:shiki"),
+    const e = localStorage.getItem("apeu-settings:shiki"),
       t = "string" == typeof e ? JSON.parse(e) : void 0,
       o = document.documentElement.getAttribute("data-theme"),
       s = window.matchMedia("(prefers-color-scheme: dark)").matches

--- a/src/services/stores/settings.ts
+++ b/src/services/stores/settings.ts
@@ -1,5 +1,7 @@
 import { persistentMap } from "@nanostores/persistent";
+import { computed } from "nanostores";
 import type { Theme } from "../../types/tokens";
+import { resolveCurrentColorScheme } from "../../utils/themes";
 
 export type Settings = {
   shiki: Theme;
@@ -15,7 +17,7 @@ export const SHIKI_SETTING_KEY = "shiki";
 export const THEME_SETTING_KEY = "theme";
 
 export const settings = persistentMap<Settings>(
-  "settings:",
+  "apeu-settings:",
   {
     shiki: SHIKI_DEFAULT,
     theme: THEME_DEFAULT,
@@ -41,3 +43,22 @@ export const isValidSettingsKey = (value: unknown): value is keyof Settings => {
 
   return typeof value === "string" && validKeys.includes(value);
 };
+
+/**
+ * The actual theme, considering system preferences.
+ */
+export const activeTheme = computed(settings, (activeSettings) =>
+  resolveCurrentColorScheme(activeSettings.theme)
+);
+
+/**
+ * The actual theme for code blocks, considering global theme and system
+ * preferences.
+ */
+export const activeShikiTheme = computed(
+  [settings, activeTheme],
+  (activeSettings, mainTheme) =>
+    activeSettings.shiki === "auto"
+      ? mainTheme
+      : resolveCurrentColorScheme(activeSettings.shiki)
+);

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,4 +1,5 @@
 import type { HTTPStatus } from "../types/data";
+import type { Theme } from "../types/tokens";
 
 export const API_ROUTES = {
   SEND_EMAIL: "/api/send-email",
@@ -111,6 +112,11 @@ export const STORIES_SUFFIX = "stories";
  * @see https://docs.astro.build/en/reference/integrations-reference/#injectroute-option
  */
 export const STORIES_EXT = `${STORIES_SUFFIX}.astro`;
+
+/**
+ * The available themes.
+ */
+export const THEMES = ["auto", "dark", "light"] as const satisfies Theme[];
 
 /**
  * The number of words read per minute depending on the lang.

--- a/src/utils/themes.ts
+++ b/src/utils/themes.ts
@@ -1,16 +1,14 @@
 import type { Theme } from "../types/tokens";
+import { THEMES } from "./constants";
 
 /**
  * Check if the given value is a valid theme.
  *
- * @param {unknown} value - A value to test.
+ * @param {unknown} value - A value to validate.
  * @returns {boolean} True if the value is a valid theme.
  */
-export const isValidTheme = (value: unknown): value is Theme => {
-  const validThemes: string[] = ["auto", "dark", "light"] satisfies Theme[];
-
-  return typeof value === "string" && validThemes.includes(value);
-};
+export const isValidTheme = (value: unknown): value is Theme =>
+  typeof value === "string" && (THEMES as string[]).includes(value);
 
 /**
  * Retrieve the preferred color scheme from the user's system preferences.


### PR DESCRIPTION
## Changes

* Refactors the theme management system by taking advantage of computed stores.
* Prefixes stored variables to prevent conflicts in dev mode (ie. if two websites uses `settings`, the value could be overwritten and possible produce invalid value)

## Tests

Existing tests should still pass.

## Docs

Changeset added, as minor, because this include a kind of breaking change for users: the variables stored in the browser local storage are now prefixed so previously configured themes will not be picked.