### PR TITLE
feat: add view transitions

### DIFF
--- a/.changeset/stale-chicken-help.md
+++ b/.changeset/stale-chicken-help.md
@@ -1,0 +1,5 @@
+---
+"apeu": minor
+---
+
+Adds View Transitions to avoid full-page navigation refresh.

--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ You can choose to use a dark theme or light theme while browsing the website. Yo
 
 A global feed is available in each language. This projects also supports individual feeds for each collections.
 
+### View transitions
+
+While all browsers do not support view transitions yet, this project uses Astro built-in view transitions to provide a fallback. This feature avoids full-page navigation refresh which seems preferrable to some.
+
 ## Authoring
 
 The content directory located at the root of the project is used to store all the website contents. You can provide a custom relative path using an environment variable named `CONTENT_PATH`.

--- a/src/components/atoms/progress-bar/progress-bar.astro
+++ b/src/components/atoms/progress-bar/progress-bar.astro
@@ -80,7 +80,7 @@ const progressValueFallback = current ? `${current}/${max}` : null;
     width: 30%;
     height: 100%;
     background-color: var(--progress-bar-color);
-    animation: progress-bar-move-indeterminate 1.5s linear 0s infinite both
+    animation: progress-bar-move-indeterminate 1.25s linear 0s infinite both
       alternate;
   }
 

--- a/src/components/atoms/progress-bar/progress-bar.astro
+++ b/src/components/atoms/progress-bar/progress-bar.astro
@@ -1,0 +1,97 @@
+---
+import type { HTMLAttributes } from "astro/types";
+
+type Props = HTMLAttributes<"div"> & {
+  /**
+   * Current value.
+   */
+  current?: number | null | undefined;
+  /**
+   * Maximal value.
+   */
+  max?: number | null | undefined;
+};
+
+const {
+  "aria-label": ariaLabel,
+  "aria-valuemax": ariaValueMax,
+  "aria-valuemin": ariaValueMin,
+  "aria-valuenow": ariaValueNow,
+  class: className,
+  current,
+  max = 1,
+  ...attrs
+} = Astro.props;
+const progressValueFallback = current ? `${current}/${max}` : null;
+---
+
+<div {...attrs} class:list={["progress-wrapper", className]}>
+  <progress
+    aria-label={ariaLabel}
+    aria-valuemax={ariaValueMax ?? max}
+    aria-valuemin={ariaValueMin ?? 0}
+    aria-valuenow={ariaValueNow ?? current}
+    class="progress-bar"
+    max={max}
+    value={current}>{progressValueFallback}</progress
+  >
+</div>
+
+<style>
+  .progress-wrapper {
+    position: relative;
+    width: 100%;
+    height: var(--spacing-2xs);
+    background-color: var(--color-muted-lighter);
+    overflow: hidden;
+  }
+
+  .progress-bar {
+    display: block;
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    appearance: none;
+    border: none;
+    border-radius: 0;
+    background-color: transparent;
+
+    &::-webkit-progress-bar {
+      background-color: transparent;
+    }
+
+    &::-webkit-progress-value {
+      background-color: var(--color-primary-lighter);
+    }
+
+    &:not(:indeterminate)::-moz-progress-bar {
+      background-color: var(--color-primary-lighter);
+    }
+
+    &:indeterminate::-moz-progress-bar {
+      background-color: transparent;
+    }
+  }
+
+  .progress-wrapper:has(.progress-bar:indeterminate)::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 30%;
+    height: 100%;
+    background-color: var(--color-primary);
+    animation: progress-bar-move-indeterminate 1.5s linear 0s infinite both
+      alternate;
+  }
+
+  @keyframes progress-bar-move-indeterminate {
+    0% {
+      transform: translateX(-50%);
+    }
+
+    100% {
+      transform: translateX(300%);
+    }
+  }
+</style>

--- a/src/components/atoms/progress-bar/progress-bar.astro
+++ b/src/components/atoms/progress-bar/progress-bar.astro
@@ -39,10 +39,12 @@ const progressValueFallback = current ? `${current}/${max}` : null;
 
 <style>
   .progress-wrapper {
+    --progress-bar-color: var(--color-primary-lighter);
+
     position: relative;
     width: 100%;
-    height: var(--spacing-2xs);
-    background-color: var(--color-muted-lighter);
+    height: var(--spacing-3xs);
+    background-color: oklch(from var(--color-muted-light) l c h / 50%);
     overflow: hidden;
   }
 
@@ -60,12 +62,9 @@ const progressValueFallback = current ? `${current}/${max}` : null;
       background-color: transparent;
     }
 
-    &::-webkit-progress-value {
-      background-color: var(--color-primary-lighter);
-    }
-
+    &::-webkit-progress-value,
     &:not(:indeterminate)::-moz-progress-bar {
-      background-color: var(--color-primary-lighter);
+      background-color: var(--progress-bar-color);
     }
 
     &:indeterminate::-moz-progress-bar {
@@ -80,7 +79,7 @@ const progressValueFallback = current ? `${current}/${max}` : null;
     left: 0;
     width: 30%;
     height: 100%;
-    background-color: var(--color-primary);
+    background-color: var(--progress-bar-color);
     animation: progress-bar-move-indeterminate 1.5s linear 0s infinite both
       alternate;
   }

--- a/src/components/atoms/progress-bar/progress-bar.stories.astro
+++ b/src/components/atoms/progress-bar/progress-bar.stories.astro
@@ -1,0 +1,48 @@
+---
+import type { ComponentProps } from "astro/types";
+import PageLayout from "../../templates/page-layout/page-layout.astro";
+import Heading from "../heading/heading.astro";
+import ProgressBarComponent from "./progress-bar.astro";
+
+const title = "ProgressBar";
+const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
+  { label: "Home", url: "/" },
+  { label: "Design system", url: "/design-system" },
+  { label: "Components", url: "/design-system/components" },
+  { label: "Atoms", url: "/design-system/components/atoms" },
+  { label: title, url: Astro.url.href },
+];
+const seo: ComponentProps<typeof PageLayout>["seo"] = {
+  nofollow: true,
+  noindex: true,
+  title: breadcrumb
+    .slice(1)
+    .reverse()
+    .map((crumb) => crumb.label)
+    .join(" | "),
+};
+---
+
+<PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
+  <Fragment slot="body">
+    <Heading as="h2">Usage</Heading>
+    <p>
+      A <code>ProgressBar</code> should be used to indicate a loading state. This
+      can be useful with view transitions for example.
+    </p>
+    <Heading as="h2">States</Heading>
+    <Heading as="h2">Using a current value</Heading>
+    <ProgressBarComponent
+      aria-label="Progress bar with value example"
+      current={0.4}
+    />
+    <Heading as="h2">Using a current value and a max</Heading>
+    <ProgressBarComponent
+      aria-label="Progress bar with value and max example"
+      current={30}
+      max={100}
+    />
+    <Heading as="h2">Indeterminate</Heading>
+    <ProgressBarComponent aria-label="Indeterminate progress bar example" />
+  </Fragment>
+</PageLayout>

--- a/src/components/atoms/progress-bar/progress-bar.test.ts
+++ b/src/components/atoms/progress-bar/progress-bar.test.ts
@@ -1,0 +1,52 @@
+import { experimental_AstroContainer as AstroContainer } from "astro/container";
+import type { ComponentProps } from "astro/types";
+import { beforeEach, describe, expect, it } from "vitest";
+import ProgressBar from "./progress-bar.astro";
+
+type LocalTestContext = {
+  container: AstroContainer;
+};
+
+describe("ProgressBar", () => {
+  beforeEach<LocalTestContext>(async (context) => {
+    context.container = await AstroContainer.create();
+  });
+
+  it<LocalTestContext>("can render a progress bar", async ({ container }) => {
+    expect.assertions(1);
+
+    const props = {} satisfies ComponentProps<typeof ProgressBar>;
+    const result = await container.renderToString(ProgressBar, {
+      props,
+    });
+
+    expect(result).toContain("</progress");
+  });
+
+  it<LocalTestContext>("can use a current value", async ({ container }) => {
+    expect.assertions(1);
+
+    const props = {
+      current: 0.5,
+    } satisfies ComponentProps<typeof ProgressBar>;
+    const result = await container.renderToString(ProgressBar, {
+      props,
+    });
+
+    expect(result).toContain(`${props.current}/1`);
+  });
+
+  it<LocalTestContext>("can use a custom max value", async ({ container }) => {
+    expect.assertions(1);
+
+    const props = {
+      current: 50,
+      max: 100,
+    } satisfies ComponentProps<typeof ProgressBar>;
+    const result = await container.renderToString(ProgressBar, {
+      props,
+    });
+
+    expect(result).toContain(`${props.current}/${props.max}`);
+  });
+});

--- a/src/components/molecules/breadcrumb/breadcrumb.astro
+++ b/src/components/molecules/breadcrumb/breadcrumb.astro
@@ -10,6 +10,25 @@ type Props = HTMLAttributes<"nav"> & {
 };
 
 const { class: className, isCentered = false, items, ...attrs } = Astro.props;
+
+const currentPageReveal = {
+  old: {
+    name: "breadcrumb-scale-to-right",
+    duration: "0.2s",
+    easing: "linear",
+    direction: "reverse",
+  },
+  new: {
+    name: "breadcrumb-scale-to-right",
+    duration: "0.3s",
+    easing: "linear",
+  },
+};
+
+const currentPageRevealTransition = {
+  forwards: currentPageReveal,
+  backwards: currentPageReveal,
+};
 ---
 
 <nav
@@ -20,18 +39,42 @@ const { class: className, isCentered = false, items, ...attrs } = Astro.props;
   <NavList class="breadcrumb-list" hideMarker isInline isOrdered items={items}>
     {
       ({ label, url, ...item }, index, crumbs) => {
+        const isFirstItem = index === 0;
         const isLastItem = index + 1 === crumbs.length;
 
         return isLastItem ? (
-          <span aria-current="page" class="breadcrumb-item">
+          <span
+            aria-current="page"
+            class="breadcrumb-item"
+            transition:animate={currentPageRevealTransition}
+            transition:name="breadcrumb-current"
+          >
             {label}
           </span>
         ) : (
           <Fragment>
-            <NavItem {...item} class="breadcrumb-item" href={url} isRounded>
+            <NavItem
+              {...item}
+              class="breadcrumb-item"
+              href={url}
+              isRounded
+              transition:animate={currentPageRevealTransition}
+              transition:name={
+                isFirstItem ? "breadcrumb-home" : `item-${index}`
+              }
+            >
               {label}
             </NavItem>
-            <span aria-hidden="true">&gt;</span>
+            <span
+              aria-hidden="true"
+              {...(isFirstItem
+                ? {}
+                : {
+                    "transition:animate": currentPageRevealTransition,
+                  })}
+            >
+              &gt;
+            </span>
           </Fragment>
         );
       }
@@ -75,6 +118,40 @@ const { class: className, isCentered = false, items, ...attrs } = Astro.props;
     &:where(span) {
       color: var(--color-muted-faded);
       font-weight: var(--font-weight-bold);
+    }
+  }
+</style>
+
+<style is:global>
+  ::view-transition-old(breadcrumb-home),
+  ::view-transition-new(breadcrumb-home) {
+    animation: none;
+    transform: none;
+    opacity: 1;
+  }
+
+  ::view-transition-old(breadcrumb-home) {
+    display: none;
+  }
+
+  ::view-transition-old(breadcrumb-current),
+  ::view-transition-new(breadcrumb-current),
+  [id^="::view-transition-old(breadcrumb-item-"],
+  [id^="::view-transition-new(breadcrumb-item-"] {
+    height: 100%;
+  }
+
+  @keyframes breadcrumb-scale-to-right {
+    0% {
+      transform: scaleX(0);
+      transform-origin: left center;
+      opacity: 0;
+    }
+
+    100% {
+      transform: scaleX(1);
+      transform-origin: left center;
+      opacity: 1;
     }
   }
 </style>

--- a/src/components/molecules/breadcrumb/breadcrumb.astro
+++ b/src/components/molecules/breadcrumb/breadcrumb.astro
@@ -11,7 +11,7 @@ type Props = HTMLAttributes<"nav"> & {
 
 const { class: className, isCentered = false, items, ...attrs } = Astro.props;
 
-const currentPageReveal = {
+const scaleToRight = {
   old: {
     name: "breadcrumb-scale-to-right",
     duration: "0.2s",
@@ -25,9 +25,9 @@ const currentPageReveal = {
   },
 };
 
-const currentPageRevealTransition = {
-  forwards: currentPageReveal,
-  backwards: currentPageReveal,
+const scaleToRightTransition = {
+  forwards: scaleToRight,
+  backwards: scaleToRight,
 };
 ---
 
@@ -46,7 +46,7 @@ const currentPageRevealTransition = {
           <span
             aria-current="page"
             class="breadcrumb-item"
-            transition:animate={currentPageRevealTransition}
+            transition:animate={scaleToRightTransition}
             transition:name="breadcrumb-current"
           >
             {label}
@@ -58,7 +58,7 @@ const currentPageRevealTransition = {
               class="breadcrumb-item"
               href={url}
               isRounded
-              transition:animate={currentPageRevealTransition}
+              transition:animate={scaleToRightTransition}
               transition:name={
                 isFirstItem ? "breadcrumb-home" : `item-${index}`
               }
@@ -70,7 +70,7 @@ const currentPageRevealTransition = {
               {...(isFirstItem
                 ? {}
                 : {
-                    "transition:animate": currentPageRevealTransition,
+                    "transition:animate": scaleToRightTransition,
                   })}
             >
               &gt;

--- a/src/components/molecules/breadcrumb/breadcrumb.test.ts
+++ b/src/components/molecules/breadcrumb/breadcrumb.test.ts
@@ -29,7 +29,7 @@ describe("Breadcrumb", () => {
       props,
     });
 
-    const listItems = [...result.matchAll(/<li.*?<\/li>/g)];
+    const listItems = [...result.matchAll(/<li[^>]*>[\S\s]*?<\/li>/g)];
 
     expect(listItems).toHaveLength(props.items.length);
     expect(result).toContain(props.items[0]?.url);

--- a/src/components/providers/page-transition-provider.astro
+++ b/src/components/providers/page-transition-provider.astro
@@ -1,0 +1,76 @@
+---
+import { useI18n } from "../../utils/i18n";
+import ProgressBar from "../atoms/progress-bar/progress-bar.astro";
+
+const { translate } = useI18n(Astro.currentLocale);
+---
+
+<ProgressBar
+  aria-label={translate("page.loading")}
+  aria-live="polite"
+  class="page-transition"
+/>
+<slot />
+
+<style>
+  .page-transition {
+    position: fixed;
+    top: 0;
+    z-index: 1000;
+
+    &:not([data-visible="true"]) {
+      display: none;
+    }
+  }
+</style>
+
+<script>
+  import {
+    TRANSITION_BEFORE_PREPARATION,
+    TRANSITION_PAGE_LOAD,
+  } from "astro:transitions/client";
+
+  let progressBarTimer: NodeJS.Timeout | undefined;
+  const DELAY_IN_MS = 200;
+  const MIN_DISPLAY_TIME_IN_MS = 500;
+
+  const hideProgressBar = () => {
+    console.log(progressBarTimer);
+    clearTimeout(progressBarTimer);
+
+    // Get the time the progress bar has been visible
+    const showTime = Number(
+      document
+        .querySelector(".page-transition")
+        ?.getAttribute("data-show-time") || 0
+    );
+    const timeVisible = Date.now() - showTime;
+
+    // If we haven't shown it long enough, delay hiding
+    if (timeVisible < MIN_DISPLAY_TIME_IN_MS) {
+      setTimeout(() => {
+        document
+          .querySelector(".page-transition")
+          ?.setAttribute("data-visible", "false");
+      }, MIN_DISPLAY_TIME_IN_MS - timeVisible);
+    } else {
+      document
+        .querySelector(".page-transition")
+        ?.setAttribute("data-visible", "false");
+    }
+  };
+
+  const showProgressBar = () => {
+    // Only show progress after small delay to avoid flashing on fast loads
+    progressBarTimer = setTimeout(() => {
+      const progressBar = document.querySelector(".page-transition");
+      if (progressBar) {
+        progressBar.setAttribute("data-visible", "true");
+        progressBar.setAttribute("data-show-time", Date.now().toString());
+      }
+    }, DELAY_IN_MS);
+  };
+
+  document.addEventListener(TRANSITION_BEFORE_PREPARATION, showProgressBar);
+  document.addEventListener(TRANSITION_PAGE_LOAD, hideProgressBar);
+</script>

--- a/src/components/providers/theme-provider.astro
+++ b/src/components/providers/theme-provider.astro
@@ -29,18 +29,38 @@
     );
   }
 
-  const prefersColorScheme = window.matchMedia("(prefers-color-scheme: dark)");
-  prefersColorScheme.addEventListener("change", updateThemes);
+  let prefersColorScheme: MediaQueryList | undefined;
+  let mainThemeUnsubscribe: () => void | undefined;
+  let codeThemeUnsubscribe: () => void | undefined;
 
-  const mainThemeUnsubscribe = activeTheme.subscribe(updateThemes);
-  const codeThemeUnsubscribe = activeShikiTheme.subscribe(updateThemes);
+  function cleanupThemeListeners() {
+    if (prefersColorScheme !== undefined) {
+      prefersColorScheme.removeEventListener("change", updateThemes);
+    }
 
-  updateThemes();
+    if (mainThemeUnsubscribe !== undefined) {
+      mainThemeUnsubscribe();
+    }
 
-  // Clean up event listeners when the component is destroyed
-  document.addEventListener("astro:before-swap", () => {
-    prefersColorScheme.removeEventListener("change", updateThemes);
-    mainThemeUnsubscribe();
-    codeThemeUnsubscribe();
-  });
+    if (codeThemeUnsubscribe !== undefined) {
+      codeThemeUnsubscribe();
+    }
+  }
+
+  function setupThemeListeners() {
+    // Clean up existing listeners if they exist to prevent edge cases where setup could happen before a previous cleanup completes (e.g. rapid clicks, back/forward navigation).
+    cleanupThemeListeners();
+
+    prefersColorScheme = window.matchMedia("(prefers-color-scheme: dark)");
+    prefersColorScheme.addEventListener("change", updateThemes);
+
+    mainThemeUnsubscribe = activeTheme.subscribe(updateThemes);
+    codeThemeUnsubscribe = activeShikiTheme.subscribe(updateThemes);
+
+    updateThemes();
+  }
+
+  setupThemeListeners();
+  document.addEventListener("astro:before-swap", cleanupThemeListeners);
+  document.addEventListener("astro:after-swap", setupThemeListeners);
 </script>

--- a/src/components/templates/layout/layout.astro
+++ b/src/components/templates/layout/layout.astro
@@ -130,7 +130,11 @@ const topId = translate("anchor.site.top");
   <body class="site" id={topId}>
     <ThemeProvider>
       <SvgFiltersProvider>
-        <ProgressBar class="site-loading" />
+        <ProgressBar
+          aria-label={translate("page.loading")}
+          aria-live="polite"
+          class="site-loading"
+        />
         <SkipTo anchor={`#${contentsId}`}>
           {translate("cta.skip.to.content")}
         </SkipTo>
@@ -218,7 +222,7 @@ const topId = translate("anchor.site.top");
     top: 0;
     z-index: 1000;
 
-    &:not([data-visible]) {
+    &:not([data-visible="true"]) {
       display: none;
     }
   }
@@ -353,13 +357,51 @@ const topId = translate("anchor.site.top");
 </style>
 
 <script>
-  document.addEventListener("astro:before-preparation", () => {
-    // Show loading indicator when navigation starts
-    document.querySelector(".site-loading")?.setAttribute("data-visible", "");
-  });
+  import {
+    TRANSITION_BEFORE_PREPARATION,
+    TRANSITION_PAGE_LOAD,
+  } from "astro:transitions/client";
 
-  document.addEventListener("astro:page-load", () => {
-    // Hide loading indicator when page is fully loaded
-    document.querySelector(".site-loading")?.removeAttribute("data-visible");
-  });
+  let progressBarTimer: NodeJS.Timeout | undefined;
+  const DELAY_IN_MS = 200;
+  const MIN_DISPLAY_TIME_IN_MS = 500;
+
+  const hideProgressBar = () => {
+    console.log(progressBarTimer);
+    clearTimeout(progressBarTimer);
+
+    // Get the time the progress bar has been visible
+    const showTime = Number(
+      document.querySelector(".site-loading")?.getAttribute("data-show-time") ||
+        0
+    );
+    const timeVisible = Date.now() - showTime;
+
+    // If we haven't shown it long enough, delay hiding
+    if (timeVisible < MIN_DISPLAY_TIME_IN_MS) {
+      setTimeout(() => {
+        document
+          .querySelector(".site-loading")
+          ?.setAttribute("data-visible", "false");
+      }, MIN_DISPLAY_TIME_IN_MS - timeVisible);
+    } else {
+      document
+        .querySelector(".site-loading")
+        ?.setAttribute("data-visible", "false");
+    }
+  };
+
+  const showProgressBar = () => {
+    // Only show progress after small delay to avoid flashing on fast loads
+    progressBarTimer = setTimeout(() => {
+      const progressBar = document.querySelector(".site-loading");
+      if (progressBar) {
+        progressBar.setAttribute("data-visible", "true");
+        progressBar.setAttribute("data-show-time", Date.now().toString());
+      }
+    }, DELAY_IN_MS);
+  };
+
+  document.addEventListener(TRANSITION_BEFORE_PREPARATION, showProgressBar);
+  document.addEventListener(TRANSITION_PAGE_LOAD, hideProgressBar);
 </script>

--- a/src/components/templates/layout/layout.astro
+++ b/src/components/templates/layout/layout.astro
@@ -7,7 +7,6 @@ import { useI18n } from "../../../utils/i18n";
 import Copyright from "../../atoms/copyright/copyright.astro";
 import Head from "../../atoms/head/head.astro";
 import License from "../../atoms/license/license.astro";
-import ProgressBar from "../../atoms/progress-bar/progress-bar.astro";
 import BackToTop from "../../molecules/back-to-top/back-to-top.astro";
 import Branding from "../../molecules/branding/branding.astro";
 import NavItem from "../../molecules/nav-item/nav-item.astro";
@@ -17,6 +16,7 @@ import MainNav from "../../organisms/main-nav/main-nav.astro";
 import Navbar from "../../organisms/navbar/navbar.astro";
 import SearchForm from "../../organisms/search-form/search-form.astro";
 import SettingsForm from "../../organisms/settings-form/settings-form.astro";
+import PageTransitionProvider from "../../providers/page-transition-provider.astro";
 import SvgFiltersProvider from "../../providers/svg-filters-provider.astro";
 import ThemeProvider from "../../providers/theme-provider.astro";
 import GlobalThemeInit from "../../utilities/global-theme-init.astro";
@@ -130,59 +130,59 @@ const topId = translate("anchor.site.top");
   <body class="site" id={topId}>
     <ThemeProvider>
       <SvgFiltersProvider>
-        <ProgressBar
-          aria-label={translate("page.loading")}
-          aria-live="polite"
-          class="site-loading"
-        />
-        <SkipTo anchor={`#${contentsId}`}>
-          {translate("cta.skip.to.content")}
-        </SkipTo>
-        <header class="site-header">
-          <div class="site-branding">
-            <Branding brand={CONFIG.BRAND} url={route("home")} />
+        <PageTransitionProvider>
+          <SkipTo anchor={`#${contentsId}`}>
+            {translate("cta.skip.to.content")}
+          </SkipTo>
+          <header class="site-header">
+            <div class="site-branding">
+              <Branding brand={CONFIG.BRAND} url={route("home")} />
+            </div>
+            <Navbar
+              aria-label={translate("nav.label.primary")}
+              class="site-navbar"
+              id="site-navbar"
+            >
+              <MainNav items={mainNav} slot="nav" />
+              <SearchForm
+                id="site-search"
+                isInline
+                queryParam={CONFIG.SEARCH.QUERY_PARAM}
+                resultsPage={route("search")}
+                slot="search"
+              />
+              <SettingsForm
+                altLanguages={seo.languages}
+                id="site-settings"
+                slot="settings"
+              />
+            </Navbar>
+          </header>
+          <div {...attrs} class:list={["site-body", className]} id={contentsId}>
+            <slot />
           </div>
-          <Navbar
-            aria-label={translate("nav.label.primary")}
-            class="site-navbar"
-            id="site-navbar"
-          >
-            <MainNav items={mainNav} slot="nav" />
-            <SearchForm
-              id="site-search"
-              isInline
-              queryParam={CONFIG.SEARCH.QUERY_PARAM}
-              resultsPage={route("search")}
-              slot="search"
+          <footer class="site-footer">
+            <Copyright
+              creationYear={CONFIG.CREATION_YEAR}
+              owner={CONFIG.BRAND}
             />
-            <SettingsForm
-              altLanguages={seo.languages}
-              id="site-settings"
-              slot="settings"
+            <License />
+            <NavList class="site-footer-nav" isInline items={footerLinks}>
+              {
+                ({ label, url, ...item }) => (
+                  <NavItem {...item} href={url}>
+                    {label}
+                  </NavItem>
+                )
+              }
+            </NavList>
+            <BackToTop
+              anchor={`#${topId}`}
+              class="site-back-to-top"
+              label={translate("cta.back.to.top")}
             />
-          </Navbar>
-        </header>
-        <div {...attrs} class:list={["site-body", className]} id={contentsId}>
-          <slot />
-        </div>
-        <footer class="site-footer">
-          <Copyright creationYear={CONFIG.CREATION_YEAR} owner={CONFIG.BRAND} />
-          <License />
-          <NavList class="site-footer-nav" isInline items={footerLinks}>
-            {
-              ({ label, url, ...item }) => (
-                <NavItem {...item} href={url}>
-                  {label}
-                </NavItem>
-              )
-            }
-          </NavList>
-          <BackToTop
-            anchor={`#${topId}`}
-            class="site-back-to-top"
-            label={translate("cta.back.to.top")}
-          />
-        </footer>
+          </footer>
+        </PageTransitionProvider>
       </SvgFiltersProvider>
     </ThemeProvider>
   </body>
@@ -214,16 +214,6 @@ const topId = translate("anchor.site.top");
       /* Fixes a Chromium bug where the SVG filter wasn't updated when
        * switching the theme... */
       transform: translate3d(0, 0, 0);
-    }
-  }
-
-  .site-loading {
-    position: fixed;
-    top: 0;
-    z-index: 1000;
-
-    &:not([data-visible="true"]) {
-      display: none;
     }
   }
 
@@ -355,53 +345,3 @@ const topId = translate("anchor.site.top");
     }
   }
 </style>
-
-<script>
-  import {
-    TRANSITION_BEFORE_PREPARATION,
-    TRANSITION_PAGE_LOAD,
-  } from "astro:transitions/client";
-
-  let progressBarTimer: NodeJS.Timeout | undefined;
-  const DELAY_IN_MS = 200;
-  const MIN_DISPLAY_TIME_IN_MS = 500;
-
-  const hideProgressBar = () => {
-    console.log(progressBarTimer);
-    clearTimeout(progressBarTimer);
-
-    // Get the time the progress bar has been visible
-    const showTime = Number(
-      document.querySelector(".site-loading")?.getAttribute("data-show-time") ||
-        0
-    );
-    const timeVisible = Date.now() - showTime;
-
-    // If we haven't shown it long enough, delay hiding
-    if (timeVisible < MIN_DISPLAY_TIME_IN_MS) {
-      setTimeout(() => {
-        document
-          .querySelector(".site-loading")
-          ?.setAttribute("data-visible", "false");
-      }, MIN_DISPLAY_TIME_IN_MS - timeVisible);
-    } else {
-      document
-        .querySelector(".site-loading")
-        ?.setAttribute("data-visible", "false");
-    }
-  };
-
-  const showProgressBar = () => {
-    // Only show progress after small delay to avoid flashing on fast loads
-    progressBarTimer = setTimeout(() => {
-      const progressBar = document.querySelector(".site-loading");
-      if (progressBar) {
-        progressBar.setAttribute("data-visible", "true");
-        progressBar.setAttribute("data-show-time", Date.now().toString());
-      }
-    }, DELAY_IN_MS);
-  };
-
-  document.addEventListener(TRANSITION_BEFORE_PREPARATION, showProgressBar);
-  document.addEventListener(TRANSITION_PAGE_LOAD, hideProgressBar);
-</script>

--- a/src/components/templates/layout/layout.astro
+++ b/src/components/templates/layout/layout.astro
@@ -1,11 +1,13 @@
 ---
 import type { ComponentProps, HTMLAttributes } from "astro/types";
+import { ClientRouter } from "astro:transitions";
 import "../../../styles/global.css";
 import { CONFIG } from "../../../utils/constants";
 import { useI18n } from "../../../utils/i18n";
 import Copyright from "../../atoms/copyright/copyright.astro";
 import Head from "../../atoms/head/head.astro";
 import License from "../../atoms/license/license.astro";
+import ProgressBar from "../../atoms/progress-bar/progress-bar.astro";
 import BackToTop from "../../molecules/back-to-top/back-to-top.astro";
 import Branding from "../../molecules/branding/branding.astro";
 import NavItem from "../../molecules/nav-item/nav-item.astro";
@@ -112,6 +114,7 @@ const topId = translate("anchor.site.top");
     seo={seo}
     themeColor="#214769"
   >
+    <ClientRouter fallback="swap" />
     <slot name="head" />
     <GlobalThemeInit />
     <ShikiThemeInit />
@@ -127,6 +130,7 @@ const topId = translate("anchor.site.top");
   <body class="site" id={topId}>
     <ThemeProvider>
       <SvgFiltersProvider>
+        <ProgressBar class="site-loading" />
         <SkipTo anchor={`#${contentsId}`}>
           {translate("cta.skip.to.content")}
         </SkipTo>
@@ -206,6 +210,17 @@ const topId = translate("anchor.site.top");
       /* Fixes a Chromium bug where the SVG filter wasn't updated when
        * switching the theme... */
       transform: translate3d(0, 0, 0);
+    }
+  }
+
+  .site-loading {
+    position: fixed;
+    top: 0;
+    z-index: 1000;
+    box-shadow: var(--shadow-floating-to-top-center);
+
+    &:not([data-visible]) {
+      display: none;
     }
   }
 
@@ -337,3 +352,15 @@ const topId = translate("anchor.site.top");
     }
   }
 </style>
+
+<script>
+  document.addEventListener("astro:before-preparation", () => {
+    // Show loading indicator when navigation starts
+    document.querySelector(".site-loading")?.setAttribute("data-visible", "");
+  });
+
+  document.addEventListener("astro:page-load", () => {
+    // Hide loading indicator when page is fully loaded
+    document.querySelector(".site-loading")?.removeAttribute("data-visible");
+  });
+</script>

--- a/src/components/templates/layout/layout.astro
+++ b/src/components/templates/layout/layout.astro
@@ -217,7 +217,6 @@ const topId = translate("anchor.site.top");
     position: fixed;
     top: 0;
     z-index: 1000;
-    box-shadow: var(--shadow-floating-to-top-center);
 
     &:not([data-visible]) {
       display: none;

--- a/src/components/templates/page-layout/page-layout.astro
+++ b/src/components/templates/page-layout/page-layout.astro
@@ -64,7 +64,12 @@ const socialImg = getOpenGraphImg({ locale, slug: Astro.url.pathname });
   }
   <div class="page-layout-content">
     <main class="page-layout-main" data-pagefind-body>
-      <Page {...attrs} heading={isHome ? null : title}>
+      <Page
+        {...attrs}
+        heading={isHome ? null : title}
+        transition:animate="fade"
+        transition:name="page"
+      >
         <slot name="meta" slot={Astro.slots.has("meta") ? "meta" : ""} />
         <slot name="body" slot={Astro.slots.has("body") ? "body" : ""} />
         <slot

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -220,6 +220,7 @@
     "page.home.section.contact.heading": "Contact",
     "page.home.title": "Home",
     "page.legal.notice.title": "Legal notice",
+    "page.loading": "The page is loading...",
     "page.notes.title": "Notes",
     "page.paginated.label": "Page {number}",
     "page.projects.title": "Projects",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -220,6 +220,7 @@
     "page.home.section.contact.heading": "Contact",
     "page.home.title": "Accueil",
     "page.legal.notice.title": "Mentions légales",
+    "page.loading": "La page est en cours de chargement...",
     "page.notes.title": "Notes",
     "page.paginated.label": "Page {number}",
     "page.projects.title": "Projets",


### PR DESCRIPTION
## Changes

* Adds a `ProgressBar` component to indicates the loading state with slow connections
* Adds a `PageTransitionProvider` that adds a loading indicator, with delay, when navigating
* Adds view transitions to animate the main content and the breadcrumb on page change.

## Tests

Manually with Chromium and Firefox.
Existing tests should still pass.

## Docs

* Changeset added.
* README updated to mention view transitions.