### PR TITLE
fix: update the theme automatically according to the system theme

### DIFF
--- a/src/components/providers/page-transition-provider.astro
+++ b/src/components/providers/page-transition-provider.astro
@@ -35,7 +35,6 @@ const { translate } = useI18n(Astro.currentLocale);
   const MIN_DISPLAY_TIME_IN_MS = 500;
 
   const hideProgressBar = () => {
-    console.log(progressBarTimer);
     clearTimeout(progressBarTimer);
 
     // Get the time the progress bar has been visible

--- a/src/components/providers/theme-provider.astro
+++ b/src/components/providers/theme-provider.astro
@@ -8,6 +8,7 @@
   import {
     activeTheme,
     activeShikiTheme,
+    updateSystemColorScheme,
     THEME_SETTING_KEY,
     SHIKI_SETTING_KEY,
   } from "../../services/stores/settings";
@@ -29,13 +30,16 @@
     );
   }
 
-  let prefersColorScheme: MediaQueryList | undefined;
+  let prefersDarkColorScheme: MediaQueryList | undefined;
   let mainThemeUnsubscribe: () => void | undefined;
   let codeThemeUnsubscribe: () => void | undefined;
 
   function cleanupThemeListeners() {
-    if (prefersColorScheme !== undefined) {
-      prefersColorScheme.removeEventListener("change", updateThemes);
+    if (prefersDarkColorScheme !== undefined) {
+      prefersDarkColorScheme.removeEventListener(
+        "change",
+        updateSystemColorScheme
+      );
     }
 
     if (mainThemeUnsubscribe !== undefined) {
@@ -51,8 +55,8 @@
     // Clean up existing listeners if they exist to prevent edge cases where setup could happen before a previous cleanup completes (e.g. rapid clicks, back/forward navigation).
     cleanupThemeListeners();
 
-    prefersColorScheme = window.matchMedia("(prefers-color-scheme: dark)");
-    prefersColorScheme.addEventListener("change", updateThemes);
+    prefersDarkColorScheme = window.matchMedia("(prefers-color-scheme: dark)");
+    prefersDarkColorScheme.addEventListener("change", updateSystemColorScheme);
 
     mainThemeUnsubscribe = activeTheme.subscribe(updateThemes);
     codeThemeUnsubscribe = activeShikiTheme.subscribe(updateThemes);

--- a/src/services/stores/settings.ts
+++ b/src/services/stores/settings.ts
@@ -1,7 +1,10 @@
 import { persistentMap } from "@nanostores/persistent";
-import { computed } from "nanostores";
+import { atom, computed } from "nanostores";
 import type { Theme } from "../../types/tokens";
-import { resolveCurrentColorScheme } from "../../utils/themes";
+import {
+  getPreferredColorScheme,
+  resolveCurrentColorScheme,
+} from "../../utils/themes";
 
 export type Settings = {
   shiki: Theme;
@@ -45,10 +48,24 @@ export const isValidSettingsKey = (value: unknown): value is keyof Settings => {
 };
 
 /**
+ * Atom that tracks system color scheme preference.
+ */
+export const systemColorScheme = atom<Exclude<Theme, "auto">>("light");
+
+/**
+ * Update the value stored for the system color scheme.
+ */
+export const updateSystemColorScheme = () => {
+  systemColorScheme.set(getPreferredColorScheme());
+};
+
+/**
  * The actual theme, considering system preferences.
  */
-export const activeTheme = computed(settings, (activeSettings) =>
-  resolveCurrentColorScheme(activeSettings.theme)
+export const activeTheme = computed(
+  [settings, systemColorScheme],
+  (activeSettings, systemTheme) =>
+    activeSettings.theme === "auto" ? systemTheme : activeSettings.theme
 );
 
 /**


### PR DESCRIPTION
The PR #92 introduced a bug where the website theme was no longer automatically updated when the system theme is updated. The user needed to refresh manually the page to see the change. This behavior is useful for users of darkman (or similar solutions) and want to use a different theme according to the time of the day.

## Changes

Adds a new variable to track the system theme and updates the website theme when the value changes.

I also removed a useless `console.log` added in #97 for debugging purposes.

## Tests

Manually

## Docs

Not required, and no changesets because the bug was introduced in a commit not yet released (v1.1.0).