### PR TITLE
fix: do not hardcode the default system color scheme

### DIFF
--- a/src/services/stores/settings.ts
+++ b/src/services/stores/settings.ts
@@ -50,7 +50,9 @@ export const isValidSettingsKey = (value: unknown): value is keyof Settings => {
 /**
  * Atom that tracks system color scheme preference.
  */
-export const systemColorScheme = atom<Exclude<Theme, "auto">>("light");
+export const systemColorScheme = atom<Exclude<Theme, "auto">>(
+  getPreferredColorScheme()
+);
 
 /**
  * Update the value stored for the system color scheme.


### PR DESCRIPTION
## Changes

While fixing the sync between system and website themes in #112, I introduced a new bug: when dark theme is the default and the website theme is set to `auto`, the website theme is initialized with the light theme (and causes some FOUC) instead of using the dark theme!

## Tests

Manually, but I'll wait tomorrow to merge to do more testings in case I missed something else.

## Docs

Not required.