### PR TITLE
refactor: improve stories writing

### DIFF
--- a/src/components/atoms/blockquote/blockquote.stories.astro
+++ b/src/components/atoms/blockquote/blockquote.stories.astro
@@ -1,52 +1,77 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
+import CodePreview from "../../molecules/code-preview/code-preview.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import Heading from "../heading/heading.astro";
 import BlockquoteComponent from "./blockquote.astro";
 
 const title = "Blockquote";
-
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Atoms", url: "/design-system/components/atoms" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "atoms",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading as="h2">Usage</Heading>
+    <Heading as="h2">Introduction</Heading>
     <p>This component is used to display a quote separated from the content.</p>
-    <BlockquoteComponent lang="en">This is a quotation.</BlockquoteComponent>
+    <CodePreview
+      code={`import Blockquote from "./components/atoms/blockquote/blockquote.astro"`}
+      label="How to import"
+    />
+    <CodePreview
+      code={`<Blockquote lang="en">This is a quotation.</Blockquote>`}
+      label="Basic use"
+    >
+      <BlockquoteComponent lang="en">This is a quotation.</BlockquoteComponent>
+    </CodePreview>
     <Heading as="h2">Blockquote with paragraphs</Heading>
-    <BlockquoteComponent>
-      <p>
-        Deleniti ut similique officia. Eum reprehenderit quibusdam molestiae rem
-        vitae ut. Officia labore delectus tempore doloremque. Officia
-        consequatur reiciendis deleniti placeat.
-      </p>
-      <p>
-        Tempore esse nihil nam. Minus quisquam animi sint cum nihil ullam
-        consequatur cumque. Aut eligendi nulla rerum quasi debitis. Vel sed a ad
-        magnam. Voluptatem corporis neque blanditiis assumenda et ut
-        consequatur.
-      </p>
-    </BlockquoteComponent>
+    <CodePreview
+      code={`<Blockquote>
+<p>
+  Deleniti ut similique officia. Eum reprehenderit quibusdam molestiae rem
+  vitae ut. Officia labore delectus tempore doloremque. Officia
+  consequatur reiciendis deleniti placeat.
+</p>
+<p>
+  Tempore esse nihil nam. Minus quisquam animi sint cum nihil ullam
+  consequatur cumque. Aut eligendi nulla rerum quasi debitis. Vel sed a ad
+  magnam. Voluptatem corporis neque blanditiis assumenda et ut
+  consequatur.
+</p>
+</Blockquote>`}
+      label="Using multiple paragraphs"
+    >
+      <BlockquoteComponent>
+        <p>
+          Deleniti ut similique officia. Eum reprehenderit quibusdam molestiae
+          rem vitae ut. Officia labore delectus tempore doloremque. Officia
+          consequatur reiciendis deleniti placeat.
+        </p>
+        <p>
+          Tempore esse nihil nam. Minus quisquam animi sint cum nihil ullam
+          consequatur cumque. Aut eligendi nulla rerum quasi debitis. Vel sed a
+          ad magnam. Voluptatem corporis neque blanditiis assumenda et ut
+          consequatur.
+        </p>
+      </BlockquoteComponent>
+    </CodePreview>
     <Heading as="h2">Blockquote with figcaption</Heading>
-    <BlockquoteComponent>
-      Necessitatibus repudiandae voluptates accusantium architecto sint.
-      <Fragment slot="caption">In <cite>Lorem ipsum</cite></Fragment>
-    </BlockquoteComponent>
+    <CodePreview
+      code={`<Blockquote>
+  Necessitatibus repudiandae voluptates accusantium architecto sint.
+  <Fragment slot="caption">In <cite>Lorem ipsum</cite></Fragment>
+</Blockquote>`}
+      label="Using a caption"
+    >
+      <BlockquoteComponent>
+        Necessitatibus repudiandae voluptates accusantium architecto sint.
+        <Fragment slot="caption">In <cite>Lorem ipsum</cite></Fragment>
+      </BlockquoteComponent>
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/atoms/blockquote/blockquote.stories.astro
+++ b/src/components/atoms/blockquote/blockquote.stories.astro
@@ -22,10 +22,12 @@ const { breadcrumb, seo } = getStoryMeta({
     <CodePreview
       code={`import Blockquote from "./components/atoms/blockquote/blockquote.astro"`}
       label="How to import"
+      lang="ts"
     />
     <CodePreview
       code={`<Blockquote lang="en">This is a quotation.</Blockquote>`}
       label="Basic use"
+      lang="astro"
     >
       <BlockquoteComponent lang="en">This is a quotation.</BlockquoteComponent>
     </CodePreview>
@@ -45,6 +47,7 @@ const { breadcrumb, seo } = getStoryMeta({
 </p>
 </Blockquote>`}
       label="Using multiple paragraphs"
+      lang="astro"
     >
       <BlockquoteComponent>
         <p>
@@ -67,6 +70,7 @@ const { breadcrumb, seo } = getStoryMeta({
   <Fragment slot="caption">In <cite>Lorem ipsum</cite></Fragment>
 </Blockquote>`}
       label="Using a caption"
+      lang="astro"
     >
       <BlockquoteComponent>
         Necessitatibus repudiandae voluptates accusantium architecto sint.

--- a/src/components/atoms/box/box.stories.astro
+++ b/src/components/atoms/box/box.stories.astro
@@ -25,6 +25,7 @@ const { breadcrumb, seo } = getStoryMeta({
     <CodePreview
       code={`import Box from "./components/atoms/box/box.astro"`}
       label="How to import"
+      lang="ts"
     />
     <CodePreview code={`<Box>The box contents.</Box>`} label="Basic use">
       <BoxComponent>The box contents.</BoxComponent>
@@ -38,6 +39,7 @@ const { breadcrumb, seo } = getStoryMeta({
 <br />
 <Box elevation="floating">The box contents.</Box>`}
       label="Using elevation"
+      lang="astro"
     >
       <BoxComponent elevation="raised">The box contents.</BoxComponent>
       <br />
@@ -49,6 +51,7 @@ const { breadcrumb, seo } = getStoryMeta({
     <CodePreview
       code={`<Box isBordered>The box contents.</Box>`}
       label="With borders"
+      lang="astro"
     >
       <BoxComponent isBordered>The box contents.</BoxComponent>
     </CodePreview>
@@ -56,6 +59,7 @@ const { breadcrumb, seo } = getStoryMeta({
     <CodePreview
       code={`<Box isBordered isRounded>The box contents.</Box>`}
       label="With rounded borders"
+      lang="astro"
     >
       <BoxComponent isBordered isRounded>The box contents.</BoxComponent>
     </CodePreview>
@@ -63,6 +67,7 @@ const { breadcrumb, seo } = getStoryMeta({
     <CodePreview
       code={`<Box isBordered isPadded>The box contents.</Box>`}
       label="With padding"
+      lang="astro"
     >
       <BoxComponent isBordered isPadded>The box contents.</BoxComponent>
     </CodePreview>
@@ -76,6 +81,7 @@ const { breadcrumb, seo } = getStoryMeta({
   <p>The last child should not have a bottom margin.</p>
 </Box>`}
       label="Using prose"
+      lang="astro"
     >
       <BoxComponent isBordered isProse>
         <p>The first child should not have a top margin.</p>
@@ -93,6 +99,7 @@ const { breadcrumb, seo } = getStoryMeta({
     <CodePreview
       code={`<Box isBordered isCentered>The box contents.</Box>`}
       label="With centering"
+      lang="astro"
     >
       <BoxComponent isBordered isCentered style="width: 15rem;"
         >The box contents.</BoxComponent

--- a/src/components/atoms/box/box.stories.astro
+++ b/src/components/atoms/box/box.stories.astro
@@ -1,190 +1,102 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
+import CodePreview from "../../molecules/code-preview/code-preview.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import Heading from "../heading/heading.astro";
 import BoxComponent from "./box.astro";
 
 const title = "Box";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Atoms", url: "/design-system/components/atoms" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "atoms",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading as="h2">Usage</Heading>
+    <Heading as="h2">Introduction</Heading>
     <p>
-      This component can be used to create a box that reuse the same styles
+      This component can be used to create a box that reuses the same styles
       across multiple components.
     </p>
-  </Fragment>
-  <Fragment slot="disconnected-body">
-    <BoxComponent>The box contents.</BoxComponent>
-    <BoxComponent
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced
+    <CodePreview
+      code={`import Box from "./components/atoms/box/box.astro"`}
+      label="How to import"
+    />
+    <CodePreview code={`<Box>The box contents.</Box>`} label="Basic use">
+      <BoxComponent>The box contents.</BoxComponent>
+    </CodePreview>
+    <Heading as="h2">Options</Heading>
+    <Heading as="h3"><code>elevation</code></Heading>
+    <CodePreview
+      code={`<Box elevation="raised">The box contents.</Box>
+<br />
+<Box elevation="elevated">The box contents.</Box>
+<br />
+<Box elevation="floating">The box contents.</Box>`}
+      label="Using elevation"
     >
-      <Heading as="h2">Options</Heading>
-      <Heading as="h3"><code>elevation</code></Heading>
-      <Heading as="h4"><code>raised</code></Heading>
-    </BoxComponent>
-    <BoxComponent elevation="raised">The box contents.</BoxComponent>
-    <BoxComponent
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced
+      <BoxComponent elevation="raised">The box contents.</BoxComponent>
+      <br />
+      <BoxComponent elevation="elevated">The box contents.</BoxComponent>
+      <br />
+      <BoxComponent elevation="floating">The box contents.</BoxComponent>
+    </CodePreview>
+    <Heading as="h3"><code>isBordered</code></Heading>
+    <CodePreview
+      code={`<Box isBordered>The box contents.</Box>`}
+      label="With borders"
     >
-      <Heading as="h4"><code>elevated</code></Heading>
-    </BoxComponent>
-    <BoxComponent elevation="elevated">The box contents.</BoxComponent>
-    <BoxComponent
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced
+      <BoxComponent isBordered>The box contents.</BoxComponent>
+    </CodePreview>
+    <Heading as="h3"><code>isRounded</code></Heading>
+    <CodePreview
+      code={`<Box isBordered isRounded>The box contents.</Box>`}
+      label="With rounded borders"
     >
-      <Heading as="h4"><code>floating</code></Heading>
-    </BoxComponent>
-    <BoxComponent elevation="floating">The box contents.</BoxComponent>
-    <BoxComponent
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced
+      <BoxComponent isBordered isRounded>The box contents.</BoxComponent>
+    </CodePreview>
+    <Heading as="h3"><code>isPadded</code></Heading>
+    <CodePreview
+      code={`<Box isBordered isPadded>The box contents.</Box>`}
+      label="With padding"
     >
-      <Heading as="h3"><code>isBordered</code></Heading>
-    </BoxComponent>
-    <BoxComponent isBordered>The box contents.</BoxComponent>
-    <BoxComponent
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced
+      <BoxComponent isBordered isPadded>The box contents.</BoxComponent>
+    </CodePreview>
+    <Heading as="h3"><code>isProse</code></Heading>
+    <p>This option will limit the size of the container.</p>
+    <CodePreview
+      code={`<Box isBordered isProse>
+  <p>The first child should not have a top margin.</p>
+  <p>In between you can use whatever you want.</p>
+  <p>Each children of type block will have both top and bottom margins.</p>
+  <p>The last child should not have a bottom margin.</p>
+</Box>`}
+      label="Using prose"
     >
-      <Heading as="h3"><code>isCentered</code></Heading>
-    </BoxComponent>
-    <BoxComponent isCentered>The box contents.</BoxComponent>
-    <BoxComponent
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced
+      <BoxComponent isBordered isProse>
+        <p>The first child should not have a top margin.</p>
+        <p>In between you can use whatever you want.</p>
+        <p>
+          Each children of type block will have both top and bottom margins.
+        </p>
+        <p>The last child should not have a bottom margin.</p>
+      </BoxComponent>
+    </CodePreview>
+    <Heading as="h3"><code>isCentered</code></Heading>
+    <p>
+      This option only have an effect if you limit the size of the container.
+    </p>
+    <CodePreview
+      code={`<Box isBordered isCentered>The box contents.</Box>`}
+      label="With centering"
     >
-      <Heading as="h3"><code>isPadded</code></Heading>
-    </BoxComponent>
-    <BoxComponent isPadded>The box contents.</BoxComponent>
-    <BoxComponent
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced
-    >
-      <Heading as="h3"><code>isProse</code></Heading>
-    </BoxComponent>
-    <BoxComponent isProse>The box contents.</BoxComponent>
-    <BoxComponent
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced
-    >
-      <Heading as="h3"><code>isRounded</code></Heading>
-    </BoxComponent>
-    <BoxComponent isBordered isRounded>The box contents.</BoxComponent>
-    <BoxComponent
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced
-    >
-      <Heading as="h2">Using <code>isProse</code></Heading>
-    </BoxComponent>
-    <BoxComponent isProse>
-      <p>The first child should not have a top margin.</p>
-      <p>In between you can use whatever you want.</p>
-      <p>Each "not-inlined" children will have both top and bottom margins.</p>
-      <p>The last child should not have a bottom margin.</p>
-    </BoxComponent>
-    <BoxComponent
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced
-    >
-      <Heading as="h3">With <code>isBordered</code></Heading>
-    </BoxComponent>
-    <BoxComponent isBordered isProse>The box contents.</BoxComponent>
-    <BoxComponent
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced
-    >
-      <Heading as="h3">With <code>isCentered</code></Heading>
-      <p>And <code>isBordered</code> to see the box limits.</p>
-    </BoxComponent>
-    <BoxComponent isBordered isCentered isProse>The box contents.</BoxComponent>
-    <BoxComponent
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced
-    >
-      <Heading as="h3">With <code>isPadded</code></Heading>
-      <p>And <code>isBordered</code> to see the box limits.</p>
-    </BoxComponent>
-    <BoxComponent isBordered isPadded isProse>The box contents.</BoxComponent>
+      <BoxComponent isBordered isCentered style="width: 15rem;"
+        >The box contents.</BoxComponent
+      >
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/atoms/button/button.stories.astro
+++ b/src/components/atoms/button/button.stories.astro
@@ -1,107 +1,204 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
+import CodePreview from "../../molecules/code-preview/code-preview.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import Heading from "../heading/heading.astro";
 import ButtonComponent from "./button.astro";
 
 const title = "Button";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Atoms", url: "/design-system/components/atoms" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "atoms",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading as="h2">Usage</Heading>
+    <Heading as="h2">Introduction</Heading>
     <p>A button is usually used to encourage a user to take action.</p>
-    <Heading as="h2">Primary buttons</Heading>
-    <Heading as="h3">States</Heading>
-    <Heading as="h4">Default</Heading>
-    <ButtonComponent kind="primary">Call to action</ButtonComponent>
-    <Heading as="h4">Busy</Heading>
-    <ButtonComponent aria-busy="true" kind="primary">
-      Call to action
-    </ButtonComponent>
-    <Heading as="h4">Disabled</Heading>
-    <ButtonComponent disabled="true" kind="primary">
-      Call to action
-    </ButtonComponent>
-    <Heading as="h2">Secondary buttons</Heading>
+    <CodePreview
+      code={`import Button from "./components/atoms/button/button.astro"`}
+      label="How to import"
+    />
+    <CodePreview code={`<Button>A label</Button>`} label="Basic use">
+      <ButtonComponent>A label</ButtonComponent>
+    </CodePreview>
+    <Heading as="h2">Button kinds</Heading>
     <p>
-      When using the <code>secondary</code> kind (default), you can choose to use
-      either a button or a link with the <code>as</code> property.
+      Buttons comes with 4 variants. You should use <code>primary</code> for important
+      call to actions.
     </p>
-    <Heading as="h3">States</Heading>
-    <Heading as="h4">Default</Heading>
-    <ButtonComponent>Call to action</ButtonComponent>
-    <Heading as="h4">Busy</Heading>
-    <ButtonComponent aria-busy="true">Call to action</ButtonComponent>
-    <Heading as="h4">Disabled</Heading>
-    <ButtonComponent disabled="true">Call to action</ButtonComponent>
+    <CodePreview
+      code={`<ButtonComponent kind="primary">A primary button</ButtonComponent>
+<br />
+<ButtonComponent kind="secondary">A secondary button</ButtonComponent>
+<br />
+<ButtonComponent kind="discreet">A discreet button</ButtonComponent>
+<br />
+<ButtonComponent kind="neutral">A neutral button</ButtonComponent>`}
+      label="Using different kinds of buttons"
+    >
+      <ButtonComponent kind="primary">A primary button</ButtonComponent>
+      <br />
+      <ButtonComponent kind="secondary">A secondary button</ButtonComponent>
+      <br />
+      <ButtonComponent kind="discreet">A discreet button</ButtonComponent>
+      <br />
+      <ButtonComponent kind="neutral">A neutral button</ButtonComponent>
+    </CodePreview>
+    <Heading as="h2">States</Heading>
+    <Heading as="h3">Busy</Heading>
+    <CodePreview
+      code={`<ButtonComponent aria-busy="true" kind="primary">A primary button</ButtonComponent>
+<br />
+<ButtonComponent aria-busy="true" kind="secondary">A secondary button</ButtonComponent>
+<br />
+<ButtonComponent aria-busy="true" kind="discreet">A discreet button</ButtonComponent>
+<br />
+<ButtonComponent aria-busy="true" kind="neutral">A neutral button</ButtonComponent>`}
+      label="Using aria-busy on different kinds of buttons"
+    >
+      <ButtonComponent aria-busy="true" kind="primary"
+        >A primary button</ButtonComponent
+      >
+      <br />
+      <ButtonComponent aria-busy="true" kind="secondary"
+        >A secondary button</ButtonComponent
+      >
+      <br />
+      <ButtonComponent aria-busy="true" kind="discreet"
+        >A discreet button</ButtonComponent
+      >
+      <br />
+      <ButtonComponent aria-busy="true" kind="neutral"
+        >A neutral button</ButtonComponent
+      >
+    </CodePreview>
+    <Heading as="h3">Disabled</Heading>
+    <CodePreview
+      code={`<ButtonComponent disabled="true" kind="primary">A primary button</ButtonComponent>
+<br />
+<ButtonComponent disabled="true" kind="secondary">A secondary button</ButtonComponent>
+<br />
+<ButtonComponent disabled="true" kind="discreet">A discreet button</ButtonComponent>
+<br />
+<ButtonComponent disabled="true" kind="neutral">A neutral button</ButtonComponent>`}
+      label="Using disabled on different kinds of buttons"
+    >
+      <ButtonComponent disabled="true" kind="primary"
+        >A primary button</ButtonComponent
+      >
+      <br />
+      <ButtonComponent disabled="true" kind="secondary"
+        >A secondary button</ButtonComponent
+      >
+      <br />
+      <ButtonComponent disabled="true" kind="discreet"
+        >A discreet button</ButtonComponent
+      >
+      <br />
+      <ButtonComponent disabled="true" kind="neutral"
+        >A neutral button</ButtonComponent
+      >
+    </CodePreview>
     <Heading as="h3"><code>isExternal</code></Heading>
-    <ButtonComponent isExternal>Call to action</ButtonComponent>
-    <Heading as="h2">Discreet buttons</Heading>
-    <p>
-      When using the <code>discreet</code> kind, you can choose to use either a button
-      or a link with the <code>as</code> property. This is a variant of the secondary
-      kind.
-    </p>
-    <Heading as="h3">States</Heading>
-    <Heading as="h4">Default</Heading>
-    <ButtonComponent kind="discreet">Call to action</ButtonComponent>
-    <Heading as="h4">Busy</Heading>
-    <ButtonComponent aria-busy="true" kind="discreet">
-      Call to action
-    </ButtonComponent>
-    <Heading as="h4">Disabled</Heading>
-    <ButtonComponent disabled="true" kind="discreet">
-      Call to action
-    </ButtonComponent>
-    <Heading as="h3"><code>isExternal</code></Heading>
-    <ButtonComponent isExternal kind="discreet">Call to action</ButtonComponent>
-    <Heading as="h2">Neutral buttons</Heading>
-    <p>
-      When using the <code>neutral</code> kind, you can choose to use either a button
-      or a link with the <code>as</code> property and you are free the style as you'd
-      like.
-    </p>
-    <Heading as="h3">States</Heading>
-    <Heading as="h4">Default</Heading>
-    <ButtonComponent kind="neutral">Call to action</ButtonComponent>
-    <Heading as="h4">Busy</Heading>
-    <ButtonComponent aria-busy="true" kind="neutral">
-      Call to action
-    </ButtonComponent>
-    <Heading as="h4">Disabled</Heading>
-    <ButtonComponent disabled="true" kind="neutral">
-      Call to action
-    </ButtonComponent>
-    <Heading as="h3"><code>isExternal</code></Heading>
-    <ButtonComponent isExternal kind="neutral">Call to action</ButtonComponent>
+    <CodePreview
+      code={`<ButtonComponent isExternal kind="secondary">A secondary button</ButtonComponent>
+<br />
+<ButtonComponent isExternal kind="discreet">A discreet button</ButtonComponent>
+<br />
+<ButtonComponent isExternal kind="neutral">A neutral button</ButtonComponent>`}
+      label="Using isExternal on different kinds of buttons"
+    >
+      <ButtonComponent isExternal kind="secondary"
+        >A secondary button</ButtonComponent
+      >
+      <br />
+      <ButtonComponent isExternal kind="discreet"
+        >A discreet button</ButtonComponent
+      >
+      <br />
+      <ButtonComponent isExternal kind="neutral"
+        >A neutral button</ButtonComponent
+      >
+    </CodePreview>
     <Heading as="h2">Links as button</Heading>
-    <Heading as="h3">States</Heading>
-    <Heading as="h4">Default</Heading>
-    <ButtonComponent as="a" href="#link">Call to action</ButtonComponent>
-    <Heading as="h4">Busy</Heading>
-    <ButtonComponent aria-busy="true" as="a" href="#link">
-      Call to action
-    </ButtonComponent>
-    <Heading as="h3"><code>isExternal</code></Heading>
-    <ButtonComponent as="a" href="#link" isExternal>
-      Call to action
-    </ButtonComponent>
+    <p>
+      Sometimes, links can be designed as a button. This component handles this
+      with the <code>as</code> property for <code>secondary</code>, <code
+        >discreet</code
+      > and <code>neutral</code> buttons. If you try to use a link with a <code
+        >primary</code
+      > button an error will be thrown.
+    </p>
+    <CodePreview
+      code={`<ButtonComponent as="a" href="#link" kind="secondary">A secondary button</ButtonComponent>
+<br />
+<ButtonComponent as="a" href="#link" kind="discreet">A discreet button</ButtonComponent>
+<br />
+<ButtonComponent as="a" href="#link" kind="neutral">A neutral button</ButtonComponent>`}
+      label="Using a link instead of a button"
+    >
+      <ButtonComponent as="a" href="#link" kind="secondary"
+        >A secondary button</ButtonComponent
+      >
+      <br />
+      <ButtonComponent as="a" href="#link" kind="discreet"
+        >A discreet button</ButtonComponent
+      >
+      <br />
+      <ButtonComponent as="a" href="#link" kind="neutral"
+        >A neutral button</ButtonComponent
+      >
+    </CodePreview>
+    <p>
+      States should behave the same when using a link instead of a button.
+      However, note that a link can't be disabled.
+    </p>
+    <Heading as="h3">Busy links</Heading>
+    <CodePreview
+      code={`<ButtonComponent aria-busy="true" as="a" href="#link" kind="secondary">A secondary button</ButtonComponent>
+<br />
+<ButtonComponent aria-busy="true" as="a" href="#link" kind="discreet">A discreet button</ButtonComponent>
+<br />
+<ButtonComponent aria-busy="true" as="a" href="#link" kind="neutral">A neutral button</ButtonComponent>`}
+      label="Using a busy link instead of a button"
+    >
+      <ButtonComponent aria-busy="true" as="a" href="#link" kind="secondary"
+        >A secondary button</ButtonComponent
+      >
+      <br />
+      <ButtonComponent aria-busy="true" as="a" href="#link" kind="discreet"
+        >A discreet button</ButtonComponent
+      >
+      <br />
+      <ButtonComponent aria-busy="true" as="a" href="#link" kind="neutral"
+        >A neutral button</ButtonComponent
+      >
+    </CodePreview>
+    <Heading as="h3">External links</Heading>
+    <CodePreview
+      code={`<ButtonComponent as="a" href="#link" isExternal kind="secondary">A secondary button</ButtonComponent>
+<br />
+<ButtonComponent as="a" href="#link" isExternal kind="discreet">A discreet button</ButtonComponent>
+<br />
+<ButtonComponent as="a" href="#link" isExternal kind="neutral">A neutral button</ButtonComponent>`}
+      label="Using an external link instead of a button"
+    >
+      <ButtonComponent as="a" href="#link" isExternal kind="secondary"
+        >A secondary button</ButtonComponent
+      >
+      <br />
+      <ButtonComponent as="a" href="#link" isExternal kind="discreet"
+        >A discreet button</ButtonComponent
+      >
+      <br />
+      <ButtonComponent as="a" href="#link" isExternal kind="neutral"
+        >A neutral button</ButtonComponent
+      >
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/atoms/button/button.stories.astro
+++ b/src/components/atoms/button/button.stories.astro
@@ -22,8 +22,13 @@ const { breadcrumb, seo } = getStoryMeta({
     <CodePreview
       code={`import Button from "./components/atoms/button/button.astro"`}
       label="How to import"
+      lang="ts"
     />
-    <CodePreview code={`<Button>A label</Button>`} label="Basic use">
+    <CodePreview
+      code={`<Button>A label</Button>`}
+      label="Basic use"
+      lang="astro"
+    >
       <ButtonComponent>A label</ButtonComponent>
     </CodePreview>
     <Heading as="h2">Button kinds</Heading>
@@ -32,14 +37,15 @@ const { breadcrumb, seo } = getStoryMeta({
       call to actions.
     </p>
     <CodePreview
-      code={`<ButtonComponent kind="primary">A primary button</ButtonComponent>
+      code={`<Button kind="primary">A primary button</Button>
 <br />
-<ButtonComponent kind="secondary">A secondary button</ButtonComponent>
+<Button kind="secondary">A secondary button</Button>
 <br />
-<ButtonComponent kind="discreet">A discreet button</ButtonComponent>
+<Button kind="discreet">A discreet button</Button>
 <br />
-<ButtonComponent kind="neutral">A neutral button</ButtonComponent>`}
+<Button kind="neutral">A neutral button</Button>`}
       label="Using different kinds of buttons"
+      lang="astro"
     >
       <ButtonComponent kind="primary">A primary button</ButtonComponent>
       <br />
@@ -52,14 +58,15 @@ const { breadcrumb, seo } = getStoryMeta({
     <Heading as="h2">States</Heading>
     <Heading as="h3">Busy</Heading>
     <CodePreview
-      code={`<ButtonComponent aria-busy="true" kind="primary">A primary button</ButtonComponent>
+      code={`<Button aria-busy="true" kind="primary">A primary button</Button>
 <br />
-<ButtonComponent aria-busy="true" kind="secondary">A secondary button</ButtonComponent>
+<Button aria-busy="true" kind="secondary">A secondary button</Button>
 <br />
-<ButtonComponent aria-busy="true" kind="discreet">A discreet button</ButtonComponent>
+<Button aria-busy="true" kind="discreet">A discreet button</Button>
 <br />
-<ButtonComponent aria-busy="true" kind="neutral">A neutral button</ButtonComponent>`}
+<Button aria-busy="true" kind="neutral">A neutral button</Button>`}
       label="Using aria-busy on different kinds of buttons"
+      lang="astro"
     >
       <ButtonComponent aria-busy="true" kind="primary"
         >A primary button</ButtonComponent
@@ -79,14 +86,15 @@ const { breadcrumb, seo } = getStoryMeta({
     </CodePreview>
     <Heading as="h3">Disabled</Heading>
     <CodePreview
-      code={`<ButtonComponent disabled="true" kind="primary">A primary button</ButtonComponent>
+      code={`<Button disabled="true" kind="primary">A primary button</Button>
 <br />
-<ButtonComponent disabled="true" kind="secondary">A secondary button</ButtonComponent>
+<Button disabled="true" kind="secondary">A secondary button</Button>
 <br />
-<ButtonComponent disabled="true" kind="discreet">A discreet button</ButtonComponent>
+<Button disabled="true" kind="discreet">A discreet button</Button>
 <br />
-<ButtonComponent disabled="true" kind="neutral">A neutral button</ButtonComponent>`}
+<Button disabled="true" kind="neutral">A neutral button</Button>`}
       label="Using disabled on different kinds of buttons"
+      lang="astro"
     >
       <ButtonComponent disabled="true" kind="primary"
         >A primary button</ButtonComponent
@@ -106,12 +114,13 @@ const { breadcrumb, seo } = getStoryMeta({
     </CodePreview>
     <Heading as="h3"><code>isExternal</code></Heading>
     <CodePreview
-      code={`<ButtonComponent isExternal kind="secondary">A secondary button</ButtonComponent>
+      code={`<Button isExternal kind="secondary">A secondary button</Button>
 <br />
-<ButtonComponent isExternal kind="discreet">A discreet button</ButtonComponent>
+<Button isExternal kind="discreet">A discreet button</Button>
 <br />
-<ButtonComponent isExternal kind="neutral">A neutral button</ButtonComponent>`}
+<Button isExternal kind="neutral">A neutral button</Button>`}
       label="Using isExternal on different kinds of buttons"
+      lang="astro"
     >
       <ButtonComponent isExternal kind="secondary"
         >A secondary button</ButtonComponent
@@ -135,12 +144,13 @@ const { breadcrumb, seo } = getStoryMeta({
       > button an error will be thrown.
     </p>
     <CodePreview
-      code={`<ButtonComponent as="a" href="#link" kind="secondary">A secondary button</ButtonComponent>
+      code={`<Button as="a" href="#link" kind="secondary">A secondary button</Button>
 <br />
-<ButtonComponent as="a" href="#link" kind="discreet">A discreet button</ButtonComponent>
+<Button as="a" href="#link" kind="discreet">A discreet button</Button>
 <br />
-<ButtonComponent as="a" href="#link" kind="neutral">A neutral button</ButtonComponent>`}
+<Button as="a" href="#link" kind="neutral">A neutral button</Button>`}
       label="Using a link instead of a button"
+      lang="astro"
     >
       <ButtonComponent as="a" href="#link" kind="secondary"
         >A secondary button</ButtonComponent
@@ -160,12 +170,13 @@ const { breadcrumb, seo } = getStoryMeta({
     </p>
     <Heading as="h3">Busy links</Heading>
     <CodePreview
-      code={`<ButtonComponent aria-busy="true" as="a" href="#link" kind="secondary">A secondary button</ButtonComponent>
+      code={`<Button aria-busy="true" as="a" href="#link" kind="secondary">A secondary button</Button>
 <br />
-<ButtonComponent aria-busy="true" as="a" href="#link" kind="discreet">A discreet button</ButtonComponent>
+<Button aria-busy="true" as="a" href="#link" kind="discreet">A discreet button</Button>
 <br />
-<ButtonComponent aria-busy="true" as="a" href="#link" kind="neutral">A neutral button</ButtonComponent>`}
+<Button aria-busy="true" as="a" href="#link" kind="neutral">A neutral button</Button>`}
       label="Using a busy link instead of a button"
+      lang="astro"
     >
       <ButtonComponent aria-busy="true" as="a" href="#link" kind="secondary"
         >A secondary button</ButtonComponent
@@ -181,12 +192,13 @@ const { breadcrumb, seo } = getStoryMeta({
     </CodePreview>
     <Heading as="h3">External links</Heading>
     <CodePreview
-      code={`<ButtonComponent as="a" href="#link" isExternal kind="secondary">A secondary button</ButtonComponent>
+      code={`<Button as="a" href="#link" isExternal kind="secondary">A secondary button</Button>
 <br />
-<ButtonComponent as="a" href="#link" isExternal kind="discreet">A discreet button</ButtonComponent>
+<Button as="a" href="#link" isExternal kind="discreet">A discreet button</Button>
 <br />
-<ButtonComponent as="a" href="#link" isExternal kind="neutral">A neutral button</ButtonComponent>`}
+<Button as="a" href="#link" isExternal kind="neutral">A neutral button</Button>`}
       label="Using an external link instead of a button"
+      lang="astro"
     >
       <ButtonComponent as="a" href="#link" isExternal kind="secondary"
         >A secondary button</ButtonComponent

--- a/src/components/atoms/callout/callout.stories.astro
+++ b/src/components/atoms/callout/callout.stories.astro
@@ -22,6 +22,7 @@ const { breadcrumb, seo } = getStoryMeta({
     <CodePreview
       code={`import Callout from "./components/atoms/callout/callout.astro"`}
       label="How to import"
+      lang="ts"
     />
     <CodePreview code={`<Callout>The contents.</Callout>`} label="Basic use">
       <CalloutComponent>The contents.</CalloutComponent>
@@ -40,6 +41,7 @@ const { breadcrumb, seo } = getStoryMeta({
 <br />
 <Callout type="warning">The contents.</Callout>`}
       label="Using different types of callouts"
+      lang="astro"
     >
       <CalloutComponent type="critical">The contents.</CalloutComponent>
       <br />
@@ -62,6 +64,7 @@ const { breadcrumb, seo } = getStoryMeta({
   The contents.
 </Callout>`}
       label="Using a custom label"
+      lang="astro"
     >
       <CalloutComponent
         label="A custom label a bit long to check small devices"

--- a/src/components/atoms/callout/callout.stories.astro
+++ b/src/components/atoms/callout/callout.stories.astro
@@ -1,51 +1,74 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
+import CodePreview from "../../molecules/code-preview/code-preview.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import Heading from "../heading/heading.astro";
 import CalloutComponent from "./callout.astro";
 
 const title = "Callout";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Atoms", url: "/design-system/components/atoms" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "atoms",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading as="h2">Usage</Heading>
+    <Heading as="h2">Introduction</Heading>
     <p>This component is used to show important information to the reader.</p>
-    <Heading as="h2">Type</Heading>
-    <Heading as="h3">Critical</Heading>
-    <CalloutComponent type="critical"> The contents. </CalloutComponent>
-    <Heading as="h3">Discovery</Heading>
-    <CalloutComponent type="discovery"> The contents. </CalloutComponent>
-    <Heading as="h3">Idea</Heading>
-    <CalloutComponent type="idea"> The contents. </CalloutComponent>
-    <Heading as="h3">Info</Heading>
-    <CalloutComponent type="info"> The contents. </CalloutComponent>
-    <Heading as="h3">Success</Heading>
-    <CalloutComponent type="success"> The contents. </CalloutComponent>
-    <Heading as="h3">Warning</Heading>
-    <CalloutComponent type="warning"> The contents. </CalloutComponent>
-    <Heading as="h2">With a custom label</Heading>
-    <CalloutComponent
-      label="A custom label a bit long for small devices"
-      type="critical"
+    <CodePreview
+      code={`import Callout from "./components/atoms/callout/callout.astro"`}
+      label="How to import"
+    />
+    <CodePreview code={`<Callout>The contents.</Callout>`} label="Basic use">
+      <CalloutComponent>The contents.</CalloutComponent>
+    </CodePreview>
+    <Heading as="h2">Types</Heading>
+    <CodePreview
+      code={`<Callout type="critical">The contents.</Callout>
+<br />
+<Callout type="discovery">The contents.</Callout>
+<br />
+<Callout type="idea">The contents.</Callout>
+<br />
+<Callout type="info">The contents.</Callout>
+<br />
+<Callout type="success">The contents.</Callout>
+<br />
+<Callout type="warning">The contents.</Callout>`}
+      label="Using different types of callouts"
     >
-      The contents.
-    </CalloutComponent>
+      <CalloutComponent type="critical">The contents.</CalloutComponent>
+      <br />
+      <CalloutComponent type="discovery">The contents.</CalloutComponent>
+      <br />
+      <CalloutComponent type="idea">The contents.</CalloutComponent>
+      <br />
+      <CalloutComponent type="info">The contents.</CalloutComponent>
+      <br />
+      <CalloutComponent type="success">The contents.</CalloutComponent>
+      <br />
+      <CalloutComponent type="warning">The contents.</CalloutComponent>
+    </CodePreview>
+    <Heading as="h2">With a custom label</Heading>
+    <CodePreview
+      code={`<Callout
+  label="A custom label a bit long to check small devices"
+  type="critical"
+>
+  The contents.
+</Callout>`}
+      label="Using a custom label"
+    >
+      <CalloutComponent
+        label="A custom label a bit long to check small devices"
+        type="critical"
+      >
+        The contents.
+      </CalloutComponent>
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/atoms/copyright/copyright.stories.astro
+++ b/src/components/atoms/copyright/copyright.stories.astro
@@ -1,47 +1,47 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
+import CodePreview from "../../molecules/code-preview/code-preview.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import Heading from "../heading/heading.astro";
 import CopyrightComponent from "./copyright.astro";
 
 const title = "Copyright";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Atoms", url: "/design-system/components/atoms" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "atoms",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading as="h2">Usage</Heading>
+    <Heading>Introduction</Heading>
     <p>
-      This component is usually used in the website's footer to display the
-      copyright.
+      A Copyright component is usually used in the website's footer to display
+      the copyright.
     </p>
+    <CodePreview
+      code={`import Copyright from "./components/atoms/copyright/copyright.astro"`}
+      label="How to import"
+    />
+    <CodePreview
+      code={`<Copyright creationYear={2025} owner="John Doe" />`}
+      label="Basic use"
+    >
+      <CopyrightComponent creationYear={2025} owner="John Doe" />
+    </CodePreview>
+    <Heading>Different current and creation years</Heading>
     <p>
-      <CopyrightComponent
-        creationYear={new Date().getFullYear()}
-        owner="John Doe"
-      />
+      When the creation year is different from the current one, both years will
+      be displayed.
     </p>
-    <p>
-      When the <code>creationYear</code> is different from the current year, then
-      the output will look like this:
-    </p>
-    <p>
-      <CopyrightComponent creationYear={2010} owner="John Doe" />
-    </p>
+    <CodePreview
+      code={`<Copyright creationYear={2020} owner="John Doe" />`}
+      label="Automatic handling of dates"
+    >
+      <CopyrightComponent creationYear={2020} owner="John Doe" />
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/atoms/copyright/copyright.stories.astro
+++ b/src/components/atoms/copyright/copyright.stories.astro
@@ -25,10 +25,12 @@ const { breadcrumb, seo } = getStoryMeta({
     <CodePreview
       code={`import Copyright from "./components/atoms/copyright/copyright.astro"`}
       label="How to import"
+      lang="ts"
     />
     <CodePreview
       code={`<Copyright creationYear={2025} owner="John Doe" />`}
       label="Basic use"
+      lang="astro"
     >
       <CopyrightComponent creationYear={2025} owner="John Doe" />
     </CodePreview>
@@ -40,6 +42,7 @@ const { breadcrumb, seo } = getStoryMeta({
     <CodePreview
       code={`<Copyright creationYear={2020} owner="John Doe" />`}
       label="Automatic handling of dates"
+      lang="astro"
     >
       <CopyrightComponent creationYear={2020} owner="John Doe" />
     </CodePreview>

--- a/src/components/atoms/description-list/description-list.stories.astro
+++ b/src/components/atoms/description-list/description-list.stories.astro
@@ -1,5 +1,6 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
+import CodePreview from "../../molecules/code-preview/code-preview.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import Heading from "../heading/heading.astro";
 import ListItem from "../list/list-item.astro";
@@ -8,26 +9,18 @@ import DescriptionListComponent from "./description-list.astro";
 import Item from "./item.astro";
 
 const title = "DescriptionList";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Atoms", url: "/design-system/components/atoms" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "atoms",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
+    <Heading>Introduction</Heading>
     <p>In a description list, you can:</p>
     <List>
       <ListItem>Use a single term associated to a single description</ListItem>
@@ -35,6 +28,34 @@ const seo: ComponentProps<typeof PageLayout>["seo"] = {
       <ListItem>Use a single term associated to multiple descriptions</ListItem>
       <ListItem>Wrap each couple with an <code>Item</code> component</ListItem>
     </List>
+    <CodePreview
+      code={`import DescriptionList from "./components/atoms/description-list/description-list.astro"`}
+      label="How to import"
+    />
+    <CodePreview
+      code={`<DescriptionList>
+  <dt>Term 1 - Variant 1</dt>
+  <dt>Term 1 - Variant 2</dt>
+  <dd>The description of Term 1 variants</dd>
+  <dt>Term 2</dt>
+  <dd>The description of term 2</dd>
+  <dt>Term 3</dt>
+  <dd>The first description of term 3</dd>
+  <dd>The second description of term 3</dd>
+</DescriptionList>`}
+      label="Basic use"
+    >
+      <DescriptionListComponent>
+        <dt>Term 1 - Variant 1</dt>
+        <dt>Term 1 - Variant 2</dt>
+        <dd>The description of Term 1 variants</dd>
+        <dt>Term 2</dt>
+        <dd>The description of term 2</dd>
+        <dt>Term 3</dt>
+        <dd>The first description of term 3</dd>
+        <dd>The second description of term 3</dd>
+      </DescriptionListComponent>
+    </CodePreview>
     <Heading as="h2">With <code>isInline: false</code> (default)</Heading>
     <Heading as="h3">Without Item component</Heading>
     <Heading as="h4">No spacing (default)</Heading>

--- a/src/components/atoms/description-list/description-list.stories.astro
+++ b/src/components/atoms/description-list/description-list.stories.astro
@@ -31,6 +31,7 @@ const { breadcrumb, seo } = getStoryMeta({
     <CodePreview
       code={`import DescriptionList from "./components/atoms/description-list/description-list.astro"`}
       label="How to import"
+      lang="ts"
     />
     <CodePreview
       code={`<DescriptionList>
@@ -44,6 +45,7 @@ const { breadcrumb, seo } = getStoryMeta({
   <dd>The second description of term 3</dd>
 </DescriptionList>`}
       label="Basic use"
+      lang="astro"
     >
       <DescriptionListComponent>
         <dt>Term 1 - Variant 1</dt>

--- a/src/components/atoms/fieldset/fieldset.stories.astro
+++ b/src/components/atoms/fieldset/fieldset.stories.astro
@@ -1,5 +1,6 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
+import CodePreview from "../../molecules/code-preview/code-preview.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import Heading from "../heading/heading.astro";
 import Label from "../label/label.astro";
@@ -8,70 +9,134 @@ import FieldsetComponent from "./fieldset.astro";
 import Legend from "./legend.astro";
 
 const title = "Fieldset";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Atoms", url: "/design-system/components/atoms" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "atoms",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
+    <Heading>Introduction</Heading>
     <p>
       A fieldset requires a slot named <code>legend</code>. You should use the
       available <code>Legend</code> component to provide one.
     </p>
-    <Heading as="h2">Default</Heading>
-    <FieldsetComponent>
-      <Legend slot="legend">The fieldset legend</Legend>
-      The fieldset contents
-    </FieldsetComponent>
+    <CodePreview
+      code={`import Fieldset from "./components/atoms/fieldset/fieldset.astro";
+import Legend from "./components/atoms/fieldset/legend.astro";`}
+      label="How to import"
+    />
+    <CodePreview
+      code={`<Fieldset>
+  <Legend slot="legend">The fieldset legend</Legend>
+  The fieldset contents
+</Fieldset>`}
+      label="Basic use"
+    >
+      <FieldsetComponent>
+        <Legend slot="legend">The fieldset legend</Legend>
+        The fieldset contents
+      </FieldsetComponent>
+    </CodePreview>
     <Heading as="h2">Options</Heading>
     <Heading as="h3">Fieldset <code>isBordered</code></Heading>
-    <FieldsetComponent isBordered>
-      <Legend slot="legend">The fieldset legend</Legend>
-      <Label for="option-fieldset-bordered1">Field 1:</Label>
-      <TextField id="option-fieldset-bordered1" type="text" />
-      <Label for="option-fieldset-bordered2">Field 2:</Label>
-      <TextField id="option-fieldset-bordered2" type="text" />
-    </FieldsetComponent>
+    <CodePreview
+      code={`<Fieldset isBordered>
+  <Legend slot="legend">The fieldset legend</Legend>
+  The fieldset contents
+</Fieldset>`}
+      label="Using borders on fieldset"
+    >
+      <FieldsetComponent isBordered>
+        <Legend slot="legend">The fieldset legend</Legend>
+        The fieldset contents
+      </FieldsetComponent>
+    </CodePreview>
     <Heading as="h3">Legend <code>isBordered</code></Heading>
-    <FieldsetComponent>
-      <Legend isBordered slot="legend">The fieldset legend</Legend>
-      <Label for="option-legend-bordered1">Field 1:</Label>
-      <TextField id="option-legend-bordered1" type="text" />
-      <Label for="option-legend-bordered2">Field 2:</Label>
-      <TextField id="option-legend-bordered2" type="text" />
-    </FieldsetComponent>
+    <CodePreview
+      code={`<Fieldset>
+  <Legend isBordered slot="legend">The fieldset legend</Legend>
+  The fieldset contents
+</Fieldset>`}
+      label="Using borders on legend"
+    >
+      <FieldsetComponent>
+        <Legend isBordered slot="legend">The fieldset legend</Legend>
+        The fieldset contents
+      </FieldsetComponent>
+    </CodePreview>
     <Heading as="h3"
       >Fieldset <code>isBordered</code> and Legend <code>isBordered</code
       ></Heading
     >
-    <FieldsetComponent isBordered>
-      <Legend isBordered slot="legend">The fieldset legend</Legend>
-      <Label for="option-fieldset-legend-bordered1">Field 1:</Label>
-      <TextField id="option-fieldset-legend-bordered1" type="text" />
-      <Label for="option-fieldset-legend-bordered2">Field 2:</Label>
-      <TextField id="option-fieldset-legend-bordered2" type="text" />
-    </FieldsetComponent>
+    <CodePreview
+      code={`<Fieldset isBordered>
+  <Legend isBordered slot="legend">The fieldset legend</Legend>
+  The fieldset contents
+</Fieldset>`}
+      label="Using borders both on fieldset and legend"
+    >
+      <FieldsetComponent isBordered>
+        <Legend isBordered slot="legend">The fieldset legend</Legend>
+        The fieldset contents
+      </FieldsetComponent>
+    </CodePreview>
     <Heading as="h3">Fieldset <code>isInline</code></Heading>
-    <FieldsetComponent gap="md" isInline>
-      <Legend slot="legend">The fieldset legend</Legend>
-      <Label for="option-fieldset-bordered1">Field 1:</Label>
-      <TextField id="option-fieldset-bordered1" type="text" />
-      <Label for="option-fieldset-bordered2">Field 2:</Label>
-      <TextField id="option-fieldset-bordered2" type="text" />
-    </FieldsetComponent>
+    <p>
+      When using <code>isInline</code>, you can also pass a <code>gap</code> property
+      to control the spacing between elements.
+    </p>
+    <CodePreview
+      code={`<Fieldset>
+  <Legend slot="legend">The fieldset legend</Legend>
+  <div>
+    <Label for="option-fieldset-default1">Field 1:</Label>
+    <TextField id="option-fieldset-default1" type="text" />
+  </div>
+  <div>
+    <Label for="option-fieldset-default2">Field 2:</Label>
+    <TextField id="option-fieldset-default2" type="text" />
+  </div>
+</Fieldset>
+<Fieldset gap="md" isInline>
+  <Legend slot="legend">The fieldset legend</Legend>
+  <div>
+    <Label for="option-fieldset-inline1">Field 1:</Label>
+    <TextField id="option-fieldset-inline1" type="text" />
+  </div>
+  <div>
+    <Label for="option-fieldset-inline2">Field 2:</Label>
+    <TextField id="option-fieldset-inline2" type="text" />
+  </div>
+</Fieldset>`}
+      label="Comparing isInline effect on fieldset"
+    >
+      <FieldsetComponent>
+        <Legend slot="legend">The fieldset legend</Legend>
+        <div>
+          <Label for="option-fieldset-default1">Field 1:</Label>
+          <TextField id="option-fieldset-default1" type="text" />
+        </div>
+        <div>
+          <Label for="option-fieldset-default2">Field 2:</Label>
+          <TextField id="option-fieldset-default2" type="text" />
+        </div>
+      </FieldsetComponent>
+      <FieldsetComponent gap="md" isInline>
+        <Legend slot="legend">The fieldset legend</Legend>
+        <div>
+          <Label for="option-fieldset-inline1">Field 1:</Label>
+          <TextField id="option-fieldset-inline1" type="text" />
+        </div>
+        <div>
+          <Label for="option-fieldset-inline2">Field 2:</Label>
+          <TextField id="option-fieldset-inline2" type="text" />
+        </div>
+      </FieldsetComponent>
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/atoms/fieldset/fieldset.stories.astro
+++ b/src/components/atoms/fieldset/fieldset.stories.astro
@@ -29,6 +29,7 @@ const { breadcrumb, seo } = getStoryMeta({
       code={`import Fieldset from "./components/atoms/fieldset/fieldset.astro";
 import Legend from "./components/atoms/fieldset/legend.astro";`}
       label="How to import"
+      lang="ts"
     />
     <CodePreview
       code={`<Fieldset>
@@ -36,6 +37,7 @@ import Legend from "./components/atoms/fieldset/legend.astro";`}
   The fieldset contents
 </Fieldset>`}
       label="Basic use"
+      lang="astro"
     >
       <FieldsetComponent>
         <Legend slot="legend">The fieldset legend</Legend>
@@ -50,6 +52,7 @@ import Legend from "./components/atoms/fieldset/legend.astro";`}
   The fieldset contents
 </Fieldset>`}
       label="Using borders on fieldset"
+      lang="astro"
     >
       <FieldsetComponent isBordered>
         <Legend slot="legend">The fieldset legend</Legend>
@@ -63,6 +66,7 @@ import Legend from "./components/atoms/fieldset/legend.astro";`}
   The fieldset contents
 </Fieldset>`}
       label="Using borders on legend"
+      lang="astro"
     >
       <FieldsetComponent>
         <Legend isBordered slot="legend">The fieldset legend</Legend>
@@ -79,6 +83,7 @@ import Legend from "./components/atoms/fieldset/legend.astro";`}
   The fieldset contents
 </Fieldset>`}
       label="Using borders both on fieldset and legend"
+      lang="astro"
     >
       <FieldsetComponent isBordered>
         <Legend isBordered slot="legend">The fieldset legend</Legend>
@@ -114,6 +119,7 @@ import Legend from "./components/atoms/fieldset/legend.astro";`}
   </div>
 </Fieldset>`}
       label="Comparing isInline effect on fieldset"
+      lang="astro"
     >
       <FieldsetComponent>
         <Legend slot="legend">The fieldset legend</Legend>

--- a/src/components/atoms/figure/figure.stories.astro
+++ b/src/components/atoms/figure/figure.stories.astro
@@ -1,37 +1,39 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
+import CodePreview from "../../molecules/code-preview/code-preview.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import Heading from "../heading/heading.astro";
 import Img from "../img/img.astro";
 import FigureComponent from "./figure.astro";
 
 const title = "Figure";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Atoms", url: "/design-system/components/atoms" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "atoms",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading as="h2">Usage</Heading>
+    <Heading as="h2">Introduction</Heading>
     <p>
       A figure can be an image, illustration, diagram, code snippet, etc. that
       can be moved to another part of the document without affecting the main
       flow.
     </p>
+    <CodePreview
+      code={`import Figure from "./components/atoms/figure/figure.astro"`}
+      label="How to import"
+    />
+    <CodePreview
+      code={`<Figure>The figure contents.</Figure>`}
+      label="Basic use"
+    >
+      <FigureComponent>The figure contents.</FigureComponent>
+    </CodePreview>
     <Heading as="h2">Without figcaption</Heading>
     <FigureComponent>
       <Img
@@ -43,42 +45,92 @@ const seo: ComponentProps<typeof PageLayout>["seo"] = {
     </FigureComponent>
     <Heading as="h2">With figcaption</Heading>
     <Heading as="h3">At the top</Heading>
-    <FigureComponent>
-      <figcaption>An image used as example</figcaption>
-      <Img
-        alt="An example"
-        height={480}
-        src="https://picsum.photos/640/480"
-        width={640}
-      />
-    </FigureComponent>
+    <CodePreview
+      code={`<Figure>
+  <figcaption>An image used as example</figcaption>
+  <Img
+    alt="An example"
+    height={480}
+    src="https://picsum.photos/640/480"
+    width={640}
+  />
+</Figure>`}
+      label="Using a caption at the top"
+    >
+      <FigureComponent>
+        <figcaption>An image used as example</figcaption>
+        <Img
+          alt="An example"
+          height={480}
+          src="https://picsum.photos/640/480"
+          width={640}
+        />
+      </FigureComponent>
+    </CodePreview>
     <Heading as="h3">At the bottom</Heading>
-    <FigureComponent>
-      <Img
-        alt="An example"
-        height={480}
-        src="https://picsum.photos/640/480"
-        width={640}
-      />
-      <figcaption>An image used as example</figcaption>
-    </FigureComponent>
+    <CodePreview
+      code={`<Figure>
+  <Img
+    alt="An example"
+    height={480}
+    src="https://picsum.photos/640/480"
+    width={640}
+  />
+  <figcaption>An image used as example</figcaption>
+</Figure>`}
+      label="Using a caption at the bottom"
+    >
+      <FigureComponent>
+        <Img
+          alt="An example"
+          height={480}
+          src="https://picsum.photos/640/480"
+          width={640}
+        />
+        <figcaption>An image used as example</figcaption>
+      </FigureComponent>
+    </CodePreview>
     <Heading as="h2">Horizontally centered</Heading>
-    <FigureComponent isCentered>
-      <Img
-        alt="An example"
-        height={480}
-        src="https://picsum.photos/640/480"
-        width={640}
-      />
-    </FigureComponent>
+    <CodePreview
+      code={`<Figure isCentered>
+  <Img
+    alt="An example"
+    height={480}
+    src="https://picsum.photos/640/480"
+    width={640}
+  />
+</Figure>`}
+      label="Using a centered figure"
+    >
+      <FigureComponent isCentered>
+        <Img
+          alt="An example"
+          height={480}
+          src="https://picsum.photos/640/480"
+          width={640}
+        />
+      </FigureComponent>
+    </CodePreview>
     <Heading as="h2">Full width</Heading>
-    <FigureComponent isFullWidth>
-      <Img
-        alt="An example"
-        height={480}
-        src="https://picsum.photos/640/480"
-        width={640}
-      />
-    </FigureComponent>
+    <CodePreview
+      code={`<Figure isFullWidth>
+  <Img
+    alt="An example"
+    height={480}
+    src="https://picsum.photos/640/480"
+    width={640}
+  />
+</Figure>`}
+      label="Using a full width figure"
+    >
+      <FigureComponent isFullWidth>
+        <Img
+          alt="An example"
+          height={480}
+          src="https://picsum.photos/640/480"
+          width={640}
+        />
+      </FigureComponent>
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/atoms/figure/figure.stories.astro
+++ b/src/components/atoms/figure/figure.stories.astro
@@ -27,10 +27,12 @@ const { breadcrumb, seo } = getStoryMeta({
     <CodePreview
       code={`import Figure from "./components/atoms/figure/figure.astro"`}
       label="How to import"
+      lang="ts"
     />
     <CodePreview
       code={`<Figure>The figure contents.</Figure>`}
       label="Basic use"
+      lang="astro"
     >
       <FigureComponent>The figure contents.</FigureComponent>
     </CodePreview>
@@ -56,6 +58,7 @@ const { breadcrumb, seo } = getStoryMeta({
   />
 </Figure>`}
       label="Using a caption at the top"
+      lang="astro"
     >
       <FigureComponent>
         <figcaption>An image used as example</figcaption>
@@ -79,6 +82,7 @@ const { breadcrumb, seo } = getStoryMeta({
   <figcaption>An image used as example</figcaption>
 </Figure>`}
       label="Using a caption at the bottom"
+      lang="astro"
     >
       <FigureComponent>
         <Img
@@ -101,6 +105,7 @@ const { breadcrumb, seo } = getStoryMeta({
   />
 </Figure>`}
       label="Using a centered figure"
+      lang="astro"
     >
       <FigureComponent isCentered>
         <Img
@@ -122,6 +127,7 @@ const { breadcrumb, seo } = getStoryMeta({
   />
 </Figure>`}
       label="Using a full width figure"
+      lang="astro"
     >
       <FigureComponent isFullWidth>
         <Img

--- a/src/components/atoms/grid/grid.stories.astro
+++ b/src/components/atoms/grid/grid.stories.astro
@@ -22,6 +22,7 @@ const { breadcrumb, seo } = getStoryMeta({
     <CodePreview
       code={`import Grid from "./components/atoms/grid/grid.astro"`}
       label="How to import"
+      lang="ts"
     />
     <CodePreview
       code={`<Grid>
@@ -33,6 +34,7 @@ const { breadcrumb, seo } = getStoryMeta({
   <div>Item 6</div>
 </Grid>`}
       label="Basic use"
+      lang="astro"
     >
       <GridComponent>
         <div>Item 1</div>
@@ -59,6 +61,7 @@ const { breadcrumb, seo } = getStoryMeta({
   <div>Item 6</div>
 </Grid>`}
       label="Setting a number of columns"
+      lang="astro"
     >
       <GridComponent cols={2}>
         <div>Item 1</div>
@@ -84,6 +87,7 @@ const { breadcrumb, seo } = getStoryMeta({
   <div>Item 6</div>
 </Grid>`}
       label="Setting a number of rows"
+      lang="astro"
     >
       <GridComponent rows={3}>
         <div>Item 1</div>
@@ -106,6 +110,7 @@ const { breadcrumb, seo } = getStoryMeta({
   <div>Item 6</div>
 </Grid>`}
       label="Setting a unique gap both for columns and rows"
+      lang="astro"
     >
       <GridComponent gap="md">
         <div>Item 1</div>
@@ -127,6 +132,7 @@ const { breadcrumb, seo } = getStoryMeta({
   <div>Item 6</div>
 </Grid>`}
       label="Setting a gap for the columns only"
+      lang="astro"
     >
       <GridComponent gap={{ col: "md" }}>
         <div>Item 1</div>
@@ -148,6 +154,7 @@ const { breadcrumb, seo } = getStoryMeta({
   <div>Item 6</div>
 </Grid>`}
       label="Setting a gap for the rows only"
+      lang="astro"
     >
       <GridComponent gap={{ row: "md" }}>
         <div>Item 1</div>
@@ -169,6 +176,7 @@ const { breadcrumb, seo } = getStoryMeta({
   <div>Item 6</div>
 </Grid>`}
       label="Setting a different gap for columns and rows"
+      lang="astro"
     >
       <GridComponent gap={{ col: "md", row: "xs" }}>
         <div>Item 1</div>
@@ -194,6 +202,7 @@ const { breadcrumb, seo } = getStoryMeta({
   <div>Item 6</div>
 </Grid>`}
       label="Setting a minimal size for columns"
+      lang="astro"
     >
       <GridComponent sizeMinCols="400px">
         <div>Item 1</div>
@@ -219,6 +228,7 @@ const { breadcrumb, seo } = getStoryMeta({
   <div>Item 6</div>
 </Grid>`}
       label="Setting a maximal size for columns"
+      lang="astro"
     >
       <GridComponent sizeMaxCols="200px">
         <div>Item 1</div>
@@ -244,6 +254,7 @@ const { breadcrumb, seo } = getStoryMeta({
   <div>Item 6</div>
 </Grid>`}
       label="Setting a custom template for columns"
+      lang="astro"
     >
       <GridComponent templateCols="1fr auto 1fr">
         <div>Item 1</div>
@@ -269,6 +280,7 @@ const { breadcrumb, seo } = getStoryMeta({
   <div>Item 6</div>
 </Grid>`}
       label="Setting a custom template for rows"
+      lang="astro"
     >
       <GridComponent templateRows="auto 3rem auto">
         <div>Item 1</div>

--- a/src/components/atoms/grid/grid.stories.astro
+++ b/src/components/atoms/grid/grid.stories.astro
@@ -1,160 +1,284 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
+import CodePreview from "../../molecules/code-preview/code-preview.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import Heading from "../heading/heading.astro";
 import GridComponent from "./grid.astro";
 
 const title = "Grid";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Atoms", url: "/design-system/components/atoms" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "atoms",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading as="h2">Usage</Heading>
+    <Heading as="h2">Introduction</Heading>
     <p>This component can be used to create a CSS grid.</p>
-    <GridComponent>
-      <div>Item 1</div>
-      <div>Item 2</div>
-      <div>Item 3</div>
-      <div>Item 4</div>
-      <div>Item 5</div>
-      <div>Item 6</div>
-    </GridComponent>
+    <CodePreview
+      code={`import Grid from "./components/atoms/grid/grid.astro"`}
+      label="How to import"
+    />
+    <CodePreview
+      code={`<Grid>
+  <div>Item 1</div>
+  <div>Item 2</div>
+  <div>Item 3</div>
+  <div>Item 4</div>
+  <div>Item 5</div>
+  <div>Item 6</div>
+</Grid>`}
+      label="Basic use"
+    >
+      <GridComponent>
+        <div>Item 1</div>
+        <div>Item 2</div>
+        <div>Item 3</div>
+        <div>Item 4</div>
+        <div>Item 5</div>
+        <div>Item 6</div>
+      </GridComponent>
+    </CodePreview>
     <Heading as="h2">Options</Heading>
     <Heading as="h3"><code>cols</code></Heading>
     <p>
       The <code>cols</code> property lets you define an explicit columns number.
       Caveat: You'll need to handle yourself small viewports.
     </p>
-    <GridComponent cols={2}>
-      <div>Item 1</div>
-      <div>Item 2</div>
-      <div>Item 3</div>
-      <div>Item 4</div>
-      <div>Item 5</div>
-      <div>Item 6</div>
-    </GridComponent>
+    <CodePreview
+      code={`<Grid cols={2}>
+  <div>Item 1</div>
+  <div>Item 2</div>
+  <div>Item 3</div>
+  <div>Item 4</div>
+  <div>Item 5</div>
+  <div>Item 6</div>
+</Grid>`}
+      label="Setting a number of columns"
+    >
+      <GridComponent cols={2}>
+        <div>Item 1</div>
+        <div>Item 2</div>
+        <div>Item 3</div>
+        <div>Item 4</div>
+        <div>Item 5</div>
+        <div>Item 6</div>
+      </GridComponent>
+    </CodePreview>
     <Heading as="h3"><code>rows</code></Heading>
     <p>
       The <code>rows</code> property lets you define an explicit rows number. Caveat:
       This is not useful by itself.
     </p>
-    <GridComponent rows={3}>
-      <div>Item 1</div>
-      <div>Item 2</div>
-      <div>Item 3</div>
-      <div>Item 4</div>
-      <div>Item 5</div>
-      <div>Item 6</div>
-    </GridComponent>
+    <CodePreview
+      code={`<Grid rows={3}>
+  <div>Item 1</div>
+  <div>Item 2</div>
+  <div>Item 3</div>
+  <div>Item 4</div>
+  <div>Item 5</div>
+  <div>Item 6</div>
+</Grid>`}
+      label="Setting a number of rows"
+    >
+      <GridComponent rows={3}>
+        <div>Item 1</div>
+        <div>Item 2</div>
+        <div>Item 3</div>
+        <div>Item 4</div>
+        <div>Item 5</div>
+        <div>Item 6</div>
+      </GridComponent>
+    </CodePreview>
     <Heading as="h3"><code>gap</code></Heading>
-    <p>
-      The <code>gap</code> property lets you define an explicit columns number. Caveat:
-      You'll need to handle yourself small viewports.
-    </p>
     <Heading as="h4">Unique gap</Heading>
-    <GridComponent gap="md">
-      <div>Item 1</div>
-      <div>Item 2</div>
-      <div>Item 3</div>
-      <div>Item 4</div>
-      <div>Item 5</div>
-      <div>Item 6</div>
-    </GridComponent>
+    <CodePreview
+      code={`<Grid gap="md">
+  <div>Item 1</div>
+  <div>Item 2</div>
+  <div>Item 3</div>
+  <div>Item 4</div>
+  <div>Item 5</div>
+  <div>Item 6</div>
+</Grid>`}
+      label="Setting a unique gap both for columns and rows"
+    >
+      <GridComponent gap="md">
+        <div>Item 1</div>
+        <div>Item 2</div>
+        <div>Item 3</div>
+        <div>Item 4</div>
+        <div>Item 5</div>
+        <div>Item 6</div>
+      </GridComponent>
+    </CodePreview>
     <Heading as="h4">Col gap</Heading>
-    <GridComponent gap={{ col: "md" }}>
-      <div>Item 1</div>
-      <div>Item 2</div>
-      <div>Item 3</div>
-      <div>Item 4</div>
-      <div>Item 5</div>
-      <div>Item 6</div>
-    </GridComponent>
+    <CodePreview
+      code={`<Grid gap={{ col: "md" }}>
+  <div>Item 1</div>
+  <div>Item 2</div>
+  <div>Item 3</div>
+  <div>Item 4</div>
+  <div>Item 5</div>
+  <div>Item 6</div>
+</Grid>`}
+      label="Setting a gap for the columns only"
+    >
+      <GridComponent gap={{ col: "md" }}>
+        <div>Item 1</div>
+        <div>Item 2</div>
+        <div>Item 3</div>
+        <div>Item 4</div>
+        <div>Item 5</div>
+        <div>Item 6</div>
+      </GridComponent>
+    </CodePreview>
     <Heading as="h4">Row gap</Heading>
-    <GridComponent gap={{ row: "md" }}>
-      <div>Item 1</div>
-      <div>Item 2</div>
-      <div>Item 3</div>
-      <div>Item 4</div>
-      <div>Item 5</div>
-      <div>Item 6</div>
-    </GridComponent>
+    <CodePreview
+      code={`<Grid gap={{ row: "md" }}>
+  <div>Item 1</div>
+  <div>Item 2</div>
+  <div>Item 3</div>
+  <div>Item 4</div>
+  <div>Item 5</div>
+  <div>Item 6</div>
+</Grid>`}
+      label="Setting a gap for the rows only"
+    >
+      <GridComponent gap={{ row: "md" }}>
+        <div>Item 1</div>
+        <div>Item 2</div>
+        <div>Item 3</div>
+        <div>Item 4</div>
+        <div>Item 5</div>
+        <div>Item 6</div>
+      </GridComponent>
+    </CodePreview>
     <Heading as="h4">Both gaps with different value</Heading>
-    <GridComponent gap={{ col: "md", row: "xs" }}>
-      <div>Item 1</div>
-      <div>Item 2</div>
-      <div>Item 3</div>
-      <div>Item 4</div>
-      <div>Item 5</div>
-      <div>Item 6</div>
-    </GridComponent>
+    <CodePreview
+      code={`<Grid gap={{ col: "md", row: "xs" }}>
+  <div>Item 1</div>
+  <div>Item 2</div>
+  <div>Item 3</div>
+  <div>Item 4</div>
+  <div>Item 5</div>
+  <div>Item 6</div>
+</Grid>`}
+      label="Setting a different gap for columns and rows"
+    >
+      <GridComponent gap={{ col: "md", row: "xs" }}>
+        <div>Item 1</div>
+        <div>Item 2</div>
+        <div>Item 3</div>
+        <div>Item 4</div>
+        <div>Item 5</div>
+        <div>Item 6</div>
+      </GridComponent>
+    </CodePreview>
     <Heading as="h3"><code>sizeMinCols</code></Heading>
     <p>
       The <code>sizeMinCols</code> property lets you override the default minimal
       size for columns.
     </p>
-    <GridComponent sizeMinCols="400px">
-      <div>Item 1</div>
-      <div>Item 2</div>
-      <div>Item 3</div>
-      <div>Item 4</div>
-      <div>Item 5</div>
-      <div>Item 6</div>
-    </GridComponent>
+    <CodePreview
+      code={`<Grid sizeMinCols="400px">
+  <div>Item 1</div>
+  <div>Item 2</div>
+  <div>Item 3</div>
+  <div>Item 4</div>
+  <div>Item 5</div>
+  <div>Item 6</div>
+</Grid>`}
+      label="Setting a minimal size for columns"
+    >
+      <GridComponent sizeMinCols="400px">
+        <div>Item 1</div>
+        <div>Item 2</div>
+        <div>Item 3</div>
+        <div>Item 4</div>
+        <div>Item 5</div>
+        <div>Item 6</div>
+      </GridComponent>
+    </CodePreview>
     <Heading as="h3"><code>sizeMaxCols</code></Heading>
     <p>
       The <code>sizeMaxCols</code> property lets you override the default maximal
       size for columns.
     </p>
-    <GridComponent sizeMaxCols="200px">
-      <div>Item 1</div>
-      <div>Item 2</div>
-      <div>Item 3</div>
-      <div>Item 4</div>
-      <div>Item 5</div>
-      <div>Item 6</div>
-    </GridComponent>
+    <CodePreview
+      code={`<Grid sizeMaxCols="200px">
+  <div>Item 1</div>
+  <div>Item 2</div>
+  <div>Item 3</div>
+  <div>Item 4</div>
+  <div>Item 5</div>
+  <div>Item 6</div>
+</Grid>`}
+      label="Setting a maximal size for columns"
+    >
+      <GridComponent sizeMaxCols="200px">
+        <div>Item 1</div>
+        <div>Item 2</div>
+        <div>Item 3</div>
+        <div>Item 4</div>
+        <div>Item 5</div>
+        <div>Item 6</div>
+      </GridComponent>
+    </CodePreview>
     <Heading as="h3"><code>templateCols</code></Heading>
     <p>
       The <code>templateCols</code> property lets you override the default template
       for columns.
     </p>
-    <GridComponent templateCols="1fr auto 1fr">
-      <div>Item 1</div>
-      <div>Item 2</div>
-      <div>Item 3</div>
-      <div>Item 4</div>
-      <div>Item 5</div>
-      <div>Item 6</div>
-    </GridComponent>
+    <CodePreview
+      code={`<Grid templateCols="1fr auto 1fr">
+  <div>Item 1</div>
+  <div>Item 2</div>
+  <div>Item 3</div>
+  <div>Item 4</div>
+  <div>Item 5</div>
+  <div>Item 6</div>
+</Grid>`}
+      label="Setting a custom template for columns"
+    >
+      <GridComponent templateCols="1fr auto 1fr">
+        <div>Item 1</div>
+        <div>Item 2</div>
+        <div>Item 3</div>
+        <div>Item 4</div>
+        <div>Item 5</div>
+        <div>Item 6</div>
+      </GridComponent>
+    </CodePreview>
     <Heading as="h3"><code>templateRows</code></Heading>
     <p>
       The <code>templateRows</code> property lets you override the default template
       for rows.
     </p>
-    <GridComponent templateRows="auto 3rem auto">
-      <div>Item 1</div>
-      <div>Item 2</div>
-      <div>Item 3</div>
-      <div>Item 4</div>
-      <div>Item 5</div>
-      <div>Item 6</div>
-    </GridComponent>
+    <CodePreview
+      code={`<Grid templateRows="auto 3rem auto">
+  <div>Item 1</div>
+  <div>Item 2</div>
+  <div>Item 3</div>
+  <div>Item 4</div>
+  <div>Item 5</div>
+  <div>Item 6</div>
+</Grid>`}
+      label="Setting a custom template for rows"
+    >
+      <GridComponent templateRows="auto 3rem auto">
+        <div>Item 1</div>
+        <div>Item 2</div>
+        <div>Item 3</div>
+        <div>Item 4</div>
+        <div>Item 5</div>
+        <div>Item 6</div>
+      </GridComponent>
+    </CodePreview>
     <Heading as="h3">Other CSS grid properties</Heading>
     <p>
       You can also use <code>alignContent</code>, <code>alignItems</code>, <code

--- a/src/components/atoms/heading/heading.stories.astro
+++ b/src/components/atoms/heading/heading.stories.astro
@@ -1,49 +1,54 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
+import CodePreview from "../../molecules/code-preview/code-preview.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import HeadingComponent from "./heading.astro";
 
 const title = "Heading";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Atoms", url: "/design-system/components/atoms" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "atoms",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <HeadingComponent as="h2">Usage</HeadingComponent>
-    <p>This component is used to display a heading.</p>
-    <HeadingComponent as="h2">Levels from h1 to h6</HeadingComponent>
-    <HeadingComponent as="h1">
-      The quick brown fox jumps over the lazy dog
-    </HeadingComponent>
-    <HeadingComponent as="h2">
-      The quick brown fox jumps over the lazy dog
-    </HeadingComponent>
-    <HeadingComponent as="h3">
-      The quick brown fox jumps over the lazy dog
-    </HeadingComponent>
-    <HeadingComponent as="h4">
-      The quick brown fox jumps over the lazy dog
-    </HeadingComponent>
-    <HeadingComponent as="h5">
-      The quick brown fox jumps over the lazy dog
-    </HeadingComponent>
-    <HeadingComponent as="h6">
-      The quick brown fox jumps over the lazy dog
-    </HeadingComponent>
+    <HeadingComponent>Introduction</HeadingComponent>
+    <p>
+      A Heading component is used to display headings on a page. It supports
+      native HTML headings from <code>h1</code> to <code>h6</code>.
+    </p>
+    <CodePreview
+      code={`import Heading from "./components/atoms/heading/heading.astro"`}
+      label="How to import"
+    />
+    <CodePreview code={`<Heading>A heading</Heading>`} label="Basic use">
+      <HeadingComponent>A heading</HeadingComponent>
+    </CodePreview>
+    <HeadingComponent>Levels</HeadingComponent>
+    <p>
+      Headings are meant to represent the hierarchy in a page, so different
+      levels are available. The default level, when <code>as</code> is not provided,
+      is <code>h2</code>.
+    </p>
+    <CodePreview
+      code={`<Heading as="h1">A heading of level 1</Heading>
+<Heading as="h2">A heading of level 2</Heading>
+<Heading as="h3">A heading of level 3</Heading>
+<Heading as="h4">A heading of level 4</Heading>
+<Heading as="h5">A heading of level 5</Heading>
+<Heading as="h6">A heading of level 6</Heading>`}
+      label="Using different heading levels"
+    >
+      <HeadingComponent as="h1">A heading of level 1</HeadingComponent>
+      <HeadingComponent as="h2">A heading of level 2</HeadingComponent>
+      <HeadingComponent as="h3">A heading of level 3</HeadingComponent>
+      <HeadingComponent as="h4">A heading of level 4</HeadingComponent>
+      <HeadingComponent as="h5">A heading of level 5</HeadingComponent>
+      <HeadingComponent as="h6">A heading of level 6</HeadingComponent>
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/atoms/heading/heading.stories.astro
+++ b/src/components/atoms/heading/heading.stories.astro
@@ -24,8 +24,13 @@ const { breadcrumb, seo } = getStoryMeta({
     <CodePreview
       code={`import Heading from "./components/atoms/heading/heading.astro"`}
       label="How to import"
+      lang="ts"
     />
-    <CodePreview code={`<Heading>A heading</Heading>`} label="Basic use">
+    <CodePreview
+      code={`<Heading>A heading</Heading>`}
+      label="Basic use"
+      lang="astro"
+    >
       <HeadingComponent>A heading</HeadingComponent>
     </CodePreview>
     <HeadingComponent>Levels</HeadingComponent>
@@ -42,6 +47,7 @@ const { breadcrumb, seo } = getStoryMeta({
 <Heading as="h5">A heading of level 5</Heading>
 <Heading as="h6">A heading of level 6</Heading>`}
       label="Using different heading levels"
+      lang="astro"
     >
       <HeadingComponent as="h1">A heading of level 1</HeadingComponent>
       <HeadingComponent as="h2">A heading of level 2</HeadingComponent>

--- a/src/components/atoms/img/img.stories.astro
+++ b/src/components/atoms/img/img.stories.astro
@@ -22,6 +22,7 @@ const { breadcrumb, seo } = getStoryMeta({
     <CodePreview
       code={`import Img from "./components/atoms/img/img.astro"`}
       label="How to import"
+      lang="ts"
     />
     <Heading>Imported local image</Heading>
     <CodePreview
@@ -30,6 +31,7 @@ import logo from "../../../assets/logo.svg";
 ---
 <Img alt="The logo" src={logo} />`}
       label="Basic use"
+      lang="astro"
     >
       <ImgComponent alt="The logo" src={logo} />
     </CodePreview>
@@ -43,7 +45,8 @@ import logo from "../../../assets/logo.svg";
 import logo from "../../../assets/logo.svg";
 ---
 <Img alt="The logo" data-clickable="true" src={logo} />`}
-      label="Basic use"
+      label="Using a clickable image"
+      lang="astro"
     >
       <ImgComponent alt="The logo" data-clickable="true" src={logo} />
     </CodePreview>
@@ -55,7 +58,8 @@ import logo from "../../../assets/logo.svg";
   src="https://picsum.photos/640/480"
   width={640}
 />`}
-      label="Basic use"
+      label="Using a remote image"
+      lang="astro"
     >
       <ImgComponent
         alt="An example"

--- a/src/components/atoms/img/img.stories.astro
+++ b/src/components/atoms/img/img.stories.astro
@@ -1,45 +1,68 @@
 ---
-import type { ComponentProps } from "astro/types";
 import logo from "../../../assets/logo.svg";
+import { getStoryMeta } from "../../../utils/stories";
+import CodePreview from "../../molecules/code-preview/code-preview.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import Heading from "../heading/heading.astro";
 import ImgComponent from "./img.astro";
 
 const title = "Img";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Atoms", url: "/design-system/components/atoms" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "atoms",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
+    <Heading>Introduction</Heading>
+    <CodePreview
+      code={`import Img from "./components/atoms/img/img.astro"`}
+      label="How to import"
+    />
     <Heading>Imported local image</Heading>
-    <ImgComponent alt="The logo" src={logo} />
+    <CodePreview
+      code={`---
+import logo from "../../../assets/logo.svg";
+---
+<Img alt="The logo" src={logo} />`}
+      label="Basic use"
+    >
+      <ImgComponent alt="The logo" src={logo} />
+    </CodePreview>
     <Heading>Imported local image with link</Heading>
     <p>
       The image can be linked to its source with the <code>data-clickable</code>
       attribute.
     </p>
-    <ImgComponent alt="The logo" data-clickable="true" src={logo} />
+    <CodePreview
+      code={`---
+import logo from "../../../assets/logo.svg";
+---
+<Img alt="The logo" data-clickable="true" src={logo} />`}
+      label="Basic use"
+    >
+      <ImgComponent alt="The logo" data-clickable="true" src={logo} />
+    </CodePreview>
     <Heading>Remote image</Heading>
-    <ImgComponent
-      alt="An example"
-      height={480}
-      src="https://picsum.photos/640/480"
-      width={640}
-    />
+    <CodePreview
+      code={`<Img
+  alt="An example"
+  height={480}
+  src="https://picsum.photos/640/480"
+  width={640}
+/>`}
+      label="Basic use"
+    >
+      <ImgComponent
+        alt="An example"
+        height={480}
+        src="https://picsum.photos/640/480"
+        width={640}
+      />
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/atoms/label/label.stories.astro
+++ b/src/components/atoms/label/label.stories.astro
@@ -1,5 +1,6 @@
 ---
 import { getStoryMeta } from "../../../utils/stories";
+import CodePreview from "../../molecules/code-preview/code-preview.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import Heading from "../heading/heading.astro";
 import LabelComponent from "./label.astro";
@@ -16,11 +17,32 @@ const { breadcrumb, seo } = getStoryMeta({
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading as="h2">Usage</Heading>
+    <Heading as="h2">Introduction</Heading>
     <p>This component is used to display a label for a form input.</p>
-    <LabelComponent>A label</LabelComponent>
+    <CodePreview
+      code={`import Label from "./components/atoms/label/label.astro"`}
+      label="How to import"
+      lang="ts"
+    />
+    <CodePreview
+      code={`<Label>Some label</Label>`}
+      label="Basic use"
+      lang="astro"
+    >
+      <LabelComponent>Some label</LabelComponent>
+    </CodePreview>
     <Heading as="h2">Options</Heading>
     <Heading as="h3"><code>isRequired</code></Heading>
-    <LabelComponent isRequired>A label</LabelComponent>
+    <p>
+      When associated with a required input, a label can visually shows this
+      requirement.
+    </p>
+    <CodePreview
+      code={`<Label isRequired>Some label</Label>`}
+      label="Showing a required field"
+      lang="astro"
+    >
+      <LabelComponent isRequired>Some label</LabelComponent>
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/atoms/label/label.stories.astro
+++ b/src/components/atoms/label/label.stories.astro
@@ -1,26 +1,17 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import Heading from "../heading/heading.astro";
 import LabelComponent from "./label.astro";
 
 const title = "Label";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Atoms", url: "/design-system/components/atoms" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "atoms",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>

--- a/src/components/atoms/license/license.stories.astro
+++ b/src/components/atoms/license/license.stories.astro
@@ -1,26 +1,17 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import Heading from "../heading/heading.astro";
 import LicenseComponent from "./license.astro";
 
 const title = "License";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Atoms", url: "/design-system/components/atoms" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "atoms",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>

--- a/src/components/atoms/license/license.stories.astro
+++ b/src/components/atoms/license/license.stories.astro
@@ -1,5 +1,6 @@
 ---
 import { getStoryMeta } from "../../../utils/stories";
+import CodePreview from "../../molecules/code-preview/code-preview.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import Heading from "../heading/heading.astro";
 import LicenseComponent from "./license.astro";
@@ -16,8 +17,16 @@ const { breadcrumb, seo } = getStoryMeta({
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading as="h2">Usage</Heading>
+    <Heading as="h2">Introduction</Heading>
     <p>This component is used to display an icon of the website license.</p>
+    <CodePreview
+      code={`import License from "./components/atoms/license/license.astro"`}
+      label="How to import"
+      lang="ts"
+    />
+    <CodePreview code={`<License />`} label="Basic use" lang="astro">
+      <LicenseComponent />
+    </CodePreview>
     <LicenseComponent />
   </Fragment>
 </PageLayout>

--- a/src/components/atoms/link/link.stories.astro
+++ b/src/components/atoms/link/link.stories.astro
@@ -1,125 +1,139 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
+import CodePreview from "../../molecules/code-preview/code-preview.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import Heading from "../heading/heading.astro";
-import ListItem from "../list/list-item.astro";
-import List from "../list/list.astro";
 import LinkComponent from "./link.astro";
 
 const title = "Link";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Atoms", url: "/design-system/components/atoms" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "atoms",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading as="h2">Usage</Heading>
+    <Heading>Introduction</Heading>
+    <p>
+      A link can be used as internal or external navigation. It can provide
+      extra information such as the target language or if this is an external or
+      download link.
+    </p>
+    <CodePreview
+      code={`import Link from "./components/atoms/link/link.astro"`}
+      label="How to import"
+    />
+    <CodePreview
+      code={`<Link href="/target">Text used as anchor</Link>`}
+      label="Basic use"
+    >
+      <LinkComponent href="/target"> Text used as anchor </LinkComponent>
+    </CodePreview>
+    <Heading>Options</Heading>
+    <Heading as="h3"><code>hreflang</code></Heading>
+    <p>
+      Use this to define the target language and to visually show that
+      information.
+    </p>
+    <CodePreview
+      code={`<Link href="/destination" hreflang="fr">Text used as anchor</Link>`}
+      label="Defining a language"
+    >
+      <LinkComponent href="/destination" hreflang="fr">
+        Text used as anchor
+      </LinkComponent>
+    </CodePreview>
+    <Heading as="h3"><code>isExternal</code></Heading>
+    <p>
+      Use this to visually show that the following the link would lead to an
+      external website.
+    </p>
+    <CodePreview
+      code={`<Link href="/target" isExternal>Text used as anchor</Link>`}
+      label="Using an external link"
+    >
+      <LinkComponent href="/target" isExternal>
+        Text used as anchor
+      </LinkComponent>
+    </CodePreview>
+    <Heading as="h3"><code>isDownload</code></Heading>
+    <p>
+      Use this to visually show that the following the link targets a file that
+      can be downloaded.
+    </p>
+    <CodePreview
+      code={`<Link href="/target.pdf" isDownload>Text used as anchor</Link>`}
+      label="Using a download link"
+    >
+      <LinkComponent href="/target.pdf" isDownload>
+        Text used as anchor
+      </LinkComponent>
+    </CodePreview>
+    <Heading as="h3">Mixing options</Heading>
+    <p>
+      Sometimes you might need to mix the previous options to represent an
+      external link in French or an external download link for example.
+    </p>
+    <CodePreview
+      code={`<Link href="/destination.pdf" hreflang="fr" isDownload>Text used as anchor</Link>
+<br />
+<Link href="/destination" hreflang="fr" isExternal>Text used as anchor</Link>
+<br />
+<Link href="/target.pdf" isDownload isExternal>Text used as anchor</Link>
+<br />
+<Link href="/destination.pdf" hreflang="fr" isDownload isExternal>Text used as anchor</Link>`}
+      label="Using multiple options"
+    >
+      <LinkComponent href="/destination.pdf" hreflang="fr" isDownload
+        >Text used as anchor</LinkComponent
+      >
+      <br />
+      <LinkComponent href="/destination" hreflang="fr" isExternal
+        >Text used as anchor</LinkComponent
+      >
+      <br />
+      <LinkComponent href="/target.pdf" isDownload isExternal>
+        Text used as anchor
+      </LinkComponent>
+      <br />
+      <LinkComponent href="/destination.pdf" hreflang="fr" isDownload isExternal
+        >Text used as anchor</LinkComponent
+      >
+    </CodePreview>
+    <Heading>Wrapping an image in a link</Heading>
+    <p>
+      When creating a gallery, it is common to wrap images with a link. This
+      component also supports this.
+    </p>
+    <CodePreview
+      code={`<Link href="/target">
+  <img alt="" src="https://picsum.photos/640/480" />
+</Link>`}
+      label="Using an image inside a link"
+    >
+      <LinkComponent href="/target">
+        <img alt="" src="https://picsum.photos/640/480" />
+      </LinkComponent>
+    </CodePreview>
+    <Heading>HTML spacing handling</Heading>
     <p>
       When used at the beginning or at the end of a sentence, a link should not
       display an extra space before or after.
     </p>
-    <p>
-      <LinkComponent href="#destination">A link</LinkComponent> at the beginning
-      of a sentence.
-    </p>
-    <p>
-      A sentence ending with <LinkComponent href="#destination"
-        >a link</LinkComponent
-      >.
-    </p>
-    <Heading as="h2">Adding target information</Heading>
-    <Heading as="h3">Language</Heading>
-    <p>
-      A link can indicate the language used in the linked resource by using the <code
-        >hreflang</code
-      > attribute.
-    </p>
-    <List>
-      <ListItem>
-        <LinkComponent href="#destination" hreflang="fr"
-          >A French link</LinkComponent
-        >
-      </ListItem>
-    </List>
-    <Heading as="h3">External link</Heading>
-    <p>
-      A link can visually indicate that it leads to an external resource either
-      by using the <code>isExternal</code> property or by defining <code
-        >external</code
-      > in the <code>rel</code> attribute.
-    </p>
-    <List>
-      <ListItem>
-        <LinkComponent href="#destination" isExternal
-          >An external link</LinkComponent
-        >
-      </ListItem>
-      <ListItem>
-        <LinkComponent href="#destination" rel="external"
-          >An external link using rel</LinkComponent
-        >
-      </ListItem>
-    </List>
-    <Heading as="h3">Download link</Heading>
-    <p>
-      A link can visually indicate that it leads to a file (e.g. a PDF) by using
-      the <code>isDownload</code> property.
-    </p>
-    <List>
-      <ListItem>
-        <LinkComponent href="#destination" isDownload
-          >A download link</LinkComponent
-        >
-      </ListItem>
-    </List>
-    <Heading as="h3">Mixing information</Heading>
-    <p>It is also possible to mix the previous information on a same link:</p>
-    <List>
-      <ListItem>
-        <LinkComponent href="#destination" hreflang="fr" isExternal
-          >An external French link</LinkComponent
-        >
-      </ListItem>
-      <ListItem>
-        <LinkComponent href="#destination" hreflang="fr" isDownload
-          >A French download link</LinkComponent
-        >
-      </ListItem>
-      <ListItem>
-        <LinkComponent href="#destination" isDownload isExternal
-          >An external download link</LinkComponent
-        >
-      </ListItem>
-      <ListItem>
-        <LinkComponent href="#destination" hreflang="fr" isDownload isExternal
-          >An external download link in French</LinkComponent
-        >
-      </ListItem>
-    </List>
-    <Heading as="h2">Wrapping an image</Heading>
-    <p>
-      Sometimes links are used to wrap an image (e.g. a gallery). This should
-      also be supported:
-    </p>
-    <LinkComponent href="#destination"
-      ><img
-        alt="An example"
-        src="https://picsum.photos/100/100"
-      /></LinkComponent
-    >
+    <CodePreview label="No extra spaces">
+      <p>
+        <LinkComponent href="#destination">A link</LinkComponent> at the beginning
+        of a sentence.
+      </p>
+      <p>
+        A sentence ending with <LinkComponent href="#destination"
+          >a link</LinkComponent
+        >.
+      </p>
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/atoms/link/link.stories.astro
+++ b/src/components/atoms/link/link.stories.astro
@@ -26,10 +26,12 @@ const { breadcrumb, seo } = getStoryMeta({
     <CodePreview
       code={`import Link from "./components/atoms/link/link.astro"`}
       label="How to import"
+      lang="ts"
     />
     <CodePreview
       code={`<Link href="/target">Text used as anchor</Link>`}
       label="Basic use"
+      lang="astro"
     >
       <LinkComponent href="/target"> Text used as anchor </LinkComponent>
     </CodePreview>
@@ -42,6 +44,7 @@ const { breadcrumb, seo } = getStoryMeta({
     <CodePreview
       code={`<Link href="/destination" hreflang="fr">Text used as anchor</Link>`}
       label="Defining a language"
+      lang="astro"
     >
       <LinkComponent href="/destination" hreflang="fr">
         Text used as anchor
@@ -55,6 +58,7 @@ const { breadcrumb, seo } = getStoryMeta({
     <CodePreview
       code={`<Link href="/target" isExternal>Text used as anchor</Link>`}
       label="Using an external link"
+      lang="astro"
     >
       <LinkComponent href="/target" isExternal>
         Text used as anchor
@@ -68,6 +72,7 @@ const { breadcrumb, seo } = getStoryMeta({
     <CodePreview
       code={`<Link href="/target.pdf" isDownload>Text used as anchor</Link>`}
       label="Using a download link"
+      lang="astro"
     >
       <LinkComponent href="/target.pdf" isDownload>
         Text used as anchor
@@ -87,6 +92,7 @@ const { breadcrumb, seo } = getStoryMeta({
 <br />
 <Link href="/destination.pdf" hreflang="fr" isDownload isExternal>Text used as anchor</Link>`}
       label="Using multiple options"
+      lang="astro"
     >
       <LinkComponent href="/destination.pdf" hreflang="fr" isDownload
         >Text used as anchor</LinkComponent
@@ -114,6 +120,7 @@ const { breadcrumb, seo } = getStoryMeta({
   <img alt="" src="https://picsum.photos/640/480" />
 </Link>`}
       label="Using an image inside a link"
+      lang="astro"
     >
       <LinkComponent href="/target">
         <img alt="" src="https://picsum.photos/640/480" />

--- a/src/components/atoms/list/list.stories.astro
+++ b/src/components/atoms/list/list.stories.astro
@@ -1,5 +1,6 @@
 ---
 import { getStoryMeta } from "../../../utils/stories";
+import CodePreview from "../../molecules/code-preview/code-preview.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import Heading from "../heading/heading.astro";
 import ListItem from "./list-item.astro";
@@ -17,56 +18,145 @@ const { breadcrumb, seo } = getStoryMeta({
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading as="h2">Usage</Heading>
+    <Heading as="h2">Introduction</Heading>
     <p>
       This component is usually used to define a list of related items, either
       ordered or unordered.
     </p>
+    <CodePreview
+      code={`import List from "./components/atoms/list/list.astro";
+import ListItem from "./components/atoms/list-item/list-item.astro";`}
+      label="How to import"
+      lang="ts"
+    />
+    <CodePreview
+      code={`<List>
+  <ListItem>Item 1</ListItem>
+  <ListItem>Item 2</ListItem>
+  <ListItem>Item 3</ListItem>
+</List>`}
+      label="Basic use"
+      lang="astro"
+    >
+      <ListComponent>
+        <ListItem>Item 1</ListItem>
+        <ListItem>Item 2</ListItem>
+        <ListItem>Item 3</ListItem>
+      </ListComponent>
+    </CodePreview>
     <Heading as="h2">Kind</Heading>
     <Heading as="h3">Unordered</Heading>
-    <ListComponent>
-      <ListItem>Item 1</ListItem>
-      <ListItem>Item 2</ListItem>
-      <ListItem>Item 3</ListItem>
-    </ListComponent>
+    <CodePreview
+      code={`<List>
+  <ListItem>Item 1</ListItem>
+  <ListItem>Item 2</ListItem>
+  <ListItem>Item 3</ListItem>
+</List>`}
+      label="Using an unordered list"
+      lang="astro"
+    >
+      <ListComponent>
+        <ListItem>Item 1</ListItem>
+        <ListItem>Item 2</ListItem>
+        <ListItem>Item 3</ListItem>
+      </ListComponent>
+    </CodePreview>
     <Heading as="h3">Ordered</Heading>
-    <ListComponent as="ol">
-      <ListItem>Item 1</ListItem>
-      <ListItem>Item 2</ListItem>
-      <ListItem>Item 3</ListItem>
-    </ListComponent>
+    <CodePreview
+      code={`<List as="ol">
+  <ListItem>Item 1</ListItem>
+  <ListItem>Item 2</ListItem>
+  <ListItem>Item 3</ListItem>
+</List>`}
+      label="Using an ordered list"
+      lang="astro"
+    >
+      <ListComponent as="ol">
+        <ListItem>Item 1</ListItem>
+        <ListItem>Item 2</ListItem>
+        <ListItem>Item 3</ListItem>
+      </ListComponent>
+    </CodePreview>
     <Heading as="h3">Nesting and mixing</Heading>
-    <ListComponent>
-      <ListItem>Item 1</ListItem>
-      <ListItem>
-        Item 2
-        <ListComponent as="ol">
-          <ListItem>Subitem 1</ListItem>
-          <ListItem>Subitem 2</ListItem>
-          <ListItem>Subitem 3</ListItem>
-        </ListComponent>
-      </ListItem>
-      <ListItem>Item 3</ListItem>
-      <ListItem>Item 4</ListItem>
-    </ListComponent>
+    <CodePreview
+      code={`<List>
+  <ListItem>Item 1</ListItem>
+  <ListItem>
+    Item 2
+    <List as="ol">
+      <ListItem>Subitem 1</ListItem>
+      <ListItem>Subitem 2</ListItem>
+      <ListItem>Subitem 3</ListItem>
+    </List>
+  </ListItem>
+  <ListItem>Item 3</ListItem>
+  <ListItem>Item 4</ListItem>
+</List>`}
+      label="Using mixed and nested lists"
+      lang="astro"
+    >
+      <ListComponent>
+        <ListItem>Item 1</ListItem>
+        <ListItem>
+          Item 2
+          <ListComponent as="ol">
+            <ListItem>Subitem 1</ListItem>
+            <ListItem>Subitem 2</ListItem>
+            <ListItem>Subitem 3</ListItem>
+          </ListComponent>
+        </ListItem>
+        <ListItem>Item 3</ListItem>
+        <ListItem>Item 4</ListItem>
+      </ListComponent>
+    </CodePreview>
     <Heading as="h2">Options</Heading>
     <Heading as="h3"><code>isInline</code></Heading>
-    <ListComponent isInline>
-      <ListItem>Item 1</ListItem>
-      <ListItem>Item 2</ListItem>
-      <ListItem>Item 3</ListItem>
-    </ListComponent>
+    <CodePreview
+      code={`<List isInline>
+  <ListItem>Item 1</ListItem>
+  <ListItem>Item 2</ListItem>
+  <ListItem>Item 3</ListItem>
+</List>`}
+      label="Using an inlined list"
+      lang="astro"
+    >
+      <ListComponent isInline>
+        <ListItem>Item 1</ListItem>
+        <ListItem>Item 2</ListItem>
+        <ListItem>Item 3</ListItem>
+      </ListComponent>
+    </CodePreview>
     <Heading as="h3"><code>hideMarker</code></Heading>
-    <ListComponent hideMarker>
-      <ListItem>Item 1</ListItem>
-      <ListItem>Item 2</ListItem>
-      <ListItem>Item 3</ListItem>
-    </ListComponent>
+    <CodePreview
+      code={`<List hideMarker>
+  <ListItem>Item 1</ListItem>
+  <ListItem>Item 2</ListItem>
+  <ListItem>Item 3</ListItem>
+</List>`}
+      label="Using a list without marker"
+      lang="astro"
+    >
+      <ListComponent hideMarker>
+        <ListItem>Item 1</ListItem>
+        <ListItem>Item 2</ListItem>
+        <ListItem>Item 3</ListItem>
+      </ListComponent>
+    </CodePreview>
     <Heading as="h3"><code>hideMarker</code> on a specific item</Heading>
-    <ListComponent>
-      <ListItem>Item 1</ListItem>
-      <ListItem hideMarker>Item 2</ListItem>
-      <ListItem>Item 3</ListItem>
-    </ListComponent>
+    <CodePreview
+      code={`<List>
+  <ListItem>Item 1</ListItem>
+  <ListItem hideMarker>Item 2</ListItem>
+  <ListItem>Item 3</ListItem>
+</List>`}
+      label="Using a list while hiding a specific marker"
+      lang="astro"
+    >
+      <ListComponent>
+        <ListItem>Item 1</ListItem>
+        <ListItem hideMarker>Item 2</ListItem>
+        <ListItem>Item 3</ListItem>
+      </ListComponent>
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/atoms/list/list.stories.astro
+++ b/src/components/atoms/list/list.stories.astro
@@ -1,27 +1,18 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import Heading from "../heading/heading.astro";
 import ListItem from "./list-item.astro";
 import ListComponent from "./list.astro";
 
 const title = "List";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Atoms", url: "/design-system/components/atoms" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "atoms",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>

--- a/src/components/atoms/progress-bar/progress-bar.stories.astro
+++ b/src/components/atoms/progress-bar/progress-bar.stories.astro
@@ -1,26 +1,17 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import Heading from "../heading/heading.astro";
 import ProgressBarComponent from "./progress-bar.astro";
 
 const title = "ProgressBar";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Atoms", url: "/design-system/components/atoms" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "atoms",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>

--- a/src/components/atoms/progress-bar/progress-bar.stories.astro
+++ b/src/components/atoms/progress-bar/progress-bar.stories.astro
@@ -1,5 +1,6 @@
 ---
 import { getStoryMeta } from "../../../utils/stories";
+import CodePreview from "../../molecules/code-preview/code-preview.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import Heading from "../heading/heading.astro";
 import ProgressBarComponent from "./progress-bar.astro";
@@ -16,24 +17,48 @@ const { breadcrumb, seo } = getStoryMeta({
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading as="h2">Usage</Heading>
+    <Heading as="h2">Introduction</Heading>
     <p>
       A <code>ProgressBar</code> should be used to indicate a loading state. This
       can be useful with view transitions for example.
     </p>
+    <CodePreview
+      code={`import ProgressBar from "./components/atoms/progress-bar/progress-bar.astro";`}
+      label="How to import"
+      lang="ts"
+    />
+    <CodePreview code={`<ProgressBar />`} label="Basic use" lang="astro">
+      <ProgressBarComponent />
+    </CodePreview>
     <Heading as="h2">States</Heading>
     <Heading as="h2">Using a current value</Heading>
-    <ProgressBarComponent
-      aria-label="Progress bar with value example"
-      current={0.4}
-    />
+    <CodePreview
+      code={`<ProgressBar current={0.4} />`}
+      label="Using a current value"
+      lang="astro"
+    >
+      <ProgressBarComponent current={0.4} />
+    </CodePreview>
     <Heading as="h2">Using a current value and a max</Heading>
-    <ProgressBarComponent
-      aria-label="Progress bar with value and max example"
-      current={30}
-      max={100}
-    />
-    <Heading as="h2">Indeterminate</Heading>
-    <ProgressBarComponent aria-label="Indeterminate progress bar example" />
+    <CodePreview
+      code={`<ProgressBar current={30} max={100} />`}
+      label="Using a maximal value"
+      lang="astro"
+    >
+      <ProgressBarComponent current={30} max={100} />
+    </CodePreview>
+    <Heading as="h2">Accessibility</Heading>
+    <p>
+      When using a <code>ProgressBar</code> component, you should provide an <code
+        >aria-label</code
+      >.
+    </p>
+    <CodePreview
+      code={`<ProgressBar aria-label="Indeterminate progress" />`}
+      label="Improving the accessibility"
+      lang="astro"
+    >
+      <ProgressBarComponent aria-label="Indeterminate progress" />
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/atoms/social-link/social-link.stories.astro
+++ b/src/components/atoms/social-link/social-link.stories.astro
@@ -1,5 +1,6 @@
 ---
 import { getStoryMeta } from "../../../utils/stories";
+import CodePreview from "../../molecules/code-preview/code-preview.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import Heading from "../heading/heading.astro";
 import SocialLinkComponent from "./social-link.astro";
@@ -16,61 +17,146 @@ const { breadcrumb, seo } = getStoryMeta({
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading as="h2">Usage</Heading>
+    <Heading as="h2">Introduction</Heading>
     <p>
       A <code>SocialLink</code> is a link designed as a button that should redirect
       the user to an external website.
     </p>
+    <CodePreview
+      code={`import SocialLink from "./components/atoms/social-link/social-link.astro";`}
+      label="How to import"
+      lang="ts"
+    />
+    <CodePreview
+      code={`<SocialLink medium="email" url="#something" />`}
+      label="Basic use"
+      lang="astro"
+    >
+      <SocialLinkComponent medium="email" url="#something" />
+    </CodePreview>
     <Heading as="h2">Supported media</Heading>
-    <p>
-      The following example show the social links in both variant: with and
-      without label.
-    </p>
-    <Heading as="h3">Bluesky</Heading>
-    <SocialLinkComponent medium="bluesky" url="#bluesky" /><br />
-    <SocialLinkComponent hideLabel medium="bluesky" url="#bluesky" />
-    <Heading as="h3">Diaspora</Heading>
-    <SocialLinkComponent medium="diaspora" url="#diaspora" /><br />
-    <SocialLinkComponent hideLabel medium="diaspora" url="#diaspora" />
-    <Heading as="h3">Email</Heading>
-    <SocialLinkComponent medium="email" url="#email" /><br />
-    <SocialLinkComponent hideLabel medium="email" url="#email" />
-    <Heading as="h3">Facebook</Heading>
-    <SocialLinkComponent medium="facebook" url="#facebook" /><br />
-    <SocialLinkComponent hideLabel medium="facebook" url="#facebook" />
-    <Heading as="h3">Github</Heading>
-    <SocialLinkComponent medium="github" url="#github" /><br />
-    <SocialLinkComponent hideLabel medium="github" url="#github" />
-    <Heading as="h3">Gitlab</Heading>
-    <SocialLinkComponent medium="gitlab" url="#gitlab" /><br />
-    <SocialLinkComponent hideLabel medium="gitlab" url="#gitlab" />
-    <Heading as="h3">LinkedIn</Heading>
-    <SocialLinkComponent medium="linkedin" url="#linkedin" /><br />
-    <SocialLinkComponent hideLabel medium="linkedin" url="#linkedin" />
-    <Heading as="h3">Mastodon</Heading>
-    <SocialLinkComponent medium="mastodon" url="#mastodon" /><br />
-    <SocialLinkComponent hideLabel medium="mastodon" url="#mastodon" />
-    <Heading as="h3">Reddit</Heading>
-    <SocialLinkComponent medium="reddit" url="#reddit" /><br />
-    <SocialLinkComponent hideLabel medium="reddit" url="#reddit" />
-    <Heading as="h3">StackOverflow</Heading>
-    <SocialLinkComponent medium="stackoverflow" url="#stackoverflow" /><br />
-    <SocialLinkComponent
-      hideLabel
-      medium="stackoverflow"
-      url="#stackoverflow"
-    />
-    <Heading as="h3">WhatsApp</Heading>
-    <SocialLinkComponent medium="whatsapp" url="#whatsapp" /><br />
-    <SocialLinkComponent hideLabel medium="whatsapp" url="#whatsapp" />
-    <Heading as="h3">X</Heading>
-    <SocialLinkComponent medium="x" url="#x" /><br />
-    <SocialLinkComponent hideLabel medium="x" url="#x" />
+    <CodePreview
+      code={`<SocialLink medium="bluesky" url="#bluesky" />
+<br />
+<SocialLink medium="diaspora" url="#diaspora" />
+<br />
+<SocialLink medium="email" url="#email" />
+<br />
+<SocialLink medium="facebook" url="#facebook" />
+<br />
+<SocialLink medium="github" url="#github" />
+<br />
+<SocialLink medium="gitlab" url="#gitlab" />
+<br />
+<SocialLink medium="linkedin" url="#linkedin" />
+<br />
+<SocialLink medium="mastodon" url="#mastodon" />
+<br />
+<SocialLink medium="reddit" url="#reddit" />
+<br />
+<SocialLink medium="stackoverflow" url="#stackoverflow" />
+<br />
+<SocialLink medium="whatsapp" url="#whatsapp" />
+<br />
+<SocialLink medium="x" url="#x" />`}
+      label="Using the supported media"
+      lang="astro"
+    >
+      <SocialLinkComponent medium="bluesky" url="#bluesky" />
+      <br />
+      <SocialLinkComponent medium="diaspora" url="#diaspora" />
+      <br />
+      <SocialLinkComponent medium="email" url="#email" />
+      <br />
+      <SocialLinkComponent medium="facebook" url="#facebook" />
+      <br />
+      <SocialLinkComponent medium="github" url="#github" />
+      <br />
+      <SocialLinkComponent medium="gitlab" url="#gitlab" />
+      <br />
+      <SocialLinkComponent medium="linkedin" url="#linkedin" />
+      <br />
+      <SocialLinkComponent medium="mastodon" url="#mastodon" />
+      <br />
+      <SocialLinkComponent medium="reddit" url="#reddit" />
+      <br />
+      <SocialLinkComponent medium="stackoverflow" url="#stackoverflow" />
+      <br />
+      <SocialLinkComponent medium="whatsapp" url="#whatsapp" />
+      <br />
+      <SocialLinkComponent medium="x" url="#x" />
+    </CodePreview>
+    <Heading as="h3">Hiding the label</Heading>
+    <CodePreview
+      code={`<SocialLink hideLabel medium="bluesky" url="#bluesky" />
+<br />
+<SocialLink hideLabel medium="diaspora" url="#diaspora" />
+<br />
+<SocialLink hideLabel medium="email" url="#email" />
+<br />
+<SocialLink hideLabel medium="facebook" url="#facebook" />
+<br />
+<SocialLink hideLabel medium="github" url="#github" />
+<br />
+<SocialLink hideLabel medium="gitlab" url="#gitlab" />
+<br />
+<SocialLink hideLabel medium="linkedin" url="#linkedin" />
+<br />
+<SocialLink hideLabel medium="mastodon" url="#mastodon" />
+<br />
+<SocialLink hideLabel medium="reddit" url="#reddit" />
+<br />
+<SocialLink hideLabel medium="stackoverflow" url="#stackoverflow" />
+<br />
+<SocialLink hideLabel medium="whatsapp" url="#whatsapp" />
+<br />
+<SocialLink hideLabel medium="x" url="#x" />`}
+      label="Using a social link without label"
+      lang="astro"
+    >
+      <SocialLinkComponent hideLabel medium="bluesky" url="#bluesky" />
+      <br />
+      <SocialLinkComponent hideLabel medium="diaspora" url="#diaspora" />
+      <br />
+      <SocialLinkComponent hideLabel medium="email" url="#email" />
+      <br />
+      <SocialLinkComponent hideLabel medium="facebook" url="#facebook" />
+      <br />
+      <SocialLinkComponent hideLabel medium="github" url="#github" />
+      <br />
+      <SocialLinkComponent hideLabel medium="gitlab" url="#gitlab" />
+      <br />
+      <SocialLinkComponent hideLabel medium="linkedin" url="#linkedin" />
+      <br />
+      <SocialLinkComponent hideLabel medium="mastodon" url="#mastodon" />
+      <br />
+      <SocialLinkComponent hideLabel medium="reddit" url="#reddit" />
+      <br />
+      <SocialLinkComponent
+        hideLabel
+        medium="stackoverflow"
+        url="#stackoverflow"
+      />
+      <br />
+      <SocialLinkComponent hideLabel medium="whatsapp" url="#whatsapp" />
+      <br />
+      <SocialLinkComponent hideLabel medium="x" url="#x" />
+    </CodePreview>
     <Heading as="h3">Using a custom label</Heading>
-    <SocialLinkComponent
-      label="Share on Mastodon"
-      medium="mastodon"
-      url="#mastodon"
-    />
+    <CodePreview
+      code={`<SocialLink
+  label="Share on Mastodon"
+  medium="mastodon"
+  url="#mastodon"
+/>`}
+      label="Using a custom label"
+      lang="astro"
+    >
+      <SocialLinkComponent
+        label="Share on Mastodon"
+        medium="mastodon"
+        url="#mastodon"
+      />
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/atoms/social-link/social-link.stories.astro
+++ b/src/components/atoms/social-link/social-link.stories.astro
@@ -1,26 +1,17 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import Heading from "../heading/heading.astro";
 import SocialLinkComponent from "./social-link.astro";
 
 const title = "SocialLink";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Atoms", url: "/design-system/components/atoms" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "atoms",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>

--- a/src/components/atoms/spinner/spinner.stories.astro
+++ b/src/components/atoms/spinner/spinner.stories.astro
@@ -1,26 +1,17 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import Heading from "../heading/heading.astro";
 import SpinnerComponent from "./spinner.astro";
 
 const title = "Spinner";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Atoms", url: "/design-system/components/atoms" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "atoms",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>

--- a/src/components/atoms/spinner/spinner.stories.astro
+++ b/src/components/atoms/spinner/spinner.stories.astro
@@ -1,5 +1,6 @@
 ---
 import { getStoryMeta } from "../../../utils/stories";
+import CodePreview from "../../molecules/code-preview/code-preview.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import Heading from "../heading/heading.astro";
 import SpinnerComponent from "./spinner.astro";
@@ -16,19 +17,38 @@ const { breadcrumb, seo } = getStoryMeta({
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading as="h2">Usage</Heading>
+    <Heading as="h2">Introduction</Heading>
     <p>
       A <code>Spinner</code> should be used to indicate a loading state.
     </p>
+    <CodePreview
+      code={`import Spinner from "./components/atoms/spinner/spinner.astro";`}
+      label="How to import"
+      lang="ts"
+    />
+    <CodePreview code={`<Spinner />`} label="Basic use">
+      <SpinnerComponent />
+    </CodePreview>
     <SpinnerComponent />
-    <Heading as="h2">With message</Heading>
-    <Heading as="h3">Under the spinner (default)</Heading>
-    <SpinnerComponent>Loading...</SpinnerComponent>
-    <Heading as="h3">On top of the spinner</Heading>
-    <SpinnerComponent isReversed>Loading...</SpinnerComponent>
-    <Heading as="h3">Inlined after the spinner</Heading>
-    <SpinnerComponent isInline>Loading...</SpinnerComponent>
-    <Heading as="h3">Inlined before the spinner</Heading>
-    <SpinnerComponent isInline isReversed>Loading...</SpinnerComponent>
+    <Heading as="h2">With text</Heading>
+    <CodePreview
+      code={`<Spinner>Loading...</Spinner>
+<br />
+<Spinner isReversed>Loading...</Spinner>
+<br />
+<Spinner isInline>Loading...</Spinner>
+<br />
+<Spinner isInline isReversed>Loading...</Spinner>`}
+      label="Basic use"
+      lang="astro"
+    >
+      <SpinnerComponent>Loading...</SpinnerComponent>
+      <br />
+      <SpinnerComponent isReversed>Loading...</SpinnerComponent>
+      <br />
+      <SpinnerComponent isInline>Loading...</SpinnerComponent>
+      <br />
+      <SpinnerComponent isInline isReversed>Loading...</SpinnerComponent>
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/atoms/text-field/text-field.stories.astro
+++ b/src/components/atoms/text-field/text-field.stories.astro
@@ -1,26 +1,17 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import Heading from "../heading/heading.astro";
 import TextFieldComponent from "./text-field.astro";
 
 const title = "TextField";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Atoms", url: "/design-system/components/atoms" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "atoms",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>

--- a/src/components/atoms/text-field/text-field.stories.astro
+++ b/src/components/atoms/text-field/text-field.stories.astro
@@ -1,5 +1,6 @@
 ---
 import { getStoryMeta } from "../../../utils/stories";
+import CodePreview from "../../molecules/code-preview/code-preview.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import Heading from "../heading/heading.astro";
 import TextFieldComponent from "./text-field.astro";
@@ -16,39 +17,90 @@ const { breadcrumb, seo } = getStoryMeta({
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading as="h2">Type</Heading>
-    <Heading as="h3">Date</Heading>
-    <TextFieldComponent type="date" />
-    <Heading as="h3">Datetime</Heading>
-    <TextFieldComponent type="datetime-local" />
-    <Heading as="h3">Email</Heading>
-    <TextFieldComponent type="email" />
-    <Heading as="h3">Month</Heading>
-    <TextFieldComponent type="month" />
-    <Heading as="h3">Password</Heading>
-    <TextFieldComponent type="password" />
-    <Heading as="h3">Search</Heading>
-    <TextFieldComponent type="search" />
-    <Heading as="h3">Tel</Heading>
-    <TextFieldComponent type="tel" />
-    <Heading as="h3">Text</Heading>
-    <TextFieldComponent type="text" />
-    <Heading as="h3">Textarea</Heading>
-    <TextFieldComponent type="textarea" />
-    <Heading as="h3">Time</Heading>
-    <TextFieldComponent type="time" />
-    <Heading as="h3">URL</Heading>
-    <TextFieldComponent type="url" />
-    <Heading as="h3">Week</Heading>
-    <TextFieldComponent type="week" />
-    <Heading as="h2">State</Heading>
-    <Heading as="h3">Editable</Heading>
-    <TextFieldComponent type="text" />
-    <Heading as="h3">Read-only</Heading>
-    <TextFieldComponent readonly="true" type="text" />
-    <Heading as="h3">Disabled</Heading>
-    <TextFieldComponent disabled="true" type="text" />
-    <Heading as="h3">With placeholder</Heading>
-    <TextFieldComponent placeholder="Some placeholder..." type="text" />
+    <Heading>Introduction</Heading>
+    <CodePreview
+      code={`import TextField from "./components/atoms/text-field/text-field.astro";`}
+      label="How to import"
+      lang="ts"
+    />
+    <CodePreview
+      code={`<TextField type="text" />`}
+      label="Basic use"
+      lang="astro"
+    >
+      <TextFieldComponent type="text" />
+    </CodePreview>
+    <Heading as="h2">Types</Heading>
+    <CodePreview
+      code={`<TextFieldComponent type="date" />
+<br />
+<TextFieldComponent type="datetime-local" />
+<br />
+<TextFieldComponent type="email" />
+<br />
+<TextFieldComponent type="month" />
+<br />
+<TextFieldComponent type="password" />
+<br />
+<TextFieldComponent type="search" />
+<br />
+<TextFieldComponent type="tel" />
+<br />
+<TextFieldComponent type="text" />
+<br />
+<TextFieldComponent type="textarea" />
+<br />
+<TextFieldComponent type="time" />
+<br />
+<TextFieldComponent type="url" />
+<br />
+<TextFieldComponent type="week" />`}
+      label="Using different types of text fields"
+      lang="astro"
+    >
+      <TextFieldComponent type="date" />
+      <br />
+      <TextFieldComponent type="datetime-local" />
+      <br />
+      <TextFieldComponent type="email" />
+      <br />
+      <TextFieldComponent type="month" />
+      <br />
+      <TextFieldComponent type="password" />
+      <br />
+      <TextFieldComponent type="search" />
+      <br />
+      <TextFieldComponent type="tel" />
+      <br />
+      <TextFieldComponent type="text" />
+      <br />
+      <TextFieldComponent type="textarea" />
+      <br />
+      <TextFieldComponent type="time" />
+      <br />
+      <TextFieldComponent type="url" />
+      <br />
+      <TextFieldComponent type="week" />
+    </CodePreview>
+    <Heading as="h2">States</Heading>
+    <CodePreview
+      code={`<TextFieldComponent type="text" />
+<br />
+<TextFieldComponent readonly="true" type="text" />
+<br />
+<TextFieldComponent disabled="true" type="text" />
+<br />
+<TextFieldComponent placeholder="Some placeholder..." type="text" />`}
+      label="Basic use"
+      lang="astro"
+    >
+      <TextFieldComponent type="text" />
+      <br />
+      <TextFieldComponent readonly="true" type="text" />
+      <br />
+      <TextFieldComponent disabled="true" type="text" />
+      <br />
+      <TextFieldComponent placeholder="Some placeholder..." type="text" />
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/atoms/time/time.stories.astro
+++ b/src/components/atoms/time/time.stories.astro
@@ -1,26 +1,17 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import Heading from "../heading/heading.astro";
 import TimeComponent from "./time.astro";
 
 const title = "Time";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Atoms", url: "/design-system/components/atoms" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "atoms",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 
 const date = new Date();
 ---

--- a/src/components/atoms/time/time.stories.astro
+++ b/src/components/atoms/time/time.stories.astro
@@ -1,5 +1,6 @@
 ---
 import { getStoryMeta } from "../../../utils/stories";
+import CodePreview from "../../molecules/code-preview/code-preview.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import Heading from "../heading/heading.astro";
 import TimeComponent from "./time.astro";
@@ -18,21 +19,80 @@ const date = new Date();
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading>Default</Heading>
-    <TimeComponent date={date} />
+    <Heading>Introduction</Heading>
+    <CodePreview
+      code={`import Time from "./components/atoms/time/time.astro";`}
+      label="How to import"
+      lang="ts"
+    />
+    <CodePreview
+      code={`---
+const date = new Date();
+---
+<Time date={date} />`}
+      label="Basic use"
+      lang="astro"
+    >
+      <TimeComponent date={date} />
+    </CodePreview>
     <Heading>With time</Heading>
-    <TimeComponent date={date} showTime />
+    <CodePreview
+      code={`---
+const date = new Date();
+---
+<Time date={date} showTime /> />`}
+      label="Showing the time"
+      lang="astro"
+    >
+      <TimeComponent date={date} showTime />
+    </CodePreview>
     <Heading>Without day</Heading>
-    <TimeComponent date={date} hideDay />
+    <CodePreview
+      code={`---
+const date = new Date();
+---
+<Time date={date} hideDay /> />`}
+      label="Hiding the day"
+      lang="astro"
+    >
+      <TimeComponent date={date} hideDay />
+    </CodePreview>
     <Heading>Without month</Heading>
     <p>
-      It does not make sense to use the day and the year without month, but you
-      can do it:
+      You shouldn't hide the month alone because it does not make sense to use
+      the day and the year without a month, but this is supported:
     </p>
-    <TimeComponent date={date} hideMonth />
+    <CodePreview
+      code={`---
+const date = new Date();
+---
+<Time date={date} hideMonth /> />`}
+      label="Hiding the month"
+      lang="astro"
+    >
+      <TimeComponent date={date} hideMonth />
+    </CodePreview>
     <Heading>Without year</Heading>
-    <TimeComponent date={date} hideYear />
+    <CodePreview
+      code={`---
+const date = new Date();
+---
+<Time date={date} hideYear /> />`}
+      label="Hiding the year"
+      lang="astro"
+    >
+      <TimeComponent date={date} hideYear />
+    </CodePreview>
     <Heading>Without day and month</Heading>
-    <TimeComponent date={date} hideDay hideMonth />
+    <CodePreview
+      code={`---
+const date = new Date();
+---
+<Time date={date} hideDay hideMonth /> />`}
+      label="Hiding the day and the month"
+      lang="astro"
+    >
+      <TimeComponent date={date} hideDay hideMonth />
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/molecules/back-to-top/back-to-top.stories.astro
+++ b/src/components/molecules/back-to-top/back-to-top.stories.astro
@@ -1,26 +1,17 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import BackToTopComponent from "./back-to-top.astro";
 
 const title = "BackToTop";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Molecules", url: "/design-system/components/molecules" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "molecules",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>

--- a/src/components/molecules/back-to-top/back-to-top.stories.astro
+++ b/src/components/molecules/back-to-top/back-to-top.stories.astro
@@ -2,6 +2,7 @@
 import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
+import CodePreview from "../code-preview/code-preview.astro";
 import BackToTopComponent from "./back-to-top.astro";
 
 const title = "BackToTop";
@@ -16,12 +17,23 @@ const { breadcrumb, seo } = getStoryMeta({
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading as="h2">Usage</Heading>
+    <Heading as="h2">Introduction</Heading>
     <p>
       A BackToTop component is special. It is used to navigate to the top of the
       page using an anchor. Its visibility is controlled according to a scroll
       threshold.
     </p>
-    <BackToTopComponent anchor="#some-anchor" label="Back to some anchor" />
+    <CodePreview
+      code={`import BackToTop from "./components/molecules/back-to-top/back-to-top.astro";`}
+      label="How to import"
+      lang="ts"
+    />
+    <CodePreview
+      code={`<BackToTop anchor="#some-anchor" label="Back to some anchor" />`}
+      label="Basic use"
+      lang="astro"
+    >
+      <BackToTopComponent anchor="#some-anchor" label="Back to some anchor" />
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/molecules/back-to/back-to.stories.astro
+++ b/src/components/molecules/back-to/back-to.stories.astro
@@ -1,26 +1,17 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import BackToComponent from "./back-to.astro";
 
 const title = "BackTo";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Molecules", url: "/design-system/components/molecules" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "molecules",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>

--- a/src/components/molecules/back-to/back-to.stories.astro
+++ b/src/components/molecules/back-to/back-to.stories.astro
@@ -2,6 +2,7 @@
 import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
+import CodePreview from "../code-preview/code-preview.astro";
 import BackToComponent from "./back-to.astro";
 
 const title = "BackTo";
@@ -16,15 +17,26 @@ const { breadcrumb, seo } = getStoryMeta({
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading as="h2">Usage</Heading>
+    <Heading as="h2">Introduction</Heading>
     <p>
       A BackTo component is special. It is used to navigate through a page using
       anchors. His purpose is to let the user go back to a previous anchor.
     </p>
+    <CodePreview
+      code={`import BackTo from "./components/molecules/back-to/back-to.astro";`}
+      label="How to import"
+      lang="ts"
+    />
+    <CodePreview
+      code={`<BackTo anchor="#some-anchor" label="Back to some anchor" />`}
+      label="Basic use"
+      lang="astro"
+    >
+      <BackToComponent anchor="#some-anchor" label="Back to some anchor" />
+    </CodePreview>
     <p>
       <strong>Note:</strong> The button is currently designed to be used a "back
       to top" button but I choose to name it BackTo to support possible future variants.
     </p>
-    <BackToComponent anchor="#some-anchor" label="Back to some anchor" />
   </Fragment>
 </PageLayout>

--- a/src/components/molecules/branding/branding.stories.astro
+++ b/src/components/molecules/branding/branding.stories.astro
@@ -2,6 +2,7 @@
 import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
+import CodePreview from "../code-preview/code-preview.astro";
 import BrandingComponent from "./branding.astro";
 
 const title = "Branding";
@@ -16,8 +17,19 @@ const { breadcrumb, seo } = getStoryMeta({
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading as="h2">Usage</Heading>
+    <Heading as="h2">Introduction</Heading>
     <p>This component is used to a logo alongside the brand.</p>
-    <BrandingComponent brand="Brand" url="#homepage" />
+    <CodePreview
+      code={`import Branding from "./components/molecules/branding/branding.astro";`}
+      label="How to import"
+      lang="ts"
+    />
+    <CodePreview
+      code={`<Branding brand="Brand" url="#homepage" />`}
+      label="Basic use"
+      lang="astro"
+    >
+      <BrandingComponent brand="Brand" url="#homepage" />
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/molecules/branding/branding.stories.astro
+++ b/src/components/molecules/branding/branding.stories.astro
@@ -1,26 +1,17 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import BrandingComponent from "./branding.astro";
 
 const title = "Branding";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Molecules", url: "/design-system/components/molecules" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "molecules",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>

--- a/src/components/molecules/breadcrumb/breadcrumb.stories.astro
+++ b/src/components/molecules/breadcrumb/breadcrumb.stories.astro
@@ -3,6 +3,7 @@ import type { ComponentProps } from "astro/types";
 import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
+import CodePreview from "../code-preview/code-preview.astro";
 import BreadcrumbComponent from "./breadcrumb.astro";
 
 const title = "Breadcrumb";
@@ -24,8 +25,27 @@ const items: ComponentProps<typeof BreadcrumbComponent>["items"] = [
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading as="h2">Usage</Heading>
+    <Heading as="h2">Introduction</Heading>
     <p>This component is used to display a breadcrumb on a page.</p>
-    <BreadcrumbComponent items={items} />
+    <CodePreview
+      code={`import Breadcrumb from "./components/molecules/breadcrumb/breadcrumb.astro";`}
+      label="How to import"
+      lang="ts"
+    />
+    <CodePreview
+      code={`---
+const items = [
+  { label: "Home", url: "#item1" },
+  { label: "Blog", url: "#item2" },
+  { label: "Year", url: "#item3" },
+  { label: "A very very long post title", url: "#item4" },
+];
+---
+<Breadcrumb items={items} />`}
+      label="Basic use"
+      lang="astro"
+    >
+      <BreadcrumbComponent items={items} />
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/molecules/breadcrumb/breadcrumb.stories.astro
+++ b/src/components/molecules/breadcrumb/breadcrumb.stories.astro
@@ -1,26 +1,18 @@
 ---
 import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import BreadcrumbComponent from "./breadcrumb.astro";
 
 const title = "Breadcrumb";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Molecules", url: "/design-system/components/molecules" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "molecules",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 
 const items: ComponentProps<typeof BreadcrumbComponent>["items"] = [
   { label: "Home", url: "#item1" },

--- a/src/components/molecules/card/card.stories.astro
+++ b/src/components/molecules/card/card.stories.astro
@@ -1,11 +1,11 @@
 ---
 import { getStoryMeta } from "../../../utils/stories";
-import Box from "../../atoms/box/box.astro";
 import Button from "../../atoms/button/button.astro";
 import Heading from "../../atoms/heading/heading.astro";
 import Img from "../../atoms/img/img.astro";
 import Link from "../../atoms/link/link.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
+import CodePreview from "../code-preview/code-preview.astro";
 import CardComponent from "./card.astro";
 
 const title = "Card";
@@ -20,296 +20,420 @@ const { breadcrumb, seo } = getStoryMeta({
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
+    <Heading>Introduction</Heading>
     <p>
       A card can be used inside or outside a container. When wrapped in a
       container, the cover will be placed on the left of the card when the
       container reaches the breakpoint.
     </p>
-  </Fragment>
-  <Fragment slot="disconnected-body">
-    <Box
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced
+    <CodePreview
+      code={`import Card from "./components/molecules/card/card.astro";`}
+      label="How to import"
+      lang="ts"
+    />
+    <CodePreview
+      code={`<Card>
+  <p>
+    Ut consequuntur modi. Accusantium quia unde sint suscipit ipsum. Sunt
+    voluptates earum ea cumque eligendi voluptate iste architecto dolores.
+    Sit impedit cum non voluptates at qui ducimus eveniet reiciendis. Ad
+    voluptate dolor dicta ea sit amet facere. Blanditiis non et.
+  </p>
+</Card>`}
+      label="Basic use"
+      lang="astro"
     >
-      <Heading>With title and body</Heading>
-    </Box>
-    <CardComponent>
-      <p>
-        Ut consequuntur modi. Accusantium quia unde sint suscipit ipsum. Sunt
-        voluptates earum ea cumque eligendi voluptate iste architecto dolores.
-        Sit impedit cum non voluptates at qui ducimus eveniet reiciendis. Ad
-        voluptate dolor dicta ea sit amet facere. Blanditiis non et.
-      </p>
-    </CardComponent>
-    <Box
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced
+      <CardComponent>
+        <p>
+          Ut consequuntur modi. Accusantium quia unde sint suscipit ipsum. Sunt
+          voluptates earum ea cumque eligendi voluptate iste architecto dolores.
+          Sit impedit cum non voluptates at qui ducimus eveniet reiciendis. Ad
+          voluptate dolor dicta ea sit amet facere. Blanditiis non et.
+        </p>
+      </CardComponent>
+    </CodePreview>
+    <p>
+      If you don't wrap the Card in a CSS container, its appearance on large
+      screens will be the same as the mobile view. You cannot see the difference
+      here since main is a container.
+    </p>
+    <Heading>With heading and body</Heading>
+    <CodePreview
+      code={`<Card>
+  <Heading as="h3" slot="heading">The card title</Heading>
+  <p>
+    Ut consequuntur modi. Accusantium quia unde sint suscipit ipsum. Sunt
+    voluptates earum ea cumque eligendi voluptate iste architecto dolores.
+    Sit impedit cum non voluptates at qui ducimus eveniet reiciendis. Ad
+    voluptate dolor dicta ea sit amet facere. Blanditiis non et.
+  </p>
+</Card>`}
+      label="Using a heading"
+      lang="astro"
     >
-      <Heading>With title, body and frontmatter</Heading>
-    </Box>
-    <CardComponent>
-      <span slot="frontmatter">Category</span>
-      <Heading as="h3" slot="heading">The card title</Heading>
-      <p>
-        Ut consequuntur modi. Accusantium quia unde sint suscipit ipsum. Sunt
-        voluptates earum ea cumque eligendi voluptate iste architecto dolores.
-        Sit impedit cum non voluptates at qui ducimus eveniet reiciendis. Ad
-        voluptate dolor dicta ea sit amet facere. Blanditiis non et.
-      </p>
-    </CardComponent>
-    <Box
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced
+      <CardComponent>
+        <Heading as="h3" slot="heading">The card title</Heading>
+        <p>
+          Ut consequuntur modi. Accusantium quia unde sint suscipit ipsum. Sunt
+          voluptates earum ea cumque eligendi voluptate iste architecto dolores.
+          Sit impedit cum non voluptates at qui ducimus eveniet reiciendis. Ad
+          voluptate dolor dicta ea sit amet facere. Blanditiis non et.
+        </p>
+      </CardComponent>
+    </CodePreview>
+    <Heading>With heading, body and frontmatter</Heading>
+    <CodePreview
+      code={`<Card>
+  <span slot="frontmatter">Category</span>
+  <Heading as="h3" slot="heading">The card title</Heading>
+  <p>
+    Ut consequuntur modi. Accusantium quia unde sint suscipit ipsum. Sunt
+    voluptates earum ea cumque eligendi voluptate iste architecto dolores.
+    Sit impedit cum non voluptates at qui ducimus eveniet reiciendis. Ad
+    voluptate dolor dicta ea sit amet facere. Blanditiis non et.
+  </p>
+</Card>`}
+      label="Using a heading and a frontmatter"
+      lang="astro"
     >
-      <Heading>With title, body and a call to action</Heading>
-    </Box>
-    <CardComponent>
-      <Heading as="h3" slot="heading">The card title</Heading>
-      <p>
-        Ut consequuntur modi. Accusantium quia unde sint suscipit ipsum. Sunt
-        voluptates earum ea cumque eligendi voluptate iste architecto dolores.
-        Sit impedit cum non voluptates at qui ducimus eveniet reiciendis. Ad
-        voluptate dolor dicta ea sit amet facere. Blanditiis non et.
-      </p>
-      <Button as="a" href="#post" slot="cta">Read more</Button>
-    </CardComponent>
-    <Box
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced
+      <CardComponent>
+        <span slot="frontmatter">Category</span>
+        <Heading as="h3" slot="heading">The card title</Heading>
+        <p>
+          Ut consequuntur modi. Accusantium quia unde sint suscipit ipsum. Sunt
+          voluptates earum ea cumque eligendi voluptate iste architecto dolores.
+          Sit impedit cum non voluptates at qui ducimus eveniet reiciendis. Ad
+          voluptate dolor dicta ea sit amet facere. Blanditiis non et.
+        </p>
+      </CardComponent>
+    </CodePreview>
+    <Heading>With heading, body and a call to action</Heading>
+    <CodePreview
+      code={`<Card>
+  <Heading as="h3" slot="heading">The card title</Heading>
+  <p>
+    Ut consequuntur modi. Accusantium quia unde sint suscipit ipsum. Sunt
+    voluptates earum ea cumque eligendi voluptate iste architecto dolores.
+    Sit impedit cum non voluptates at qui ducimus eveniet reiciendis. Ad
+    voluptate dolor dicta ea sit amet facere. Blanditiis non et.
+  </p>
+  <Button as="a" href="#post" slot="cta">Read more</Button>
+</Card>`}
+      label="Using a heading and a call to action"
+      lang="astro"
     >
-      <Heading>With title, body and meta</Heading>
-    </Box>
-    <CardComponent>
-      <Heading as="h3" slot="heading">The card title</Heading>
-      <p>
-        Ut consequuntur modi. Accusantium quia unde sint suscipit ipsum. Sunt
-        voluptates earum ea cumque eligendi voluptate iste architecto dolores.
-        Sit impedit cum non voluptates at qui ducimus eveniet reiciendis. Ad
-        voluptate dolor dicta ea sit amet facere. Blanditiis non et.
-      </p>
-      <div slot="meta">Some meta</div>
-    </CardComponent>
-    <Box
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced
+      <CardComponent>
+        <Heading as="h3" slot="heading">The card title</Heading>
+        <p>
+          Ut consequuntur modi. Accusantium quia unde sint suscipit ipsum. Sunt
+          voluptates earum ea cumque eligendi voluptate iste architecto dolores.
+          Sit impedit cum non voluptates at qui ducimus eveniet reiciendis. Ad
+          voluptate dolor dicta ea sit amet facere. Blanditiis non et.
+        </p>
+        <Button as="a" href="#post" slot="cta">Read more</Button>
+      </CardComponent>
+    </CodePreview>
+    <Heading>With heading, body and meta</Heading>
+    <CodePreview
+      code={`<Card>
+  <Heading as="h3" slot="heading">The card title</Heading>
+  <p>
+    Ut consequuntur modi. Accusantium quia unde sint suscipit ipsum. Sunt
+    voluptates earum ea cumque eligendi voluptate iste architecto dolores.
+    Sit impedit cum non voluptates at qui ducimus eveniet reiciendis. Ad
+    voluptate dolor dicta ea sit amet facere. Blanditiis non et.
+  </p>
+  <div slot="meta">Some meta</div>
+</Card>`}
+      label="Using a heading and meta"
+      lang="astro"
     >
-      <Heading>With title, body, meta and a call to action</Heading>
-    </Box>
-    <CardComponent>
-      <Heading as="h3" slot="heading">The card title</Heading>
-      <p>
-        Ut consequuntur modi. Accusantium quia unde sint suscipit ipsum. Sunt
-        voluptates earum ea cumque eligendi voluptate iste architecto dolores.
-        Sit impedit cum non voluptates at qui ducimus eveniet reiciendis. Ad
-        voluptate dolor dicta ea sit amet facere. Blanditiis non et.
-      </p>
-      <div slot="meta">Some meta</div>
-      <Button as="a" href="#post" slot="cta">Read more</Button>
-    </CardComponent>
-    <Box
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced
+      <CardComponent>
+        <Heading as="h3" slot="heading">The card title</Heading>
+        <p>
+          Ut consequuntur modi. Accusantium quia unde sint suscipit ipsum. Sunt
+          voluptates earum ea cumque eligendi voluptate iste architecto dolores.
+          Sit impedit cum non voluptates at qui ducimus eveniet reiciendis. Ad
+          voluptate dolor dicta ea sit amet facere. Blanditiis non et.
+        </p>
+        <div slot="meta">Some meta</div>
+      </CardComponent>
+    </CodePreview>
+    <Heading>With heading, body, meta and a call to action</Heading>
+    <CodePreview
+      code={`<Card>
+  <Heading as="h3" slot="heading">The card title</Heading>
+  <p>
+    Ut consequuntur modi. Accusantium quia unde sint suscipit ipsum. Sunt
+    voluptates earum ea cumque eligendi voluptate iste architecto dolores.
+    Sit impedit cum non voluptates at qui ducimus eveniet reiciendis. Ad
+    voluptate dolor dicta ea sit amet facere. Blanditiis non et.
+  </p>
+  <div slot="meta">Some meta</div>
+  <Button as="a" href="#post" slot="cta">Read more</Button>
+</Card>`}
+      label="Using a heading, some meta and a call to action"
+      lang="astro"
     >
-      <Heading>With title, body and cover</Heading>
-    </Box>
-    <CardComponent>
-      <Img
-        alt="The card cover"
-        height={480}
-        slot="cover"
-        src="https://picsum.photos/640/480"
-        width={640}
-      />
-      <Heading as="h3" slot="heading">The card title</Heading>
-      <p>
-        Ut consequuntur modi. Accusantium quia unde sint suscipit ipsum. Sunt
-        voluptates earum ea cumque eligendi voluptate iste architecto dolores.
-        Sit impedit cum non voluptates at qui ducimus eveniet reiciendis. Ad
-        voluptate dolor dicta ea sit amet facere. Blanditiis non et.
-      </p>
-    </CardComponent>
-    <Box
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced
+      <CardComponent>
+        <Heading as="h3" slot="heading">The card title</Heading>
+        <p>
+          Ut consequuntur modi. Accusantium quia unde sint suscipit ipsum. Sunt
+          voluptates earum ea cumque eligendi voluptate iste architecto dolores.
+          Sit impedit cum non voluptates at qui ducimus eveniet reiciendis. Ad
+          voluptate dolor dicta ea sit amet facere. Blanditiis non et.
+        </p>
+        <div slot="meta">Some meta</div>
+        <Button as="a" href="#post" slot="cta">Read more</Button>
+      </CardComponent>
+    </CodePreview>
+    <Heading>With heading, body and cover</Heading>
+    <CodePreview
+      code={`<Card>
+  <Img
+    alt="The card cover"
+    height={480}
+    slot="cover"
+    src="https://picsum.photos/640/480"
+    width={640}
+  />
+  <Heading as="h3" slot="heading">The card title</Heading>
+  <p>
+    Ut consequuntur modi. Accusantium quia unde sint suscipit ipsum. Sunt
+    voluptates earum ea cumque eligendi voluptate iste architecto dolores.
+    Sit impedit cum non voluptates at qui ducimus eveniet reiciendis. Ad
+    voluptate dolor dicta ea sit amet facere. Blanditiis non et.
+  </p>
+</Card>`}
+      label="Using a heading and a cover"
+      lang="astro"
     >
-      <Heading>With title, body, cover and meta</Heading>
-    </Box>
-    <CardComponent>
-      <Img
-        alt="The card cover"
-        height={480}
-        slot="cover"
-        src="https://picsum.photos/640/480"
-        width={640}
-      />
-      <Heading as="h3" slot="heading">The card title</Heading>
-      <p>
-        Ut consequuntur modi. Accusantium quia unde sint suscipit ipsum. Sunt
-        voluptates earum ea cumque eligendi voluptate iste architecto dolores.
-        Sit impedit cum non voluptates at qui ducimus eveniet reiciendis. Ad
-        voluptate dolor dicta ea sit amet facere. Blanditiis non et.
-      </p>
-      <div slot="meta">Some meta</div>
-    </CardComponent>
-    <Box
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced
+      <CardComponent>
+        <Img
+          alt="The card cover"
+          height={480}
+          slot="cover"
+          src="https://picsum.photos/640/480"
+          width={640}
+        />
+        <Heading as="h3" slot="heading">The card title</Heading>
+        <p>
+          Ut consequuntur modi. Accusantium quia unde sint suscipit ipsum. Sunt
+          voluptates earum ea cumque eligendi voluptate iste architecto dolores.
+          Sit impedit cum non voluptates at qui ducimus eveniet reiciendis. Ad
+          voluptate dolor dicta ea sit amet facere. Blanditiis non et.
+        </p>
+      </CardComponent>
+    </CodePreview>
+    <Heading>With heading, body, cover and meta</Heading>
+    <CodePreview
+      code={`<Card>
+  <Img
+    alt="The card cover"
+    height={480}
+    slot="cover"
+    src="https://picsum.photos/640/480"
+    width={640}
+  />
+  <Heading as="h3" slot="heading">The card title</Heading>
+  <p>
+    Ut consequuntur modi. Accusantium quia unde sint suscipit ipsum. Sunt
+    voluptates earum ea cumque eligendi voluptate iste architecto dolores.
+    Sit impedit cum non voluptates at qui ducimus eveniet reiciendis. Ad
+    voluptate dolor dicta ea sit amet facere. Blanditiis non et.
+  </p>
+  <div slot="meta">Some meta</div>
+</Card>`}
+      label="Using a heading, a cover and some meta"
+      lang="astro"
     >
-      <Heading>With all</Heading>
-    </Box>
-    <CardComponent>
-      <span slot="frontmatter">Category</span>
-      <Img
-        alt="The card cover"
-        height={480}
-        slot="cover"
-        src="https://picsum.photos/640/480"
-        width={640}
-      />
-      <Heading as="h3" slot="heading">The card title</Heading>
-      <p>
-        Ut consequuntur modi. Accusantium quia unde sint suscipit ipsum. Sunt
-        voluptates earum ea cumque eligendi voluptate iste architecto dolores.
-        Sit impedit cum non voluptates at qui ducimus eveniet reiciendis. Ad
-        voluptate dolor dicta ea sit amet facere. Blanditiis non et.
-      </p>
-      <div slot="meta">Some meta</div>
-      <Button as="a" href="#post" slot="cta">Read more</Button>
-    </CardComponent>
-    <Box
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced
+      <CardComponent>
+        <Img
+          alt="The card cover"
+          height={480}
+          slot="cover"
+          src="https://picsum.photos/640/480"
+          width={640}
+        />
+        <Heading as="h3" slot="heading">The card title</Heading>
+        <p>
+          Ut consequuntur modi. Accusantium quia unde sint suscipit ipsum. Sunt
+          voluptates earum ea cumque eligendi voluptate iste architecto dolores.
+          Sit impedit cum non voluptates at qui ducimus eveniet reiciendis. Ad
+          voluptate dolor dicta ea sit amet facere. Blanditiis non et.
+        </p>
+        <div slot="meta">Some meta</div>
+      </CardComponent>
+    </CodePreview>
+    <Heading>With everything</Heading>
+    <CodePreview
+      code={`<Card>
+  <span slot="frontmatter">Category</span>
+  <Img
+    alt="The card cover"
+    height={480}
+    slot="cover"
+    src="https://picsum.photos/640/480"
+    width={640}
+  />
+  <Heading as="h3" slot="heading">The card title</Heading>
+  <p>
+    Ut consequuntur modi. Accusantium quia unde sint suscipit ipsum. Sunt
+    voluptates earum ea cumque eligendi voluptate iste architecto dolores.
+    Sit impedit cum non voluptates at qui ducimus eveniet reiciendis. Ad
+    voluptate dolor dicta ea sit amet facere. Blanditiis non et.
+  </p>
+  <div slot="meta">Some meta</div>
+  <Button as="a" href="#post" slot="cta">Read more</Button>
+</Card>`}
+      label="Using every slots"
+      lang="astro"
     >
-      <Heading>With linked heading without cta</Heading>
-    </Box>
-    <CardComponent>
-      <Img
-        alt="The card cover"
-        height={480}
-        slot="cover"
-        src="https://picsum.photos/640/480"
-        width={640}
-      />
-      <Heading as="h3" slot="heading">
-        <Link href="#the-post">The card title</Link>
-      </Heading>
-      <p>
-        Ut consequuntur modi. Accusantium quia unde sint suscipit ipsum. Sunt
-        voluptates earum ea cumque eligendi voluptate iste architecto dolores.
-        Sit impedit cum non voluptates at qui ducimus eveniet reiciendis. Ad
-        voluptate dolor dicta ea sit amet facere. Blanditiis non et.
-      </p>
-      <div slot="meta">Some meta</div>
-    </CardComponent>
-    <Box
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced
+      <CardComponent>
+        <span slot="frontmatter">Category</span>
+        <Img
+          alt="The card cover"
+          height={480}
+          slot="cover"
+          src="https://picsum.photos/640/480"
+          width={640}
+        />
+        <Heading as="h3" slot="heading">The card title</Heading>
+        <p>
+          Ut consequuntur modi. Accusantium quia unde sint suscipit ipsum. Sunt
+          voluptates earum ea cumque eligendi voluptate iste architecto dolores.
+          Sit impedit cum non voluptates at qui ducimus eveniet reiciendis. Ad
+          voluptate dolor dicta ea sit amet facere. Blanditiis non et.
+        </p>
+        <div slot="meta">Some meta</div>
+        <Button as="a" href="#post" slot="cta">Read more</Button>
+      </CardComponent>
+    </CodePreview>
+    <Heading>With a link wrapped in a heading and without cta</Heading>
+    <CodePreview
+      code={`<Card>
+  <Img
+    alt="The card cover"
+    height={480}
+    slot="cover"
+    src="https://picsum.photos/640/480"
+    width={640}
+  />
+  <Heading as="h3" slot="heading">
+    <Link href="#the-post">The card title</Link>
+  </Heading>
+  <p>
+    Ut consequuntur modi. Accusantium quia unde sint suscipit ipsum. Sunt
+    voluptates earum ea cumque eligendi voluptate iste architecto dolores.
+    Sit impedit cum non voluptates at qui ducimus eveniet reiciendis. Ad
+    voluptate dolor dicta ea sit amet facere. Blanditiis non et.
+  </p>
+  <div slot="meta">Some meta</div>
+</Card>`}
+      label="Using a link in a heading without other cta"
+      lang="astro"
     >
-      <Heading>With all and a very long excerpt</Heading>
-    </Box>
-    <CardComponent>
-      <span slot="frontmatter">Category</span>
-      <Img
-        alt="The card cover"
-        height={480}
-        slot="cover"
-        src="https://picsum.photos/640/480"
-        width={640}
-      />
-      <Heading as="h3" slot="heading">The card title</Heading>
-      <p>
-        Ut consequuntur modi. Accusantium quia unde sint suscipit ipsum. Sunt
-        voluptates earum ea cumque eligendi voluptate iste architecto dolores.
-        Sit impedit cum non voluptates at qui ducimus eveniet reiciendis. Ad
-        voluptate dolor dicta ea sit amet facere. Blanditiis non et.
-      </p>
-      <p>
-        Vero omnis quas iste sunt vitae qui. Rem ut qui pariatur autem sed.
-        Asperiores ipsum laborum consequuntur veniam ad quasi voluptates quia
-        quia. Doloremque vel est et recusandae aliquid neque aut nemo
-        perspiciatis.
-      </p>
-      <p>
-        Quia beatae aliquam iusto soluta velit. Illo quam perferendis in
-        corrupti blanditiis delectus. Ratione omnis et cum earum consequatur
-        recusandae repellendus. Enim qui maiores eaque voluptate tempora ut
-        aliquam. Fugit laborum sint reiciendis quo corporis dolor nihil et.
-        Nesciunt deserunt incidunt animi voluptas nihil animi debitis.
-      </p>
-      <p>
-        Error ea voluptatem amet consectetur. Totam neque in ut eum ducimus.
-        Dolores est quam rerum necessitatibus aut ad et doloremque. Quae quia
-        sint quis nihil accusamus et. Explicabo placeat esse. Quo necessitatibus
-        voluptate deleniti sequi debitis delectus.
-      </p>
-      <div slot="meta">Some meta</div>
-      <Button as="a" href="#post" slot="cta">Read more</Button>
-    </CardComponent>
-    <Box
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced
+      <CardComponent>
+        <Img
+          alt="The card cover"
+          height={480}
+          slot="cover"
+          src="https://picsum.photos/640/480"
+          width={640}
+        />
+        <Heading as="h3" slot="heading">
+          <Link href="#the-post">The card title</Link>
+        </Heading>
+        <p>
+          Ut consequuntur modi. Accusantium quia unde sint suscipit ipsum. Sunt
+          voluptates earum ea cumque eligendi voluptate iste architecto dolores.
+          Sit impedit cum non voluptates at qui ducimus eveniet reiciendis. Ad
+          voluptate dolor dicta ea sit amet facere. Blanditiis non et.
+        </p>
+        <div slot="meta">Some meta</div>
+      </CardComponent>
+    </CodePreview>
+    <Heading>With all and a very long excerpt</Heading>
+    <CodePreview
+      code={`<Card>
+  <span slot="frontmatter">Category</span>
+  <Img
+    alt="The card cover"
+    height={480}
+    slot="cover"
+    src="https://picsum.photos/640/480"
+    width={640}
+  />
+  <Heading as="h3" slot="heading">The card title</Heading>
+  <p>
+    Ut consequuntur modi. Accusantium quia unde sint suscipit ipsum. Sunt
+    voluptates earum ea cumque eligendi voluptate iste architecto dolores.
+    Sit impedit cum non voluptates at qui ducimus eveniet reiciendis. Ad
+    voluptate dolor dicta ea sit amet facere. Blanditiis non et.
+  </p>
+  <p>
+    Vero omnis quas iste sunt vitae qui. Rem ut qui pariatur autem sed.
+    Asperiores ipsum laborum consequuntur veniam ad quasi voluptates quia
+    quia. Doloremque vel est et recusandae aliquid neque aut nemo
+    perspiciatis.
+  </p>
+  <p>
+    Quia beatae aliquam iusto soluta velit. Illo quam perferendis in
+    corrupti blanditiis delectus. Ratione omnis et cum earum consequatur
+    recusandae repellendus. Enim qui maiores eaque voluptate tempora ut
+    aliquam. Fugit laborum sint reiciendis quo corporis dolor nihil et.
+    Nesciunt deserunt incidunt animi voluptas nihil animi debitis.
+  </p>
+  <p>
+    Error ea voluptatem amet consectetur. Totam neque in ut eum ducimus.
+    Dolores est quam rerum necessitatibus aut ad et doloremque. Quae quia
+    sint quis nihil accusamus et. Explicabo placeat esse. Quo
+    necessitatibus voluptate deleniti sequi debitis delectus.
+  </p>
+  <div slot="meta">Some meta</div>
+  <Button as="a" href="#post" slot="cta">Read more</Button>
+</Card>`}
+      label="Using a link in a heading without other cta"
+      lang="astro"
     >
-      <Heading>Outside a container</Heading>
-      <p>
-        If you don't wrap the Card in a container, its appearance on large
-        screens will be the same as the mobile view. You cannot see the
-        difference here since main is a container.
-      </p>
-    </Box>
+      <CardComponent>
+        <span slot="frontmatter">Category</span>
+        <Img
+          alt="The card cover"
+          height={480}
+          slot="cover"
+          src="https://picsum.photos/640/480"
+          width={640}
+        />
+        <Heading as="h3" slot="heading">The card title</Heading>
+        <p>
+          Ut consequuntur modi. Accusantium quia unde sint suscipit ipsum. Sunt
+          voluptates earum ea cumque eligendi voluptate iste architecto dolores.
+          Sit impedit cum non voluptates at qui ducimus eveniet reiciendis. Ad
+          voluptate dolor dicta ea sit amet facere. Blanditiis non et.
+        </p>
+        <p>
+          Vero omnis quas iste sunt vitae qui. Rem ut qui pariatur autem sed.
+          Asperiores ipsum laborum consequuntur veniam ad quasi voluptates quia
+          quia. Doloremque vel est et recusandae aliquid neque aut nemo
+          perspiciatis.
+        </p>
+        <p>
+          Quia beatae aliquam iusto soluta velit. Illo quam perferendis in
+          corrupti blanditiis delectus. Ratione omnis et cum earum consequatur
+          recusandae repellendus. Enim qui maiores eaque voluptate tempora ut
+          aliquam. Fugit laborum sint reiciendis quo corporis dolor nihil et.
+          Nesciunt deserunt incidunt animi voluptas nihil animi debitis.
+        </p>
+        <p>
+          Error ea voluptatem amet consectetur. Totam neque in ut eum ducimus.
+          Dolores est quam rerum necessitatibus aut ad et doloremque. Quae quia
+          sint quis nihil accusamus et. Explicabo placeat esse. Quo
+          necessitatibus voluptate deleniti sequi debitis delectus.
+        </p>
+        <div slot="meta">Some meta</div>
+        <Button as="a" href="#post" slot="cta">Read more</Button>
+      </CardComponent>
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/molecules/card/card.stories.astro
+++ b/src/components/molecules/card/card.stories.astro
@@ -1,5 +1,5 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import Box from "../../atoms/box/box.astro";
 import Button from "../../atoms/button/button.astro";
 import Heading from "../../atoms/heading/heading.astro";
@@ -9,22 +9,13 @@ import PageLayout from "../../templates/page-layout/page-layout.astro";
 import CardComponent from "./card.astro";
 
 const title = "Card";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Molecules", url: "/design-system/components/molecules" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "molecules",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>

--- a/src/components/molecules/cards-list/cards-list.stories.astro
+++ b/src/components/molecules/cards-list/cards-list.stories.astro
@@ -1,11 +1,10 @@
 ---
 import { getStoryMeta } from "../../../utils/stories";
-import Box from "../../atoms/box/box.astro";
 import Heading from "../../atoms/heading/heading.astro";
 import Link from "../../atoms/link/link.astro";
-import ListItem from "../../atoms/list/list-item.astro";
-import List from "../../atoms/list/list.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
+import Card from "../card/card.astro";
+import CodePreview from "../code-preview/code-preview.astro";
 import CardsListComponent from "./cards-list.astro";
 
 const title = "CardsList";
@@ -43,7 +42,7 @@ const items = [
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading as="h2">Usage</Heading>
+    <Heading as="h2">Introduction</Heading>
     <p>
       When using a <code>CardsList</code> component, you'll need to provide a function
       as child that describes how to render the given items. See the example at the
@@ -53,32 +52,39 @@ const items = [
       > section in Astro documentation. If you want to specify the columns, you can
       use the <code>--cols</code> CSS variable.
     </p>
-  </Fragment>
-  <Fragment slot="disconnected-body">
-    <Box
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced
+    <CodePreview
+      code={`import CardsList from "./components/molecules/cards-list/cards-list.astro";`}
+      label="How to import"
+      lang="ts"
+    />
+    <CodePreview
+      code={`<CardsList items={items}>
+  {
+    (item: (typeof items)[number]) => (
+      <Card>
+        <Heading as="h3" slot="heading">
+          <Link href={item.url}>{item.heading}</Link>
+        </Heading>
+        {item.body}
+      </Card>
+    )
+  }
+</CardsList>`}
+      label="Basic use"
+      lang="astro"
     >
-      <Heading as="h2">Default</Heading>
-    </Box>
-    <CardsListComponent items={items}>
-      {
-        (item: (typeof items)[number]) => (
-          <Box isPadded>
-            <p>Received:</p>
-            <List>
-              <ListItem>Body: {item.body}</ListItem>
-              <ListItem>Heading: {item.heading}</ListItem>
-              <ListItem>Url: {item.url}</ListItem>
-            </List>
-          </Box>
-        )
-      }
-    </CardsListComponent>
+      <CardsListComponent items={items}>
+        {
+          (item: (typeof items)[number]) => (
+            <Card>
+              <Heading as="h3" slot="heading">
+                <Link href={item.url}>{item.heading}</Link>
+              </Heading>
+              {item.body}
+            </Card>
+          )
+        }
+      </CardsListComponent>
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/molecules/cards-list/cards-list.stories.astro
+++ b/src/components/molecules/cards-list/cards-list.stories.astro
@@ -1,5 +1,5 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import Box from "../../atoms/box/box.astro";
 import Heading from "../../atoms/heading/heading.astro";
 import Link from "../../atoms/link/link.astro";
@@ -9,22 +9,13 @@ import PageLayout from "../../templates/page-layout/page-layout.astro";
 import CardsListComponent from "./cards-list.astro";
 
 const title = "CardsList";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Molecules", url: "/design-system/components/molecules" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "molecules",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 
 const items = [
   {

--- a/src/components/molecules/code-block/code-block.stories.astro
+++ b/src/components/molecules/code-block/code-block.stories.astro
@@ -1,26 +1,17 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import CodeBlockComponent from "./code-block.astro";
 
 const title = "CodeBlock";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Molecules", url: "/design-system/components/molecules" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "molecules",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 
 const jsCodeSample = `
 console.log("Hello world!");

--- a/src/components/molecules/code-block/code-block.stories.astro
+++ b/src/components/molecules/code-block/code-block.stories.astro
@@ -2,6 +2,7 @@
 import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
+import CodePreview from "../code-preview/code-preview.astro";
 import CodeBlockComponent from "./code-block.astro";
 
 const title = "CodeBlock";
@@ -58,33 +59,115 @@ const complexDiffCodeSample = `
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
+    <Heading>Introduction</Heading>
+    <CodePreview
+      code={`import CodeBlock from "./components/molecules/code-block/code-block.astro";`}
+      label="How to import"
+      lang="ts"
+    />
+    <CodePreview
+      code={`<CodeBlock code={jsCodeSample} />`}
+      label="Basic use"
+      lang="astro"
+    >
+      <CodeBlockComponent code={jsCodeSample} />
+    </CodePreview>
     <Heading as="h2">With lang</Heading>
-    <CodeBlockComponent code={jsCodeSample} lang="js" />
+    <CodePreview
+      code={`<CodeBlock code={jsCodeSample} lang="js" />`}
+      label="Using a lang"
+      lang="astro"
+    >
+      <CodeBlockComponent code={jsCodeSample} lang="js" />
+    </CodePreview>
     <Heading as="h2">With file path</Heading>
-    <CodeBlockComponent
-      code={jsCodeSample}
-      filePath="./hello-world.js"
-      lang="js"
-    />
+    <CodePreview
+      code={`<CodeBlock code={jsCodeSample} filePath="./hello-world.js" lang="js" />`}
+      label="Using a lang with a file path"
+      lang="astro"
+    >
+      <CodeBlockComponent
+        code={jsCodeSample}
+        filePath="./hello-world.js"
+        lang="js"
+      />
+    </CodePreview>
     <Heading as="h2">With line numbers</Heading>
-    <CodeBlockComponent code={jsCodeSample} lang="js" showLineNumbers />
+    <CodePreview
+      code={`<CodeBlock code={jsCodeSample} lang="js" showLineNumbers />`}
+      label="Using line numbers"
+      lang="astro"
+    >
+      <CodeBlockComponent code={jsCodeSample} lang="js" showLineNumbers />
+    </CodePreview>
     <Heading as="h2">With line numbers and custom starting line</Heading>
-    <CodeBlockComponent
-      code={jsCodeSample}
-      lang="js"
-      lineStart={5}
-      showLineNumbers
-    />
+    <CodePreview
+      code={`<CodeBlock
+  code={jsCodeSample}
+  lang="js"
+  lineStart={5}
+  showLineNumbers
+/>`}
+      label="Using line numbers with a custom starting line"
+      lang="astro"
+    >
+      <CodeBlockComponent
+        code={jsCodeSample}
+        lang="js"
+        lineStart={5}
+        showLineNumbers
+      />
+    </CodePreview>
     <Heading as="h2">With prompt</Heading>
-    <CodeBlockComponent code={commandLineCodeSample} lang="shell" showPrompt />
+    <CodePreview
+      code={`<CodeBlock code={commandLineCodeSample} lang="shell" showPrompt />`}
+      label="Using a prompt"
+      lang="astro"
+    >
+      <CodeBlockComponent
+        code={commandLineCodeSample}
+        lang="shell"
+        showPrompt
+      />
+    </CodePreview>
     <Heading as="h2">With prompt and custom username</Heading>
-    <CodeBlockComponent
-      code={commandLineCodeSample}
-      lang="shell"
-      promptUser="john"
-      showPrompt
-    />
+    <CodePreview
+      code={`<CodeBlock
+  code={commandLineCodeSample}
+  lang="shell"
+  promptUser="john"
+  showPrompt
+/>`}
+      label="Using a prompt with a custom user"
+      lang="astro"
+    >
+      <CodeBlockComponent
+        code={commandLineCodeSample}
+        lang="shell"
+        promptUser="john"
+        showPrompt
+      />
+    </CodePreview>
     <Heading as="h2">With prompt and custom host</Heading>
+    <CodePreview
+      code={`<CodeBlock
+  code={commandLineCodeSample}
+  lang="shell"
+  promptHost="doe"
+  promptUser="john"
+  showPrompt
+/>`}
+      label="Using a prompt with a custom host"
+      lang="astro"
+    >
+      <CodeBlockComponent
+        code={commandLineCodeSample}
+        lang="shell"
+        promptHost="doe"
+        promptUser="john"
+        showPrompt
+      />
+    </CodePreview>
     <CodeBlockComponent
       code={commandLineCodeSample}
       lang="shell"
@@ -93,49 +176,96 @@ const complexDiffCodeSample = `
       showPrompt
     />
     <Heading as="h2">With prompt as root</Heading>
-    <CodeBlockComponent
-      code="nano /etc/hosts"
-      lang="shell"
-      promptUser="root"
-      showPrompt
-    />
+    <CodePreview
+      code={`<CodeBlock
+  code={commandLineCodeSample}
+  lang="shell"
+  promptUser="root"
+  showPrompt
+/>`}
+      label="Using a prompt as root"
+      lang="astro"
+    >
+      <CodeBlockComponent
+        code={commandLineCodeSample}
+        lang="shell"
+        promptUser="root"
+        showPrompt
+      />
+    </CodePreview>
     <Heading as="h2">With SQL prompt</Heading>
-    <CodeBlockComponent code={sqlCodeSample} lang="sql" showPrompt />
+    <CodePreview
+      code={`<CodeBlock code={sqlCodeSample} lang="sql" showPrompt />`}
+      label="Using an SQL prompt"
+      lang="astro"
+    >
+      <CodeBlockComponent code={sqlCodeSample} lang="sql" showPrompt />
+    </CodePreview>
     <Heading as="h2">With SQL prompt and custom prompt host</Heading>
-    <CodeBlockComponent
-      code={sqlCodeSample}
-      lang="sql"
-      promptHost="MariaDB"
-      showPrompt
-    />
+    <CodePreview
+      code={`<CodeBlock code={sqlCodeSample} lang="sql" promptHost="MariaDB" showPrompt />`}
+      label="Using a prompt with a custom host"
+      lang="astro"
+    >
+      <CodeBlockComponent
+        code={sqlCodeSample}
+        lang="sql"
+        promptHost="MariaDB"
+        showPrompt
+      />
+    </CodePreview>
     <Heading as="h2">With SQL prompt and custom database name</Heading>
-    <CodeBlockComponent
-      code={sqlCodeSample}
-      lang="sql"
-      promptDB="recipes"
-      showPrompt
-    />
+    <CodePreview
+      code={`<CodeBlock code={sqlCodeSample} lang="sql" promptDB="recipes" showPrompt />`}
+      label="Using a prompt with a custom database"
+      lang="astro"
+    >
+      <CodeBlockComponent
+        code={sqlCodeSample}
+        lang="sql"
+        promptDB="recipes"
+        showPrompt
+      />
+    </CodePreview>
     <Heading as="h2">Diff</Heading>
-    <CodeBlockComponent code={diffCodeSample} lang="diff" showLineNumbers />
+    <CodePreview
+      code={`<CodeBlock code={diffCodeSample} lang="diff" showLineNumbers />`}
+      label="Using a diff"
+      lang="astro"
+    >
+      <CodeBlockComponent code={diffCodeSample} lang="diff" showLineNumbers />
+    </CodePreview>
     <Heading as="h2">Diff with syntax highlighting</Heading>
-    <CodeBlockComponent
-      code={diffCodeSample}
-      isDiff
-      lang="ts"
-      showLineNumbers
-    />
-    <Heading as="h2">A complex diff example</Heading>
+    <CodePreview
+      code={`<CodeBlock code={diffCodeSample} isDiff lang="ts" showLineNumbers />`}
+      label="Using a diff with syntax highlighting"
+      lang="astro"
+    >
+      <CodeBlockComponent
+        code={diffCodeSample}
+        isDiff
+        lang="ts"
+        showLineNumbers
+      />
+    </CodePreview>
+    <Heading as="h2">Limitations</Heading>
     <p>
       Ideally, I'd like that removed lines affects the line numbers for the next
       lines but due to <code>counter</code> limitations, it seems impossible with
       CSS only when having multiple removed lines at once. So this type of blocks
       should be avoided.
     </p>
-    <CodeBlockComponent
-      code={complexDiffCodeSample}
-      isDiff
-      lang="css"
-      showLineNumbers
-    />
+    <CodePreview
+      code={`<CodeBlock code={complexDiffCodeSample} isDiff lang="css" showLineNumbers />`}
+      label="Using a diff with syntax highlighting"
+      lang="astro"
+    >
+      <CodeBlockComponent
+        code={complexDiffCodeSample}
+        isDiff
+        lang="css"
+        showLineNumbers
+      />
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/molecules/code-preview/code-preview.astro
+++ b/src/components/molecules/code-preview/code-preview.astro
@@ -1,0 +1,84 @@
+---
+import type { ComponentProps } from "astro/types";
+import { Code } from "astro:components";
+import { shikiTheme } from "../../../lib/shiki/theme";
+
+type Props = Pick<ComponentProps<typeof Code>, "lang" | "wrap"> & {
+  code?: string | null | undefined;
+  label?: string | null | undefined;
+};
+
+const { code, label, lang = "text", wrap = false } = Astro.props;
+const hasUseAndPreview = code && Astro.slots.has("default");
+---
+
+<figure class="code-preview">
+  {label ? <figcaption>{label}</figcaption> : null}
+  {
+    code ? (
+      <div class="use">
+        {hasUseAndPreview && <div class="use-label">Use</div>}
+        {/* prettier-ignore */}
+        <Code class="use-content" code={code} lang={lang} theme={shikiTheme} wrap={wrap} />
+      </div>
+    ) : null
+  }
+  {
+    Astro.slots.has("default") ? (
+      <div class="preview">
+        {hasUseAndPreview && <div class="preview-label">Preview</div>}
+        <div class="preview-content">
+          <slot />
+        </div>
+      </div>
+    ) : null
+  }
+</figure>
+
+<style>
+  .code-preview {
+    margin-inline: 0;
+    background: var(--color-regular-dark);
+    border: var(--border-size-sm) solid var(--color-border);
+    border-radius: var(--border-radii-md);
+  }
+
+  figcaption {
+    padding: var(--spacing-xs) var(--spacing-sm);
+    background: var(--color-regular-darker);
+    border-block-end: var(--border-size-sm) solid var(--color-border);
+  }
+
+  .use-label,
+  .preview-label {
+    padding-block: var(--spacing-xs) var(--spacing-2xs);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-bold);
+  }
+
+  .use-content {
+    margin: 0;
+    font-family: var(--font-family-mono);
+  }
+
+  .use,
+  .preview {
+    margin-top: 0;
+    padding: 0 var(--spacing-sm) var(--spacing-sm);
+
+    &:where(:not(:has(.use-label, .preview-label))) {
+      padding-block-start: var(--spacing-sm);
+    }
+  }
+
+  :where(.code-preview:has(.use)) .preview {
+    border-block-start: var(--border-size-sm) solid var(--color-border);
+  }
+
+  .use-content,
+  .preview-content {
+    padding: var(--spacing-md);
+    background: var(--color-regular);
+    border: var(--border-size-sm) solid var(--color-border);
+  }
+</style>

--- a/src/components/molecules/collapsible/collapsible.stories.astro
+++ b/src/components/molecules/collapsible/collapsible.stories.astro
@@ -1,8 +1,8 @@
 ---
 import { getStoryMeta } from "../../../utils/stories";
-import Box from "../../atoms/box/box.astro";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
+import CodePreview from "../code-preview/code-preview.astro";
 import CollapsibleComponent from "./collapsible.astro";
 
 const title = "Collapsible";
@@ -17,31 +17,34 @@ const { breadcrumb, seo } = getStoryMeta({
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading as="h2">Usage</Heading>
+    <Heading as="h2">Introduction</Heading>
     <p>
       This component let you toggle the visibility of its contents by clicking
       on its label.
     </p>
-  </Fragment>
-  <Fragment slot="disconnected-body">
-    <CollapsibleComponent>
-      <span slot="label">A label</span>
-      The collapsible body
-    </CollapsibleComponent>
-    <Box
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced
+    <CodePreview
+      code={`import Collapsible from "./components/molecules/collapsible/collapsible.astro";`}
+      label="How to import"
+      lang="ts"
+    />
+    <CodePreview
+      code={`<Collapsible>
+  <span slot="label">A label</span>
+  The collapsible body
+</Collapsible>`}
+      label="Basic use"
+      lang="astro"
     >
-      <Heading as="h2">Using <code>isProse</code></Heading>
-    </Box>
-    <CollapsibleComponent isProse>
-      <span slot="label">A label</span>
-      The collapsible body
-    </CollapsibleComponent>
+      <CollapsibleComponent>
+        <span slot="label">A label</span>
+        The collapsible body
+      </CollapsibleComponent>
+    </CodePreview>
+    <p>
+      A <code>{`<Collapsible />`}</code> inherits some properties from the <code
+        >{`<Box />`}</code
+      > component. You can, for example, use the <code>isProse</code> property to
+      limit its width.
+    </p>
   </Fragment>
 </PageLayout>

--- a/src/components/molecules/collapsible/collapsible.stories.astro
+++ b/src/components/molecules/collapsible/collapsible.stories.astro
@@ -1,27 +1,18 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import Box from "../../atoms/box/box.astro";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import CollapsibleComponent from "./collapsible.astro";
 
 const title = "Collapsible";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Molecules", url: "/design-system/components/molecules" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "molecules",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>

--- a/src/components/molecules/copy-to-clipboard/copy-to-clipboard.stories.astro
+++ b/src/components/molecules/copy-to-clipboard/copy-to-clipboard.stories.astro
@@ -2,6 +2,7 @@
 import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
+import CodePreview from "../code-preview/code-preview.astro";
 import CopyToClipboardComponent from "./copy-to-clipboard.astro";
 
 const title = "CopyToClipboard";
@@ -16,34 +17,65 @@ const { breadcrumb, seo } = getStoryMeta({
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading as="h2">Usage</Heading>
+    <Heading as="h2">Introduction</Heading>
     <p>
       A <code>CopyToClipboard</code> component should be used as a call to action
       to let users copy some contents to their clipboard with a simple click.
     </p>
+    <CodePreview
+      code={`import CopyToClipboard from "./components/molecules/copy-to-clipboard/copy-to-clipboard.astro";`}
+      label="How to import"
+      lang="ts"
+    />
     <Heading as="h2">Example 1</Heading>
     <p>The copy button can copy a text in an element next to the button.</p>
-    <div id="example1">
-      <CopyToClipboardComponent
-        feedback="Copied!"
-        label="Copy example 1"
-        selector="#example1 > div"
-      />
-      <div>The contents to copy to the clipboard.</div>
-    </div>
+    <CodePreview
+      code={`<div id="example1">
+  <CopyToClipboard
+    feedback="Copied!"
+    label="Copy example 1"
+    selector="#example1 > div"
+  />
+  <div>The contents to copy to the clipboard.</div>
+</div>`}
+      label="Using the button before the text to copy"
+      lang="astro"
+    >
+      <div id="example1">
+        <CopyToClipboardComponent
+          feedback="Copied!"
+          label="Copy example 1"
+          selector="#example1 > div"
+        />
+        <div>The contents to copy to the clipboard.</div>
+      </div>
+    </CodePreview>
     <Heading as="h2">Example 2</Heading>
     <p>
       The copy button can copy a text in an element placed before the button.
     </p>
-    <pre
-      id="example2">
+    <CodePreview
+      code={`<pre id="example2">
+  <code>console.log("Hello, world!");</code>
+</pre>
+<CopyToClipboard
+  feedback="Code copied!"
+  label="Copy code in example 2"
+  selector="pre > code"
+/>`}
+      label="Using the button after the text to copy"
+      lang="astro"
+    >
+      <pre
+        id="example2">
           <code>console.log("Hello, world!");</code>
-        </pre>
-    <CopyToClipboardComponent
-      feedback="Code copied!"
-      label="Copy code in example 2"
-      selector="pre > code"
-    />
+      </pre>
+      <CopyToClipboardComponent
+        feedback="Code copied!"
+        label="Copy code in example 2"
+        selector="pre > code"
+      />
+    </CodePreview>
     <Heading as="h2">Example 3</Heading>
     <p>
       The copy button can look for the text to copy using an ancestor of the
@@ -51,21 +83,41 @@ const { breadcrumb, seo } = getStoryMeta({
       you use a generic
       <code>selector</code> which is repeated multiple times across the document.
     </p>
+    <CodePreview
+      code={`<div>
+  <div>
     <div>
+      <CopyToClipboard
+        feedback="Answer copied!"
+        label="Copy code in example 3"
+        lookUpNodeLvl={3}
+        selector="code"
+      />
+    </div>
+  </div>
+  <pre>
+    <code>console.log("The answer to universe is 42!");</code>
+  </pre>
+</div>`}
+      label="Using the lookUpNodeLvl property"
+      lang="astro"
+    >
       <div>
         <div>
-          <CopyToClipboardComponent
-            feedback="Answer copied!"
-            label="Copy code in example 3"
-            lookUpNodeLvl={3}
-            selector="code"
-          />
+          <div>
+            <CopyToClipboardComponent
+              feedback="Answer copied!"
+              label="Copy code in example 3"
+              lookUpNodeLvl={3}
+              selector="code"
+            />
+          </div>
         </div>
+        <pre>
+          <code>console.log("The answer to universe is 42!");</code>
+        </pre>
       </div>
-      <pre>
-            <code>console.log("The answer to universe is 42!");</code>
-          </pre>
-    </div>
+    </CodePreview>
     <p>
       Without <code>lookUpNodeLvl</code>, the button would have copied the
       previous example instead of this one when using <code>code</code> as <code

--- a/src/components/molecules/copy-to-clipboard/copy-to-clipboard.stories.astro
+++ b/src/components/molecules/copy-to-clipboard/copy-to-clipboard.stories.astro
@@ -1,26 +1,17 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import CopyToClipboardComponent from "./copy-to-clipboard.astro";
 
 const title = "CopyToClipboard";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Molecules", url: "/design-system/components/molecules" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "molecules",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>

--- a/src/components/molecules/greetings/greetings.stories.astro
+++ b/src/components/molecules/greetings/greetings.stories.astro
@@ -1,26 +1,18 @@
 ---
 import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import GreetingsComponent from "./greetings.astro";
 
 const title = "Greetings";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Molecules", url: "/design-system/components/molecules" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "molecules",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 
 const props: ComponentProps<typeof GreetingsComponent> = {
   name: "John Doe",

--- a/src/components/molecules/greetings/greetings.stories.astro
+++ b/src/components/molecules/greetings/greetings.stories.astro
@@ -1,8 +1,8 @@
 ---
-import type { ComponentProps } from "astro/types";
 import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
+import CodePreview from "../code-preview/code-preview.astro";
 import GreetingsComponent from "./greetings.astro";
 
 const title = "Greetings";
@@ -13,19 +13,26 @@ const { breadcrumb, seo } = getStoryMeta({
     title,
   },
 });
-
-const props: ComponentProps<typeof GreetingsComponent> = {
-  name: "John Doe",
-};
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading as="h2">Usage</Heading>
+    <Heading as="h2">Introduction</Heading>
     <p>
       The <code>Greetings</code> component should be used on a homepage to introduce
       the author of the website.
     </p>
-    <GreetingsComponent {...props} />
+    <CodePreview
+      code={`import Greetings from "./components/molecules/greetings/greetings.astro";`}
+      label="How to import"
+      lang="ts"
+    />
+    <CodePreview
+      code={`<Greetings name="John Doe" />`}
+      label="Basic use"
+      lang="astro"
+    >
+      <GreetingsComponent name="John Doe" />
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/molecules/labelled-field/labelled-field.stories.astro
+++ b/src/components/molecules/labelled-field/labelled-field.stories.astro
@@ -1,5 +1,5 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import Label from "../../atoms/label/label.astro";
 import ListItem from "../../atoms/list/list-item.astro";
@@ -9,22 +9,13 @@ import PageLayout from "../../templates/page-layout/page-layout.astro";
 import LabelledFieldComponent from "./labelled-field.astro";
 
 const title = "LabelledField";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Molecules", url: "/design-system/components/molecules" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "molecules",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>

--- a/src/components/molecules/labelled-field/labelled-field.stories.astro
+++ b/src/components/molecules/labelled-field/labelled-field.stories.astro
@@ -6,6 +6,7 @@ import ListItem from "../../atoms/list/list-item.astro";
 import List from "../../atoms/list/list.astro";
 import TextField from "../../atoms/text-field/text-field.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
+import CodePreview from "../code-preview/code-preview.astro";
 import LabelledFieldComponent from "./labelled-field.astro";
 
 const title = "LabelledField";
@@ -20,105 +21,237 @@ const { breadcrumb, seo } = getStoryMeta({
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading as="h2">Usage</Heading>
+    <Heading as="h2">Introduction</Heading>
     <p>This component is used to display a field and a label tied together.</p>
-    <LabelledFieldComponent>
-      <Label for="usage-example" slot="label">A label</Label>
-      <TextField id="usage-example" slot="field" type="text" />
-    </LabelledFieldComponent>
-    <Heading as="h2">Variant: <code>vertical</code> (default)</Heading>
-    <Heading as="h3">Default</Heading>
-    <LabelledFieldComponent>
-      <Label for="vertical-default" slot="label">A label</Label>
-      <TextField id="vertical-default" slot="field" type="text" />
-    </LabelledFieldComponent>
-    <Heading as="h3">With hint</Heading>
-    <LabelledFieldComponent>
-      <Label for="vertical-hint" slot="label">A label</Label>
-      <TextField id="vertical-hint" slot="field" type="text" />
-      <Fragment slot="hint">A hint about this field.</Fragment>
-    </LabelledFieldComponent>
-    <Heading as="h3">With errors</Heading>
-    <LabelledFieldComponent>
-      <Label for="vertical-errors" slot="label">A label</Label>
-      <TextField id="vertical-errors" slot="field" type="text" />
-      <List slot="errors">
-        <ListItem>error 1 because...</ListItem>
-        <ListItem>error 2 because...</ListItem>
-      </List>
-    </LabelledFieldComponent>
-    <Heading as="h3">With hint, errors and spacing</Heading>
-    <LabelledFieldComponent>
-      <Label for="vertical-hint-errors" slot="label">A label</Label>
-      <TextField id="vertical-hint-errors" slot="field" type="text" />
-      <Fragment slot="hint">A hint about this field.</Fragment>
-      <List slot="errors">
-        <ListItem>error 1 because...</ListItem>
-        <ListItem>error 2 because...</ListItem>
-      </List>
-    </LabelledFieldComponent>
-    <Heading as="h2">Variant: <code>inline</code></Heading>
-    <Heading as="h3">Default</Heading>
-    <LabelledFieldComponent variant="inline">
-      <Label for="inline-default" slot="label">A label</Label>
-      <TextField id="inline-default" slot="field" type="text" />
-    </LabelledFieldComponent>
-    <Heading as="h3">With hint</Heading>
-    <LabelledFieldComponent variant="inline">
-      <Label for="inline-hint" slot="label">A label</Label>
-      <TextField id="inline-hint" slot="field" type="text" />
-      <Fragment slot="hint">A hint about this field.</Fragment>
-    </LabelledFieldComponent>
-    <Heading as="h3">With errors</Heading>
-    <LabelledFieldComponent variant="inline">
-      <Label for="inline-errors" slot="label">A label</Label>
-      <TextField id="inline-errors" slot="field" type="text" />
-      <List slot="errors">
-        <ListItem>error 1 because...</ListItem>
-        <ListItem>error 2 because...</ListItem>
-      </List>
-    </LabelledFieldComponent>
-    <Heading as="h3">With hint, errors and spacing</Heading>
-    <LabelledFieldComponent variant="inline">
-      <Label for="inline-hint-errors" slot="label">A label</Label>
-      <TextField id="inline-hint-errors" slot="field" type="text" />
-      <Fragment slot="hint">A hint about this field.</Fragment>
-      <List slot="errors">
-        <ListItem>error 1 because...</ListItem>
-        <ListItem>error 2 because...</ListItem>
-      </List>
-    </LabelledFieldComponent>
-    <Heading as="h2">Variant: <code>inline-reversed</code></Heading>
+    <CodePreview
+      code={`import LabelledField from "./components/molecules/labelled-field/labelled-field.astro";`}
+      label="How to import"
+      lang="ts"
+    />
+    <CodePreview
+      code={`<LabelledField>
+  <Label for="use-example" slot="label">A label</Label>
+  <TextField id="use-example" slot="field" type="text" />
+</LabelledField>`}
+      label="Basic use"
+      lang="astro"
+    >
+      <LabelledFieldComponent>
+        <Label for="use-example" slot="label">A label</Label>
+        <TextField id="use-example" slot="field" type="text" />
+      </LabelledFieldComponent>
+    </CodePreview>
+    <Heading>Variants</Heading>
     <p>Reversing order can be useful with boolean fields like a checkbox.</p>
-    <Heading as="h3">Default</Heading>
-    <LabelledFieldComponent variant="inline-reversed">
-      <Label for="inline-reversed-default" slot="label">A label</Label>
-      <input id="inline-reversed-default" slot="field" type="checkbox" />
-    </LabelledFieldComponent>
-    <Heading as="h3">With hint</Heading>
-    <LabelledFieldComponent variant="inline-reversed">
-      <Label for="inline-reversed-hint" slot="label">A label</Label>
-      <input id="inline-reversed-hint" slot="field" type="checkbox" />
-      <Fragment slot="hint">A hint about this field.</Fragment>
-    </LabelledFieldComponent>
-    <Heading as="h3">With errors</Heading>
-    <LabelledFieldComponent variant="inline-reversed">
-      <Label for="inline-reversed-errors" slot="label">A label</Label>
-      <input id="inline-reversed-errors" slot="field" type="checkbox" />
-      <List slot="errors">
-        <ListItem>error 1 because...</ListItem>
-        <ListItem>error 2 because...</ListItem>
-      </List>
-    </LabelledFieldComponent>
-    <Heading as="h3">With hint, errors and spacing</Heading>
-    <LabelledFieldComponent variant="inline-reversed">
-      <Label for="inline-reversed-hint-errors" slot="label">A label</Label>
-      <input id="inline-reversed-hint-errors" slot="field" type="checkbox" />
-      <Fragment slot="hint">A hint about this field.</Fragment>
-      <List slot="errors">
-        <ListItem>error 1 because...</ListItem>
-        <ListItem>error 2 because...</ListItem>
-      </List>
-    </LabelledFieldComponent>
+    <CodePreview
+      code={`<LabelledField variant="vertical">
+  <Label for="variant-vertical-example" slot="label">A label</Label>
+  <TextField id="variant-vertical-example" slot="field" type="text" />
+</LabelledField>
+<br />
+<LabelledField variant="inline">
+  <Label for="variant-inline-example" slot="label">A label</Label>
+  <TextField id="variant-inline-example" slot="field" type="text" />
+</LabelledField>
+<br />
+<LabelledField variant="inline-reversed">
+  <Label for="variant-inline-reversed-example" slot="label">A label</Label>
+  <input id="variant-inline-reversed-example" slot="field" type="checkbox" />
+</LabelledField>`}
+      label="Using different variants"
+      lang="astro"
+    >
+      <LabelledFieldComponent variant="vertical">
+        <Label for="variant-vertical-example" slot="label">A label</Label>
+        <TextField id="variant-vertical-example" slot="field" type="text" />
+      </LabelledFieldComponent>
+      <br />
+      <LabelledFieldComponent variant="inline">
+        <Label for="variant-inline-example" slot="label">A label</Label>
+        <TextField id="variant-inline-example" slot="field" type="text" />
+      </LabelledFieldComponent>
+      <br />
+      <LabelledFieldComponent variant="inline-reversed">
+        <Label for="variant-inline-reversed-example" slot="label">A label</Label
+        >
+        <input
+          id="variant-inline-reversed-example"
+          slot="field"
+          type="checkbox"
+        />
+      </LabelledFieldComponent>
+    </CodePreview>
+    <Heading>Hints</Heading>
+    <CodePreview
+      code={`<LabelledField variant="vertical">
+  <Label for="hint-vertical-example" slot="label">A label</Label>
+  <TextField id="hint-vertical-example" slot="field" type="text" />
+  <Fragment slot="hint">A hint about this field.</Fragment>
+</LabelledField>
+<br />
+<LabelledField variant="inline">
+  <Label for="hint-inline-example" slot="label">A label</Label>
+  <TextField id="hint-inline-example" slot="field" type="text" />
+  <Fragment slot="hint">A hint about this field.</Fragment>
+</LabelledField>
+<br />
+<LabelledField variant="inline-reversed">
+  <Label for="hint-inline-reversed-example" slot="label">A label</Label>
+  <input id="hint-inline-reversed-example" slot="field" type="checkbox" />
+  <Fragment slot="hint">A hint about this field.</Fragment>
+</LabelledField>`}
+      label="Using different variants with hints"
+      lang="astro"
+    >
+      <LabelledFieldComponent variant="vertical">
+        <Label for="hint-vertical-example" slot="label">A label</Label>
+        <TextField id="hint-vertical-example" slot="field" type="text" />
+        <Fragment slot="hint">A hint about this field.</Fragment>
+      </LabelledFieldComponent>
+      <br />
+      <LabelledFieldComponent variant="inline">
+        <Label for="hint-inline-example" slot="label">A label</Label>
+        <TextField id="hint-inline-example" slot="field" type="text" />
+        <Fragment slot="hint">A hint about this field.</Fragment>
+      </LabelledFieldComponent>
+      <br />
+      <LabelledFieldComponent variant="inline-reversed">
+        <Label for="hint-inline-reversed-example" slot="label">A label</Label>
+        <input id="hint-inline-reversed-example" slot="field" type="checkbox" />
+        <Fragment slot="hint">A hint about this field.</Fragment>
+      </LabelledFieldComponent>
+    </CodePreview>
+    <Heading>Errors</Heading>
+    <CodePreview
+      code={`<LabelledField variant="vertical">
+  <Label for="errors-vertical-example" slot="label">A label</Label>
+  <TextField id="errors-vertical-example" slot="field" type="text" />
+  <List slot="errors">
+    <ListItem>error 1 because...</ListItem>
+    <ListItem>error 2 because...</ListItem>
+  </List>
+</LabelledField>
+<br />
+<LabelledField variant="inline">
+  <Label for="errors-inline-example" slot="label">A label</Label>
+  <TextField id="errors-inline-example" slot="field" type="text" />
+  <List slot="errors">
+    <ListItem>error 1 because...</ListItem>
+    <ListItem>error 2 because...</ListItem>
+  </List>
+</LabelledField>
+<br />
+<LabelledField variant="inline-reversed">
+  <Label for="errors-inline-reversed-example" slot="label">A label</Label>
+  <input id="errors-inline-reversed-example" slot="field" type="checkbox" />
+  <List slot="errors">
+    <ListItem>error 1 because...</ListItem>
+    <ListItem>error 2 because...</ListItem>
+  </List>
+</LabelledField>`}
+      label="Using different variants with errors"
+      lang="astro"
+    >
+      <LabelledFieldComponent variant="vertical">
+        <Label for="errors-vertical-example" slot="label">A label</Label>
+        <TextField id="errors-vertical-example" slot="field" type="text" />
+        <List slot="errors">
+          <ListItem>error 1 because...</ListItem>
+          <ListItem>error 2 because...</ListItem>
+        </List>
+      </LabelledFieldComponent>
+      <br />
+      <LabelledFieldComponent variant="inline">
+        <Label for="errors-inline-example" slot="label">A label</Label>
+        <TextField id="errors-inline-example" slot="field" type="text" />
+        <List slot="errors">
+          <ListItem>error 1 because...</ListItem>
+          <ListItem>error 2 because...</ListItem>
+        </List>
+      </LabelledFieldComponent>
+      <br />
+      <LabelledFieldComponent variant="inline-reversed">
+        <Label for="errors-inline-reversed-example" slot="label">A label</Label>
+        <input
+          id="errors-inline-reversed-example"
+          slot="field"
+          type="checkbox"
+        />
+        <List slot="errors">
+          <ListItem>error 1 because...</ListItem>
+          <ListItem>error 2 because...</ListItem>
+        </List>
+      </LabelledFieldComponent>
+    </CodePreview>
+    <Heading>Hint and errors</Heading>
+    <CodePreview
+      code={`<LabelledField variant="vertical">
+  <Label for="hint-errors-vertical-example" slot="label">A label</Label>
+  <TextField id="hint-errors-vertical-example" slot="field" type="text" />
+  <Fragment slot="hint">A hint about this field.</Fragment>
+  <List slot="errors">
+    <ListItem>error 1 because...</ListItem>
+    <ListItem>error 2 because...</ListItem>
+  </List>
+</LabelledField>
+<br />
+<LabelledField variant="inline">
+  <Label for="hint-errors-inline-example" slot="label">A label</Label>
+  <TextField id="hint-errors-inline-example" slot="field" type="text" />
+  <Fragment slot="hint">A hint about this field.</Fragment>
+  <List slot="errors">
+    <ListItem>error 1 because...</ListItem>
+    <ListItem>error 2 because...</ListItem>
+  </List>
+</LabelledField>
+<br />
+<LabelledField variant="inline-reversed">
+  <Label for="hint-errors-inline-reversed-example" slot="label">A label</Label>
+  <input id="hint-errors-inline-reversed-example" slot="field" type="checkbox" />
+  <Fragment slot="hint">A hint about this field.</Fragment>
+  <List slot="errors">
+    <ListItem>error 1 because...</ListItem>
+    <ListItem>error 2 because...</ListItem>
+  </List>
+</LabelledField>`}
+      label="Using different variants with hint and errors"
+      lang="astro"
+    >
+      <LabelledFieldComponent variant="vertical">
+        <Label for="hint-errors-vertical-example" slot="label">A label</Label>
+        <TextField id="hint-errors-vertical-example" slot="field" type="text" />
+        <Fragment slot="hint">A hint about this field.</Fragment>
+        <List slot="errors">
+          <ListItem>error 1 because...</ListItem>
+          <ListItem>error 2 because...</ListItem>
+        </List>
+      </LabelledFieldComponent>
+      <br />
+      <LabelledFieldComponent variant="inline">
+        <Label for="hint-errors-inline-example" slot="label">A label</Label>
+        <TextField id="hint-errors-inline-example" slot="field" type="text" />
+        <Fragment slot="hint">A hint about this field.</Fragment>
+        <List slot="errors">
+          <ListItem>error 1 because...</ListItem>
+          <ListItem>error 2 because...</ListItem>
+        </List>
+      </LabelledFieldComponent>
+      <br />
+      <LabelledFieldComponent variant="inline-reversed">
+        <Label for="hint-errors-inline-reversed-example" slot="label"
+          >A label</Label
+        >
+        <input
+          id="hint-errors-inline-reversed-example"
+          slot="field"
+          type="checkbox"
+        />
+        <Fragment slot="hint">A hint about this field.</Fragment>
+        <List slot="errors">
+          <ListItem>error 1 because...</ListItem>
+          <ListItem>error 2 because...</ListItem>
+        </List>
+      </LabelledFieldComponent>
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/molecules/language-picker/language-picker.stories.astro
+++ b/src/components/molecules/language-picker/language-picker.stories.astro
@@ -3,6 +3,7 @@ import type { ComponentProps } from "astro/types";
 import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
+import CodePreview from "../code-preview/code-preview.astro";
 import LanguagePickerComponent from "./language-picker.astro";
 
 /* cSpell:ignore Español Français */
@@ -24,26 +25,55 @@ const languages: ComponentProps<typeof LanguagePickerComponent>["languages"] = {
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading as="h2">Usage</Heading>
+    <Heading as="h2">Introduction</Heading>
     <p>
       This component is used to let an user choose the current language of the
       website.
     </p>
-    <LanguagePickerComponent
-      current="es"
-      id="usage-example"
-      label="Choose a language:"
-      languages={languages}
+    <CodePreview
+      code={`import LanguagePicker from "./components/molecules/language-picker/language-picker.astro";`}
+      label="How to import"
+      lang="ts"
     />
+    <CodePreview
+      code={`<LanguagePicker
+  current="es"
+  id="usage-example"
+  label="Choose a language:"
+  languages={languages}
+/>`}
+      label="Basic use"
+      lang="astro"
+    >
+      <LanguagePickerComponent
+        current="es"
+        id="usage-example"
+        label="Choose a language:"
+        languages={languages}
+      />
+    </CodePreview>
     <Heading as="h2">Options</Heading>
     <Heading as="h3"><code>isInline</code></Heading>
-    <LanguagePickerComponent
-      current="es"
-      gap="2xs"
-      id="is-inline-example"
-      isInline
-      label="Choose a language:"
-      languages={languages}
-    />
+    <CodePreview
+      code={`<LanguagePicker
+  current="es"
+  gap="2xs"
+  id="is-inline-example"
+  isInline
+  label="Choose a language:"
+  languages={languages}
+/>`}
+      label="Basic use"
+      lang="astro"
+    >
+      <LanguagePickerComponent
+        current="es"
+        gap="2xs"
+        id="is-inline-example"
+        isInline
+        label="Choose a language:"
+        languages={languages}
+      />
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/molecules/language-picker/language-picker.stories.astro
+++ b/src/components/molecules/language-picker/language-picker.stories.astro
@@ -1,5 +1,6 @@
 ---
 import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import LanguagePickerComponent from "./language-picker.astro";
@@ -7,22 +8,13 @@ import LanguagePickerComponent from "./language-picker.astro";
 /* cSpell:ignore Español Français */
 
 const title = "LanguagePicker";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Molecules", url: "/design-system/components/molecules" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "molecules",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 const languages: ComponentProps<typeof LanguagePickerComponent>["languages"] = {
   en: { name: "English", route: "#en" },
   es: { name: "Español", route: "#es" },

--- a/src/components/molecules/nav-item/nav-item.stories.astro
+++ b/src/components/molecules/nav-item/nav-item.stories.astro
@@ -1,26 +1,17 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import NavItemComponent from "./nav-item.astro";
 
 const title = "NavItem";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Molecules", url: "/design-system/components/molecules" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "molecules",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>

--- a/src/components/molecules/nav-item/nav-item.stories.astro
+++ b/src/components/molecules/nav-item/nav-item.stories.astro
@@ -2,6 +2,7 @@
 import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
+import CodePreview from "../code-preview/code-preview.astro";
 import NavItemComponent from "./nav-item.astro";
 
 const title = "NavItem";
@@ -16,55 +17,90 @@ const { breadcrumb, seo } = getStoryMeta({
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading as="h2">Usage</Heading>
+    <Heading as="h2">Introduction</Heading>
     <p>
       This component is used to define a navigation item inside a navigation
       list.
     </p>
-    <Heading as="h2">Variant: <code>isBlock: false</code> (default)</Heading>
-    <NavItemComponent href="#destination">Nav Item</NavItemComponent>
+    <CodePreview
+      code={`import NavItem from "./components/molecules/nav-item/nav-item.astro";`}
+      label="How to import"
+      lang="ts"
+    />
+    <CodePreview
+      code={`<NavItem href="#destination">Nav Item</NavItem>`}
+      label="Basic use"
+      lang="astro"
+    >
+      <NavItemComponent href="#destination">Nav Item</NavItemComponent>
+    </CodePreview>
+    <Heading>Variants</Heading>
+    <CodePreview
+      code={`<NavItem href="#destination">Nav Item</NavItem>
+<NavItem href="#destination" isBlock>Nav Item</NavItem>`}
+      label="Using variants"
+      lang="astro"
+    >
+      <NavItemComponent href="#destination">Nav Item</NavItemComponent>
+      <NavItemComponent href="#destination" isBlock>Nav Item</NavItemComponent>
+    </CodePreview>
+    <Heading>Other options</Heading>
     <Heading as="h3"><code>isBordered</code></Heading>
-    <NavItemComponent href="#destination" isBordered>Nav Item</NavItemComponent>
+    <CodePreview
+      code={`<NavItem href="#destination" isBordered>Nav Item</NavItem>
+<NavItem href="#destination" isBlock isBordered>Nav Item</NavItem>`}
+      label="Using borders on both variants"
+      lang="astro"
+    >
+      <NavItemComponent href="#destination" isBordered>
+        Nav Item
+      </NavItemComponent>
+      <NavItemComponent href="#destination" isBlock isBordered>
+        Nav Item
+      </NavItemComponent>
+    </CodePreview>
     <Heading as="h3"><code>isRounded</code></Heading>
-    <p>And with <code>isBordered</code> to highlight the difference.</p>
-    <NavItemComponent href="#destination" isBordered isRounded>
-      Nav Item
-    </NavItemComponent>
-    <Heading as="h3">With icon</Heading>
-    <NavItemComponent href="#destination" icon="home" iconSize={40}>
-      Nav Item
-    </NavItemComponent>
-    <Heading as="h3">Tag</Heading>
-    <Heading as="h4"><code>a</code></Heading>
-    <NavItemComponent as="a" href="#destination">A nav link</NavItemComponent>
-    <Heading as="h4"><code>label</code></Heading>
+    <CodePreview
+      code={`<NavItem href="#destination" isBordered isRounded>Nav Item</NavItem>
+<NavItem href="#destination" isBlock isBordered isRounded>Nav Item</NavItem>`}
+      label="Using rounded borders on both variants"
+      lang="astro"
+    >
+      <NavItemComponent href="#destination" isBordered isRounded>
+        Nav Item
+      </NavItemComponent>
+      <NavItemComponent href="#destination" isBlock isBordered isRounded>
+        Nav Item
+      </NavItemComponent>
+    </CodePreview>
+    <Heading as="h3">With an icon</Heading>
+    <CodePreview
+      code={`<NavItem href="#destination" icon="home" iconSize={40}>Nav Item</NavItem>
+<NavItem href="#destination" icon="home" iconSize={40} isBlock>Nav Item</NavItem>`}
+      label="Using icons on both variants"
+      lang="astro"
+    >
+      <NavItemComponent href="#destination" icon="home" iconSize={40}>
+        Nav Item
+      </NavItemComponent>
+      <NavItemComponent href="#destination" icon="home" iconSize={40} isBlock>
+        Nav Item
+      </NavItemComponent>
+    </CodePreview>
+    <Heading as="h3">As a label</Heading>
+    <CodePreview
+      code={`<NavItem as="label">Nav Item</NavItem>
+<NavItem as="label" isBlock>Nav Item</NavItem>`}
+      label="Using a label instead of a link with both variants"
+      lang="astro"
+    >
+      <NavItemComponent as="label">Nav Item</NavItemComponent>
+      <NavItemComponent as="label" isBlock>Nav Item</NavItemComponent>
+    </CodePreview>
     <p>
       When you are not using the block variant, please consider using a regular <code
         >Label</code
       > component instead.
     </p>
-    <NavItemComponent as="label">A nav label</NavItemComponent>
-    <Heading as="h2">Variant: <code>isBlock: true</code></Heading>
-    <NavItemComponent href="#destination" isBlock>Nav Item</NavItemComponent>
-    <Heading as="h3"><code>isBordered</code></Heading>
-    <NavItemComponent href="#destination" isBlock isBordered>
-      Nav Item
-    </NavItemComponent>
-    <Heading as="h3"><code>isRounded</code></Heading>
-    <p>And with <code>isBordered</code> to highlight the difference.</p>
-    <NavItemComponent href="#destination" isBlock isBordered isRounded>
-      Nav Item
-    </NavItemComponent>
-    <Heading as="h3">With icon</Heading>
-    <NavItemComponent href="#destination" icon="home" iconSize={40} isBlock>
-      Nav Item
-    </NavItemComponent>
-    <Heading as="h3">Tag</Heading>
-    <Heading as="h4"><code>a</code></Heading>
-    <NavItemComponent as="a" href="#destination" isBlock
-      >A nav link</NavItemComponent
-    >
-    <Heading as="h4"><code>label</code></Heading>
-    <NavItemComponent as="label" isBlock>A nav label</NavItemComponent>
   </Fragment>
 </PageLayout>

--- a/src/components/molecules/nav-list/nav-list.stories.astro
+++ b/src/components/molecules/nav-list/nav-list.stories.astro
@@ -1,5 +1,6 @@
 ---
 import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import ListItem from "../../atoms/list/list-item.astro";
 import List from "../../atoms/list/list.astro";
@@ -7,22 +8,13 @@ import PageLayout from "../../templates/page-layout/page-layout.astro";
 import NavListComponent from "./nav-list.astro";
 
 const title = "NavList";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Molecules", url: "/design-system/components/molecules" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "molecules",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 
 const items = [
   { label: "Item 1", url: "#item-1" },

--- a/src/components/molecules/nav-list/nav-list.stories.astro
+++ b/src/components/molecules/nav-list/nav-list.stories.astro
@@ -1,10 +1,9 @@
 ---
-import type { ComponentProps } from "astro/types";
 import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
-import ListItem from "../../atoms/list/list-item.astro";
-import List from "../../atoms/list/list.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
+import CodePreview from "../code-preview/code-preview.astro";
+import NavItem from "../nav-item/nav-item.astro";
 import NavListComponent from "./nav-list.astro";
 
 const title = "NavList";
@@ -15,17 +14,11 @@ const { breadcrumb, seo } = getStoryMeta({
     title,
   },
 });
-
-const items = [
-  { label: "Item 1", url: "#item-1" },
-  { label: "Item 2", url: "#item-2" },
-  { label: "Item 3", url: "#item-3" },
-] satisfies ComponentProps<typeof NavListComponent>["items"];
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading as="h2">Usage</Heading>
+    <Heading as="h2">Introduction</Heading>
     <p>
       This component is used to define a navigation list. It accepts an <code
         >items</code
@@ -34,25 +27,45 @@ const items = [
         >NavItem</code
       > component.
     </p>
-    <NavListComponent items={items}>
-      {
-        (item) => (
-          <List>
-            <ListItem>
-              <code>icon:</code> {item.icon ?? "undefined"}
-            </ListItem>
-            <ListItem>
-              <code>iconSize:</code> {item.iconSize ?? "undefined"}
-            </ListItem>
-            <ListItem>
-              <code>label:</code> {item.label}
-            </ListItem>
-            <ListItem>
-              <code>url:</code> {item.url}
-            </ListItem>
-          </List>
-        )
-      }
-    </NavListComponent>
+    <CodePreview
+      code={`import NavList from "./components/molecules/nav-list/nav-list.astro";`}
+      label="How to import"
+      lang="ts"
+    />
+    <CodePreview
+      code={`<NavList
+  items={[
+    { label: "Item 1", url: "#item-1" },
+    { label: "Item 2", url: "#item-2" },
+    { label: "Item 3", url: "#item-3" },
+  ]}
+>
+  {
+    (item) => (
+      <NavItem href={item.url} icon={item.icon} iconSize={item.iconSize}>
+        {item.label}
+      </NavItem>
+    )
+  }
+</NavList>`}
+      label="Basic use"
+      lang="astro"
+    >
+      <NavListComponent
+        items={[
+          { label: "Item 1", url: "#item-1" },
+          { label: "Item 2", url: "#item-2" },
+          { label: "Item 3", url: "#item-3" },
+        ]}
+      >
+        {
+          (item) => (
+            <NavItem href={item.url} icon={item.icon} iconSize={item.iconSize}>
+              {item.label}
+            </NavItem>
+          )
+        }
+      </NavListComponent>
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/molecules/popover/popover.stories.astro
+++ b/src/components/molecules/popover/popover.stories.astro
@@ -2,6 +2,7 @@
 import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
+import CodePreview from "../code-preview/code-preview.astro";
 import PopoverComponent from "./popover.astro";
 
 const title = "Popover";
@@ -16,71 +17,181 @@ const { breadcrumb, seo } = getStoryMeta({
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading as="h2">Default</Heading>
-    <PopoverComponent controllerId="default-controller" modalId="default-modal">
-      <label for="default-controller" slot="label">Open default modal</label>
-      <div id="default-modal" slot="modal">
-        The content of the default modal.
-      </div>
-    </PopoverComponent>
-    <Heading as="h2">Using callback functions to access IDs</Heading>
-    <PopoverComponent
-      controllerId="callback-controller"
-      modalId="callback-modal"
+    <Heading as="h2">Introduction</Heading>
+    <CodePreview
+      code={`import Popover from "./components/molecules/popover/popover.astro";`}
+      label="How to import"
+      lang="ts"
+    />
+    <CodePreview
+      code={`<Popover
+  controllerId="default-controller"
+  modalId="default-modal"
+>
+  <label for="default-controller" slot="label">Open default modal</label>
+  <div id="default-modal" slot="modal">
+    The content of the default modal.
+  </div>
+</Popover>`}
+      label="Basic use"
+      lang="astro"
     >
-      <fragment slot="label">
-        {
-          (controllerId: string) => (
-            <label for={controllerId}>Open callback example modal</label>
-          )
-        }
-      </fragment>
-      <fragment slot="modal">
-        {
-          (modalId: string) => (
-            <div id={modalId} slot="modal">
-              The content of the callback example modal.
-            </div>
-          )
-        }
-      </fragment>
-    </PopoverComponent>
+      <PopoverComponent
+        controllerId="default-controller"
+        modalId="default-modal"
+      >
+        <label for="default-controller" slot="label">Open default modal</label>
+        <div id="default-modal" slot="modal">
+          The content of the default modal.
+        </div>
+      </PopoverComponent>
+    </CodePreview>
+    <Heading as="h2">Using callback functions to access IDs</Heading>
+    <CodePreview
+      code={`<Popover
+  controllerId="callback-controller"
+  modalId="callback-modal"
+>
+  <fragment slot="label">
+    {
+      (controllerId: string) => (
+        <label for={controllerId}>Open callback example modal</label>
+      )
+    }
+  </fragment>
+  <fragment slot="modal">
+    {
+      (modalId: string) => (
+        <div id={modalId} slot="modal">
+          The content of the callback example modal.
+        </div>
+      )
+    }
+  </fragment>
+</Popover>`}
+      label="Using callback functions"
+      lang="astro"
+    >
+      <PopoverComponent
+        controllerId="callback-controller"
+        modalId="callback-modal"
+      >
+        <fragment slot="label">
+          {
+            (controllerId: string) => (
+              <label for={controllerId}>Open callback example modal</label>
+            )
+          }
+        </fragment>
+        <fragment slot="modal">
+          {
+            (modalId: string) => (
+              <div id={modalId} slot="modal">
+                The content of the callback example modal.
+              </div>
+            )
+          }
+        </fragment>
+      </PopoverComponent>
+    </CodePreview>
     <Heading as="h2">Opening direction</Heading>
     <Heading as="h3">Bottom</Heading>
-    <PopoverComponent
-      controllerId="bottom-controller"
-      modalId="bottom-modal"
-      openTo="bottom"
+    <CodePreview
+      code={`<Popover
+  controllerId="bottom-controller"
+  modalId="bottom-modal"
+  openTo="bottom"
+>
+  <label for="bottom-controller" slot="label">Open bottom modal</label>
+  <div id="bottom-modal" slot="modal">
+    The content of the bottom modal.
+  </div>
+</Popover>`}
+      label="Opening the modal to the bottom"
+      lang="astro"
     >
-      <label for="bottom-controller" slot="label">Open bottom modal</label>
-      <div id="bottom-modal" slot="modal">The content of the bottom modal.</div>
-    </PopoverComponent>
+      <PopoverComponent
+        controllerId="bottom-controller"
+        modalId="bottom-modal"
+        openTo="bottom"
+      >
+        <label for="bottom-controller" slot="label">Open bottom modal</label>
+        <div id="bottom-modal" slot="modal">
+          The content of the bottom modal.
+        </div>
+      </PopoverComponent>
+    </CodePreview>
     <Heading as="h3">Top</Heading>
-    <PopoverComponent
-      controllerId="top-controller"
-      modalId="top-modal"
-      openTo="top"
+    <CodePreview
+      code={`<Popover
+  controllerId="top-controller"
+  modalId="top-modal"
+  openTo="top"
+>
+  <label for="top-controller" slot="label">Open top modal</label>
+  <div id="top-modal" slot="modal">
+    The content of the top modal.
+  </div>
+</Popover>`}
+      label="Opening the modal to the top"
+      lang="astro"
     >
-      <label for="top-controller" slot="label">Open top modal</label>
-      <div id="top-modal" slot="modal">The content of the top modal.</div>
-    </PopoverComponent>
+      <PopoverComponent
+        controllerId="top-controller"
+        modalId="top-modal"
+        openTo="top"
+      >
+        <label for="top-controller" slot="label">Open top modal</label>
+        <div id="top-modal" slot="modal">The content of the top modal.</div>
+      </PopoverComponent>
+    </CodePreview>
     <Heading as="h3">Left</Heading>
-    <PopoverComponent
-      controllerId="left-controller"
-      modalId="left-modal"
-      openTo="left"
+    <CodePreview
+      code={`<Popover
+  controllerId="left-controller"
+  modalId="left-modal"
+  openTo="left"
+>
+  <label for="left-controller" slot="label">Open left modal</label>
+  <div id="left-modal" slot="modal">
+    The content of the left modal.
+  </div>
+</Popover>`}
+      label="Opening the modal to the left"
+      lang="astro"
     >
-      <label for="left-controller" slot="label">Open left modal</label>
-      <div id="left-modal" slot="modal">The content of the left modal.</div>
-    </PopoverComponent>
+      <PopoverComponent
+        controllerId="left-controller"
+        modalId="left-modal"
+        openTo="left"
+      >
+        <label for="left-controller" slot="label">Open left modal</label>
+        <div id="left-modal" slot="modal">The content of the left modal.</div>
+      </PopoverComponent>
+    </CodePreview>
     <Heading as="h3">Right</Heading>
-    <PopoverComponent
-      controllerId="right-controller"
-      modalId="right-modal"
-      openTo="right"
+    <CodePreview
+      code={`<Popover
+  controllerId="right-controller"
+  modalId="right-modal"
+  openTo="right"
+>
+  <label for="right-controller" slot="label">Open right modal</label>
+  <div id="right-modal" slot="modal">
+    The content of the right modal.
+  </div>
+</Popover>`}
+      label="Opening the modal to the right"
+      lang="astro"
     >
-      <label for="right-controller" slot="label">Open right modal</label>
-      <div id="right-modal" slot="modal">The content of the right modal.</div>
-    </PopoverComponent>
+      <PopoverComponent
+        controllerId="right-controller"
+        modalId="right-modal"
+        openTo="right"
+      >
+        <label for="right-controller" slot="label">Open right modal</label>
+        <div id="right-modal" slot="modal">The content of the right modal.</div>
+      </PopoverComponent>
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/molecules/popover/popover.stories.astro
+++ b/src/components/molecules/popover/popover.stories.astro
@@ -1,27 +1,17 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import PopoverComponent from "./popover.astro";
 
 const title = "Popover";
-
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Molecules", url: "/design-system/components/molecules" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "molecules",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>

--- a/src/components/molecules/radio-group/radio-group.stories.astro
+++ b/src/components/molecules/radio-group/radio-group.stories.astro
@@ -1,27 +1,19 @@
 ---
 import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import RadioGroupComponent from "./radio-group.astro";
 import RadioItem from "./radio-item.astro";
 
 const title = "RadioGroup";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Molecules", url: "/design-system/components/molecules" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "molecules",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 
 const getItems = (
   name: string

--- a/src/components/molecules/radio-group/radio-group.stories.astro
+++ b/src/components/molecules/radio-group/radio-group.stories.astro
@@ -1,8 +1,8 @@
 ---
-import type { ComponentProps } from "astro/types";
 import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
+import CodePreview from "../code-preview/code-preview.astro";
 import RadioGroupComponent from "./radio-group.astro";
 import RadioItem from "./radio-item.astro";
 
@@ -14,85 +14,241 @@ const { breadcrumb, seo } = getStoryMeta({
     title,
   },
 });
-
-const getItems = (
-  name: string
-): (ComponentProps<typeof RadioItem> & {
-  label: string;
-})[] => [
-  { fieldId: `${name}-item-1`, label: "Item 1", name, value: "item-1" },
-  { fieldId: `${name}-item-2`, label: "Item 2", name, value: "item-2" },
-  { fieldId: `${name}-item-3`, label: "Item 3", name, value: "item-3" },
-];
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading as="h2">Usage</Heading>
+    <Heading as="h2">Introduction</Heading>
     <p>This component is used to display a group of <code>RadioItem</code>.</p>
-    <RadioGroupComponent label="The legend">
-      {
-        getItems("default").map((item) => (
-          <RadioItem
-            class="radio-group__item"
-            fieldId={item.fieldId}
-            name={item.name}
-            value={item.value}
-          >
-            {item.label}
-          </RadioItem>
-        ))
-      }
-    </RadioGroupComponent>
+    <CodePreview
+      code={`import RadioGroup from "./components/molecules/radio-group/radio-group.astro";
+import RadioItem from "./components/molecules/radio-item/radio-item.astro";`}
+      label="How to import"
+      lang="ts"
+    />
+    <CodePreview
+      code={`<RadioGroup label="The legend">
+{
+  [
+    { fieldId: "use-item-1", label: "Item 1", name: "use", value: "item-1" },
+    { fieldId: "use-item-2", label: "Item 2", name: "use", value: "item-2" },
+    { fieldId: "use-item-3", label: "Item 3", name: "use", value: "item-3" },
+  ].map((item) => (
+    <RadioItem
+      fieldId={item.fieldId}
+      name={item.name}
+      value={item.value}
+    >
+      {item.label}
+    </RadioItem>
+  ))
+}
+</RadioGroup>`}
+      label="Basic use"
+      lang="astro"
+    >
+      <RadioGroupComponent label="The legend">
+        {
+          [
+            {
+              fieldId: "use-item-1",
+              label: "Item 1",
+              name: "use",
+              value: "item-1",
+            },
+            {
+              fieldId: "use-item-2",
+              label: "Item 2",
+              name: "use",
+              value: "item-2",
+            },
+            {
+              fieldId: "use-item-3",
+              label: "Item 3",
+              name: "use",
+              value: "item-3",
+            },
+          ].map((item) => (
+            <RadioItem
+              fieldId={item.fieldId}
+              name={item.name}
+              value={item.value}
+            >
+              {item.label}
+            </RadioItem>
+          ))
+        }
+      </RadioGroupComponent>
+    </CodePreview>
     <Heading as="h2">Options</Heading>
     <Heading as="h3"><code>isBordered</code></Heading>
-    <RadioGroupComponent isBordered label="The legend">
-      {
-        getItems("bordered").map((item, _idx, arr) => (
-          <RadioItem
-            class="radio-group__item"
-            fieldId={item.fieldId}
-            isChecked={item.value === arr[0]?.value}
-            name={item.name}
-            value={item.value}
-          >
-            {item.label}
-          </RadioItem>
-        ))
-      }
-    </RadioGroupComponent>
+    <CodePreview
+      code={`<RadioGroup isBordered label="The legend">
+{
+  [
+    { fieldId: "bordered-item-1", label: "Item 1", name: "bordered", value: "item-1" },
+    { fieldId: "bordered-item-2", label: "Item 2", name: "bordered", value: "item-2" },
+    { fieldId: "bordered-item-3", label: "Item 3", name: "bordered", value: "item-3" },
+  ].map((item) => (
+    <RadioItem
+      fieldId={item.fieldId}
+      name={item.name}
+      value={item.value}
+    >
+      {item.label}
+    </RadioItem>
+  ))
+}
+</RadioGroup>`}
+      label="Using borders"
+      lang="astro"
+    >
+      <RadioGroupComponent isBordered label="The legend">
+        {
+          [
+            {
+              fieldId: "bordered-item-1",
+              label: "Item 1",
+              name: "bordered",
+              value: "item-1",
+            },
+            {
+              fieldId: "bordered-item-2",
+              label: "Item 2",
+              name: "bordered",
+              value: "item-2",
+            },
+            {
+              fieldId: "bordered-item-3",
+              label: "Item 3",
+              name: "bordered",
+              value: "item-3",
+            },
+          ].map((item) => (
+            <RadioItem
+              fieldId={item.fieldId}
+              name={item.name}
+              value={item.value}
+            >
+              {item.label}
+            </RadioItem>
+          ))
+        }
+      </RadioGroupComponent>
+    </CodePreview>
     <Heading as="h3"><code>isInline</code></Heading>
-    <RadioGroupComponent isInline label="The legend">
-      {
-        getItems("inlined").map((item, _idx, arr) => (
-          <RadioItem
-            class="radio-group__item"
-            fieldId={item.fieldId}
-            isChecked={item.value === arr[0]?.value}
-            name={item.name}
-            value={item.value}
-          >
-            {item.label}
-          </RadioItem>
-        ))
-      }
-    </RadioGroupComponent>
+    <CodePreview
+      code={`<RadioGroup isInline label="The legend">
+{
+  [
+    { fieldId: "inlined-item-1", label: "Item 1", name: "inlined", value: "item-1" },
+    { fieldId: "inlined-item-2", label: "Item 2", name: "inlined", value: "item-2" },
+    { fieldId: "inlined-item-3", label: "Item 3", name: "inlined", value: "item-3" },
+  ].map((item) => (
+    <RadioItem
+      fieldId={item.fieldId}
+      name={item.name}
+      value={item.value}
+    >
+      {item.label}
+    </RadioItem>
+  ))
+}
+</RadioGroup>`}
+      label="Inlining radio items"
+      lang="astro"
+    >
+      <RadioGroupComponent isInline label="The legend">
+        {
+          [
+            {
+              fieldId: "inlined-item-1",
+              label: "Item 1",
+              name: "inlined",
+              value: "item-1",
+            },
+            {
+              fieldId: "inlined-item-2",
+              label: "Item 2",
+              name: "inlined",
+              value: "item-2",
+            },
+            {
+              fieldId: "inlined-item-3",
+              label: "Item 3",
+              name: "inlined",
+              value: "item-3",
+            },
+          ].map((item) => (
+            <RadioItem
+              fieldId={item.fieldId}
+              name={item.name}
+              value={item.value}
+            >
+              {item.label}
+            </RadioItem>
+          ))
+        }
+      </RadioGroupComponent>
+    </CodePreview>
     <Heading as="h3"><code>hideRadio</code> on <code>RadioItem</code></Heading>
-    <RadioGroupComponent label="The legend">
-      {
-        getItems("hidden-radio").map((item, _idx, arr) => (
-          <RadioItem
-            class="radio-group__item"
-            fieldId={item.fieldId}
-            hideRadio
-            isChecked={item.value === arr[0]?.value}
-            name={item.name}
-            value={item.value}
-          >
-            {item.label}
-          </RadioItem>
-        ))
-      }
-    </RadioGroupComponent>
+    <CodePreview
+      code={`<RadioGroup label="The legend">
+{
+  [
+    { fieldId: "hidden-radio-item-1", label: "Item 1", name: "hidden-radio", value: "item-1" },
+    { fieldId: "hidden-radio-item-2", label: "Item 2", name: "hidden-radio", value: "item-2" },
+    { fieldId: "hidden-radio-item-3", label: "Item 3", name: "hidden-radio", value: "item-3" },
+  ].map((item, _idx, arr) => (
+    <RadioItem
+      fieldId={item.fieldId}
+      hideRadio
+      isChecked={item.value === arr[0]?.value}
+      name={item.name}
+      value={item.value}
+    >
+      {item.label}
+    </RadioItem>
+  ))
+}
+</RadioGroup>`}
+      label="Hiding the radio buttons"
+      lang="astro"
+    >
+      <RadioGroupComponent isInline label="The legend">
+        {
+          [
+            {
+              fieldId: "hidden-radio-item-1",
+              label: "Item 1",
+              name: "hidden-radio",
+              value: "item-1",
+            },
+            {
+              fieldId: "hidden-radio-item-2",
+              label: "Item 2",
+              name: "hidden-radio",
+              value: "item-2",
+            },
+            {
+              fieldId: "hidden-radio-item-3",
+              label: "Item 3",
+              name: "hidden-radio",
+              value: "item-3",
+            },
+          ].map((item, _idx, arr) => (
+            <RadioItem
+              fieldId={item.fieldId}
+              hideRadio
+              isChecked={item.value === arr[0]?.value}
+              name={item.name}
+              value={item.value}
+            >
+              {item.label}
+            </RadioItem>
+          ))
+        }
+      </RadioGroupComponent>
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/molecules/skip-to/skip-to.stories.astro
+++ b/src/components/molecules/skip-to/skip-to.stories.astro
@@ -1,26 +1,17 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import SkipToComponent from "./skip-to.astro";
 
 const title = "SkipTo";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Molecules", url: "/design-system/components/molecules" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "molecules",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>

--- a/src/components/molecules/skip-to/skip-to.stories.astro
+++ b/src/components/molecules/skip-to/skip-to.stories.astro
@@ -2,6 +2,7 @@
 import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
+import CodePreview from "../code-preview/code-preview.astro";
 import SkipToComponent from "./skip-to.astro";
 
 const title = "SkipTo";
@@ -16,17 +17,30 @@ const { breadcrumb, seo } = getStoryMeta({
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading as="h2">Usage</Heading>
+    <Heading as="h2">Introduction</Heading>
     <p>
       A SkipLink component is special. It is used to navigate through a page
       using anchors.
     </p>
-    <p>
-      Click here then use <kbd>Tab</kbd> key to focus the skip link below. It should
-      then appears on the top left of your screen.
-    </p>
-    <SkipToComponent anchor="#some-id">
-      Skip to some anchor on the page
-    </SkipToComponent>
+    <CodePreview
+      code={`import SkipTo from "./components/molecules/skip-to/skip-to.astro";`}
+      label="How to import"
+      lang="ts"
+    />
+    <CodePreview
+      code={`<SkipTo anchor="#some-id">
+  Skip to some anchor on the page
+</SkipTo>`}
+      label="Basic use"
+      lang="astro"
+    >
+      <p>
+        Click here then use <kbd>Tab</kbd> key to focus the skip link below. It should
+        then appears on the top left of your screen.
+      </p>
+      <SkipToComponent anchor="#some-id">
+        Skip to some anchor on the page
+      </SkipToComponent>
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/molecules/social-links/social-links.stories.astro
+++ b/src/components/molecules/social-links/social-links.stories.astro
@@ -3,6 +3,7 @@ import type { ComponentProps } from "astro/types";
 import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
+import CodePreview from "../code-preview/code-preview.astro";
 import SocialLinksComponent from "./social-links.astro";
 
 const title = "SocialLinks";
@@ -24,14 +25,30 @@ const links: ComponentProps<typeof SocialLinksComponent>["links"] = {
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading>Usage</Heading>
+    <Heading>Introduction</Heading>
     <p>
       A <code>SocialLinks</code> component should be used to display a list of social
       links, usually the profiles of an author.
     </p>
-    <Heading>With labels</Heading>
-    <SocialLinksComponent links={links} />
+    <CodePreview
+      code={`import SocialLinks from "./components/molecules/social-links/social-links.astro";`}
+      label="How to import"
+      lang="ts"
+    />
+    <CodePreview
+      code={`<SocialLinks links={links} />`}
+      label="Basic use"
+      lang="astro"
+    >
+      <SocialLinksComponent links={links} />
+    </CodePreview>
     <Heading>With hidden labels</Heading>
-    <SocialLinksComponent hideLabels links={links} />
+    <CodePreview
+      code={`<SocialLinks hideLabels links={links} />`}
+      label="Hiding the labels"
+      lang="astro"
+    >
+      <SocialLinksComponent hideLabels links={links} />
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/molecules/social-links/social-links.stories.astro
+++ b/src/components/molecules/social-links/social-links.stories.astro
@@ -1,27 +1,18 @@
 ---
 import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import SocialLinksComponent from "./social-links.astro";
 
 const title = "SocialLinks";
-
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Molecules", url: "/design-system/components/molecules" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "molecules",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 
 const links: ComponentProps<typeof SocialLinksComponent>["links"] = {
   diaspora: "#diaspora",

--- a/src/components/molecules/switch/switch.stories.astro
+++ b/src/components/molecules/switch/switch.stories.astro
@@ -2,6 +2,7 @@
 import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
+import CodePreview from "../code-preview/code-preview.astro";
 import SwitchComponent from "./switch.astro";
 
 const title = "Switch";
@@ -16,62 +17,140 @@ const { breadcrumb, seo } = getStoryMeta({
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading as="h2">Usage</Heading>
+    <Heading as="h2">Introduction</Heading>
     <p>
       A <code>Switch</code> component should be used with boolean settings.
     </p>
-    <SwitchComponent
-      id="usage-example"
-      items={[
-        { label: "Item 1", value: "item1" },
-        { label: "Item 2", value: "item2" },
-      ]}
-      label="Usage Example"
-      value="item1"
+    <CodePreview
+      code={`import Switch from "./components/molecules/switch/switch.astro";`}
+      label="How to import"
+      lang="ts"
     />
+    <CodePreview
+      code={`<Switch
+  id="use-example"
+  items={[
+    { label: "Item 1", value: "item1" },
+    { label: "Item 2", value: "item2" },
+  ]}
+  label="Use Example"
+  value="item1"
+/>`}
+      label="Basic use"
+      lang="astro"
+    >
+      <SwitchComponent
+        id="use-example"
+        items={[
+          { label: "Item 1", value: "item1" },
+          { label: "Item 2", value: "item2" },
+        ]}
+        label="Use Example"
+        value="item1"
+      />
+    </CodePreview>
     <Heading as="h2">Options</Heading>
     <Heading as="h3">Items with icons</Heading>
-    <SwitchComponent
-      id="items-icons-example"
-      items={[
-        { icon: "sun", label: "Item 1", value: "item1" },
-        { icon: "moon", label: "Item 2", value: "item2" },
-      ]}
-      label="Items with icons Example"
-      value="item1"
-    />
+    <CodePreview
+      code={`<Switch
+  id="items-icons-example"
+  items={[
+    { icon: "sun", label: "Item 1", value: "item1" },
+    { icon: "moon", label: "Item 2", value: "item2" },
+  ]}
+  label="Items with icons Example"
+  value="item1"
+/>`}
+      label="Using icons"
+      lang="astro"
+    >
+      <SwitchComponent
+        id="items-icons-example"
+        items={[
+          { icon: "sun", label: "Item 1", value: "item1" },
+          { icon: "moon", label: "Item 2", value: "item2" },
+        ]}
+        label="Items with icons Example"
+        value="item1"
+      />
+    </CodePreview>
     <Heading as="h3"><code>hideItemsLabel</code></Heading>
-    <SwitchComponent
-      hideItemsLabel
-      id="hidden-items-label-example"
-      items={[
-        { icon: "sun", label: "Item 1", value: "item1" },
-        { icon: "moon", label: "Item 2", value: "item2" },
-      ]}
-      label="Hidden Items Label Example"
-      value="item1"
-    />
+    <CodePreview
+      code={`<Switch
+  hideItemsLabel
+  id="hidden-items-label-example"
+  items={[
+    { icon: "sun", label: "Item 1", value: "item1" },
+    { icon: "moon", label: "Item 2", value: "item2" },
+  ]}
+  label="Hidden Items Label Example"
+  value="item1"
+/>`}
+      label="Using hidden items labels"
+      lang="astro"
+    >
+      <SwitchComponent
+        hideItemsLabel
+        id="hidden-items-label-example"
+        items={[
+          { icon: "sun", label: "Item 1", value: "item1" },
+          { icon: "moon", label: "Item 2", value: "item2" },
+        ]}
+        label="Hidden Items Label Example"
+        value="item1"
+      />
+    </CodePreview>
     <Heading as="h3"><code>hideLabel</code></Heading>
-    <SwitchComponent
-      hideLabel
-      id="hidden-items-label-example"
-      items={[
-        { label: "Item 1", value: "item1" },
-        { label: "Item 2", value: "item2" },
-      ]}
-      label="Hidden Items Label Example"
-      value="item1"
-    />
+    <CodePreview
+      code={`<Switch
+  hideLabel
+  id="hidden-items-label-example"
+  items={[
+    { label: "Item 1", value: "item1" },
+    { label: "Item 2", value: "item2" },
+  ]}
+  label="Hidden Items Label Example"
+  value="item1"
+/>`}
+      label="Using a hidden label"
+      lang="astro"
+    >
+      <SwitchComponent
+        hideLabel
+        id="hidden-items-label-example"
+        items={[
+          { label: "Item 1", value: "item1" },
+          { label: "Item 2", value: "item2" },
+        ]}
+        label="Hidden Items Label Example"
+        value="item1"
+      />
+    </CodePreview>
     <Heading as="h3"><code>isInline</code></Heading>
-    <SwitchComponent
-      id="inline-example"
-      isInline
-      items={[
-        { label: "Item 1", value: "item1" },
-        { label: "Item 2", value: "item2" },
-      ]}
-      label="Inline Example"
-      value="item1"
-    />
+    <CodePreview
+      code={`<Switch
+  id="inline-example"
+  isInline
+  items={[
+    { label: "Item 1", value: "item1" },
+    { label: "Item 2", value: "item2" },
+  ]}
+  label="Inline Example"
+  value="item1"
+/>`}
+      label="Inlining the label"
+      lang="astro"
+    >
+      <SwitchComponent
+        id="inline-example"
+        isInline
+        items={[
+          { label: "Item 1", value: "item1" },
+          { label: "Item 2", value: "item2" },
+        ]}
+        label="Inline Example"
+        value="item1"
+      />
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/molecules/switch/switch.stories.astro
+++ b/src/components/molecules/switch/switch.stories.astro
@@ -1,26 +1,17 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import SwitchComponent from "./switch.astro";
 
 const title = "Switch";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Molecules", url: "/design-system/components/molecules" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "molecules",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>

--- a/src/components/molecules/theme-setting/theme-setting.stories.astro
+++ b/src/components/molecules/theme-setting/theme-setting.stories.astro
@@ -2,6 +2,7 @@
 import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
+import CodePreview from "../code-preview/code-preview.astro";
 import ThemeSettingComponent from "./theme-setting.astro";
 
 const title = "ThemeSetting";
@@ -12,74 +13,143 @@ const { breadcrumb, seo } = getStoryMeta({
     title,
   },
 });
-const switchLabel = "Enable dark mode?";
-const toggleLabel = "Choose a theme:";
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading as="h2">Usage</Heading>
+    <Heading as="h2">Introduction</Heading>
     <p>
       A <code>ThemeSetting</code> component is used to let the user choose the he
       wants to use for the website.
     </p>
-    <ThemeSettingComponent label={toggleLabel} setting="theme" />
+    <CodePreview
+      code={`import ThemeSetting from "./components/molecules/theme-setting/theme-setting.astro";`}
+      label="How to import"
+      lang="ts"
+    />
+    <CodePreview
+      code={`<ThemeSetting label="Choose a theme:" setting="theme" />`}
+      label="Basic use"
+      lang="astro"
+    >
+      <ThemeSettingComponent label="Choose a theme:" setting="theme" />
+    </CodePreview>
     <Heading as="h2">Options</Heading>
     <Heading as="h3"><code>isInline</code></Heading>
-    <ThemeSettingComponent
-      id="inlined-example"
-      isInline
-      label={toggleLabel}
-      setting="theme"
-    />
+    <CodePreview
+      code={`<ThemeSetting
+  id="inlined-example"
+  isInline
+  label="Choose a theme:"
+  setting="theme"
+/>`}
+      label="Using isInline"
+      lang="astro"
+    >
+      <ThemeSettingComponent
+        id="inlined-example"
+        isInline
+        label="Choose a theme:"
+        setting="theme"
+      />
+    </CodePreview>
     <Heading as="h3"><code>variant="switch"</code></Heading>
-    <ThemeSettingComponent
-      label={switchLabel}
-      setting="theme"
-      variant="switch"
-    />
+    <CodePreview
+      code={`<ThemeSetting
+  label="Enable dark mode?"
+  setting="theme"
+  variant="switch"
+/>`}
+      label="Using the switch variant"
+      lang="astro"
+    >
+      <ThemeSettingComponent
+        label="Enable dark mode?"
+        setting="theme"
+        variant="switch"
+      />
+    </CodePreview>
     <Heading as="h2">With multiple toggles on the page</Heading>
     <p>
       If you need multiple toggles on the same page for the same setting key,
       you must provide an <code>id</code>.
     </p>
-    <ThemeSettingComponent
-      id="toggle1"
-      label={toggleLabel}
-      setting="shiki"
-      variant="toggle"
-    />
-    <ThemeSettingComponent
-      id="toggle2"
-      label={toggleLabel}
-      setting="shiki"
-      variant="toggle"
-    />
-    <ThemeSettingComponent
-      id="toggle3"
-      label={toggleLabel}
-      setting="shiki"
-      variant="toggle"
-    />
-    <Heading as="h2">With multiple switches on the page</Heading>
-    <p>
-      If you need multiple switches on the same page for the <code>id</code> is not
-      required.
-    </p>
-    <ThemeSettingComponent
-      label={switchLabel}
-      setting="shiki"
-      variant="switch"
-    />
-    <ThemeSettingComponent
-      label={switchLabel}
-      setting="shiki"
-      variant="switch"
-    />
-    <ThemeSettingComponent
-      label={switchLabel}
-      setting="shiki"
-      variant="switch"
-    />
+    <CodePreview
+      code={`<ThemeSetting
+  id="toggle1"
+  label="Choose a theme:"
+  setting="shiki"
+  variant="toggle"
+/>
+<ThemeSetting
+  id="toggle2"
+  label="Choose a theme:"
+  setting="shiki"
+  variant="toggle"
+/>
+<ThemeSetting
+  id="toggle3"
+  label="Choose a theme:"
+  setting="shiki"
+  variant="toggle"
+/>`}
+      label="Using multiple toggles on a page"
+      lang="astro"
+    >
+      <ThemeSettingComponent
+        id="toggle1"
+        label="Choose a theme:"
+        setting="shiki"
+        variant="toggle"
+      />
+      <ThemeSettingComponent
+        id="toggle2"
+        label="Choose a theme:"
+        setting="shiki"
+        variant="toggle"
+      />
+      <ThemeSettingComponent
+        id="toggle3"
+        label="Choose a theme:"
+        setting="shiki"
+        variant="toggle"
+      />
+    </CodePreview>
+    <p>This limitation does not apply to the switch variant.</p>
+    <CodePreview
+      code={`<ThemeSetting
+  label="Enable dark mode?"
+  setting="shiki"
+  variant="switch"
+/>
+<ThemeSetting
+  label="Enable dark mode?"
+  setting="shiki"
+  variant="switch"
+/>
+<ThemeSetting
+  label="Enable dark mode?"
+  setting="shiki"
+  variant="switch"
+/>`}
+      label="Using multiple switches on a page"
+      lang="astro"
+    >
+      <ThemeSettingComponent
+        label="Enable dark mode?"
+        setting="shiki"
+        variant="switch"
+      />
+      <ThemeSettingComponent
+        label="Enable dark mode?"
+        setting="shiki"
+        variant="switch"
+      />
+      <ThemeSettingComponent
+        label="Enable dark mode?"
+        setting="shiki"
+        variant="switch"
+      />
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/molecules/theme-setting/theme-setting.stories.astro
+++ b/src/components/molecules/theme-setting/theme-setting.stories.astro
@@ -1,26 +1,17 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import ThemeSettingComponent from "./theme-setting.astro";
 
 const title = "ThemeSetting";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Molecules", url: "/design-system/components/molecules" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "molecules",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 const switchLabel = "Enable dark mode?";
 const toggleLabel = "Choose a theme:";
 ---

--- a/src/components/molecules/toggle/toggle.stories.astro
+++ b/src/components/molecules/toggle/toggle.stories.astro
@@ -1,8 +1,8 @@
 ---
-import type { ComponentProps } from "astro/types";
 import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
+import CodePreview from "../code-preview/code-preview.astro";
 import ToggleComponent from "./toggle.astro";
 
 const title = "Toggle";
@@ -13,54 +13,150 @@ const { breadcrumb, seo } = getStoryMeta({
     title,
   },
 });
-
-const getItems = (
-  name: string
-): ComponentProps<typeof ToggleComponent>["items"] => [
-  { id: `${name}-item-1`, label: "Item 1", value: "item-1" },
-  { id: `${name}-item-2`, label: "Item 2", value: "item-2" },
-  { id: `${name}-item-3`, label: "Item 3", value: "item-3" },
-];
-
-const getItemsWithIcon = (
-  name: string
-): ComponentProps<typeof ToggleComponent>["items"] => [
-  { icon: "caret", id: `${name}-item-1`, label: "Item 1", value: "item-1" },
-  { icon: "gear", id: `${name}-item-2`, label: "Item 2", value: "item-2" },
-  { icon: "search", id: `${name}-item-3`, label: "Item 3", value: "item-3" },
-];
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading>Default</Heading>
-    <ToggleComponent
-      groupName="default"
-      items={getItems("default")}
-      label="The legend"
+    <Heading>Introduction</Heading>
+    <CodePreview
+      code={`import Toggle from "./components/molecules/toggle/toggle.astro";`}
+      label="How to import"
+      lang="ts"
     />
+    <CodePreview
+      code={`<Toggle
+  groupName="use"
+  items={[
+    { id: 'use-item-1', label: "Item 1", value: "item-1" },
+    { id: 'use-item-2', label: "Item 2", value: "item-2" },
+    { id: 'use-item-3', label: "Item 3", value: "item-3" },
+  ]}
+  label="The legend"
+/>`}
+      label="Basic use"
+      lang="astro"
+    >
+      <ToggleComponent
+        groupName="use"
+        items={[
+          { id: "use-item-1", label: "Item 1", value: "item-1" },
+          { id: "use-item-2", label: "Item 2", value: "item-2" },
+          { id: "use-item-3", label: "Item 3", value: "item-3" },
+        ]}
+        label="The legend"
+      />
+    </CodePreview>
     <Heading>With default value</Heading>
-    <ToggleComponent
-      groupName="default-value"
-      items={getItems("default-value")}
-      label="The legend"
-      value={getItems("default-value")[0]?.value}
-    />
+    <CodePreview
+      code={`<Toggle
+  groupName="default-value"
+  items={[
+    { id: "default-item-1", label: "Item 1", value: "item-1" },
+    { id: "default-item-2", label: "Item 2", value: "item-2" },
+    { id: "default-item-3", label: "Item 3", value: "item-3" },
+  ]}
+  label="The legend"
+  value="item-2"
+/>`}
+      label="Using a default value"
+      lang="astro"
+    >
+      <ToggleComponent
+        groupName="default-value"
+        items={[
+          { id: "default-item-1", label: "Item 1", value: "item-1" },
+          { id: "default-item-2", label: "Item 2", value: "item-2" },
+          { id: "default-item-3", label: "Item 3", value: "item-3" },
+        ]}
+        label="The legend"
+        value="item-2"
+      />
+    </CodePreview>
     <Heading>With icons</Heading>
-    <ToggleComponent
-      groupName="with-icons"
-      items={getItemsWithIcon("with-icons")}
-      label="The legend"
-      value={getItemsWithIcon("with-icons")[0]?.value}
-    />
+    <CodePreview
+      code={`<Toggle
+  groupName="with-icons"
+  items={[
+    {
+      icon: "caret",
+      id: 'with-icons-item-1',
+      label: "Item 1",
+      value: "item-1",
+    },
+    {
+      icon: "gear",
+      id: 'with-icons-item-2',
+      label: "Item 2",
+      value: "item-2",
+    },
+    {
+      icon: "search",
+      id: 'with-icons-item-3',
+      label: "Item 3",
+      value: "item-3",
+    },
+  ]}
+  label="The legend"
+  value="item-1"
+/>`}
+      label="Using icons"
+      lang="astro"
+    >
+      <ToggleComponent
+        groupName="with-icons"
+        items={[
+          {
+            icon: "caret",
+            id: `with-icons-item-1`,
+            label: "Item 1",
+            value: "item-1",
+          },
+          {
+            icon: "gear",
+            id: `with-icons-item-2`,
+            label: "Item 2",
+            value: "item-2",
+          },
+          {
+            icon: "search",
+            id: `with-icons-item-3`,
+            label: "Item 3",
+            value: "item-3",
+          },
+        ]}
+        label="The legend"
+        value="item-1"
+      />
+    </CodePreview>
     <Heading>Inline</Heading>
-    <ToggleComponent
-      gap="xs"
-      groupName="inline"
-      isInline
-      items={getItems("inline")}
-      label="The legend"
-      value={getItems("inline")[0]?.value}
-    />
+    <CodePreview
+      code={`<Toggle
+  gap="xs"
+  groupName="inline"
+  isInline
+  items={[
+    { id: "inline-item-1", label: "Item 1", value: "item-1" },
+    { id: "inline-item-2", label: "Item 2", value: "item-2" },
+    { id: "inline-item-3", label: "Item 3", value: "item-3" },
+  ]}
+  label="The legend"
+  value="item-1"
+/>`}
+      label="Using a toggle with an inlined legend"
+      lang="astro"
+    >
+      <ToggleComponent
+        gap="xs"
+        groupName="inline"
+        isInline
+        items={[
+          { id: "inline-item-1", label: "Item 1", value: "item-1" },
+          { id: "inline-item-2", label: "Item 2", value: "item-2" },
+          { id: "inline-item-3", label: "Item 3", value: "item-3" },
+        ]}
+        label="The legend"
+        value="item-1"
+      />
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/molecules/toggle/toggle.stories.astro
+++ b/src/components/molecules/toggle/toggle.stories.astro
@@ -1,26 +1,18 @@
 ---
 import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import ToggleComponent from "./toggle.astro";
 
 const title = "Toggle";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Molecules", url: "/design-system/components/molecules" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "molecules",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 
 const getItems = (
   name: string

--- a/src/components/organisms/collection-card/collection-card.stories.astro
+++ b/src/components/organisms/collection-card/collection-card.stories.astro
@@ -1,8 +1,8 @@
 ---
 import type { ComponentProps } from "astro/types";
 import { getStoryMeta } from "../../../utils/stories";
-import Box from "../../atoms/box/box.astro";
 import Heading from "../../atoms/heading/heading.astro";
+import CodePreview from "../../molecules/code-preview/code-preview.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import CollectionCardComponent from "./collection-card.astro";
 
@@ -29,6 +29,7 @@ const blog = {
   collection: "blogroll",
   description: {
     en: "A short description about the blog.",
+    fr: "A short description about the blog.",
   },
   id: "any-blog",
   meta: {
@@ -151,163 +152,318 @@ const tag = {
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading as="h2">Usage</Heading>
+    <Heading as="h2">Introduction</Heading>
     <p>
       A <code>CollectionCard</code> component should be used to display a collection
       entry preview and to visit a link to learn more about this entry.
     </p>
-  </Fragment>
-  <Fragment slot="disconnected-body">
-    <CollectionCardComponent entry={basicCard} headingLvl="h3" />
-    <Box
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced
-    >
-      <Heading as="h2">Variants</Heading>
-      <Heading as="h3">With collection</Heading>
-    </Box>
-    <CollectionCardComponent
-      entry={basicCard}
-      headingLvl="h4"
-      isCentered
-      showCollection
+    <CodePreview
+      code={`import CollectionCard from "./components/organisms/collection-card/collection-card.astro";`}
+      label="How to import"
+      lang="ts"
     />
-    <Box
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced><Heading as="h3">With featured meta</Heading></Box
+    <CodePreview
+      code={`---
+const basicCard = {
+  collection: "pages",
+  description: "A short description of the page.",
+  id: "basic-card",
+  locale: "en",
+  route: "#a-basic-card",
+  slug: "a-basic-card",
+  title: "The page title",
+}
+---
+<CollectionCard entry={basicCard} headingLvl="h3" />`}
+      label="Basic use"
+      lang="astro"
     >
-    <CollectionCardComponent
-      entry={project}
-      featuredMeta={{ key: "kind" }}
-      headingLvl="h4"
-      isCentered
-    />
-    <Box
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced><Heading as="h3">With CTA</Heading></Box
+      <CollectionCardComponent entry={basicCard} headingLvl="h3" />
+    </CodePreview>
+    <Heading>With the collection name</Heading>
+    <CodePreview
+      code={`---
+const basicCard = {
+  collection: "pages",
+  description: "A short description of the page.",
+  id: "basic-card",
+  locale: "en",
+  route: "#a-basic-card",
+  slug: "a-basic-card",
+  title: "The page title",
+}
+---
+<CollectionCard entry={basicCard} headingLvl="h3" showCollection />`}
+      label="Showing the collection name"
+      lang="astro"
     >
-    <CollectionCardComponent
-      cta={{ label: "Read more" }}
-      entry={basicCard}
-      headingLvl="h4"
-      isCentered
-    />
-    <Box
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced
+      <CollectionCardComponent
+        entry={basicCard}
+        headingLvl="h3"
+        showCollection
+      />
+    </CodePreview>
+    <Heading>With a call to action</Heading>
+    <CodePreview
+      code={`---
+const basicCard = {
+  collection: "pages",
+  description: "A short description of the page.",
+  id: "basic-card",
+  locale: "en",
+  route: "#a-basic-card",
+  slug: "a-basic-card",
+  title: "The page title",
+}
+---
+<CollectionCard cta={{ label: "Read more" }} entry={basicCard} headingLvl="h3" />`}
+      label="Showing a call to action"
+      lang="astro"
     >
-      <Heading as="h2">Collections examples</Heading>
-      <p>Following you'll see some common examples for each collection.</p>
-    </Box>
-    <Box
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced><Heading as="h3">Blogroll</Heading></Box
+      <CollectionCardComponent
+        cta={{ label: "Read more" }}
+        entry={basicCard}
+        headingLvl="h3"
+      />
+    </CodePreview>
+    <Heading>With featured meta</Heading>
+    <CodePreview
+      code={`---
+const project = {
+  collection: "projects",
+  description: "An excerpt about the project.",
+  id: "project-card",
+  locale: "en",
+  meta: {
+    kind: "site",
+    repository: {
+      name: "repo",
+      url: "https://github.com/user/repo",
+    },
+    publishedOn: new Date("2024-09-16"),
+    updatedOn: new Date("2024-09-16"),
+  },
+  route: "#et-perferendis-qui",
+  slug: "et-perferendis-qui",
+  title: "The project title",
+}
+---
+<CollectionCard entry={project} featuredMeta={{key: "kind", icon: "project"}} headingLvl="h3" />`}
+      label="Showing featured meta"
+      lang="astro"
     >
-    <CollectionCardComponent entry={blog} headingLvl="h4" isCentered />
-    <Box
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced><Heading as="h3">Blog Category</Heading></Box
+      <CollectionCardComponent
+        entry={project}
+        featuredMeta={{ key: "kind", icon: "project" }}
+        headingLvl="h3"
+      />
+    </CodePreview>
+    <Heading>Collections examples</Heading>
+    <p>Below you'll see some common examples for each collection.</p>
+    <Heading as="h3">Blogroll</Heading>
+    <CodePreview
+      code={`---
+const blog = {
+  collection: "blogroll",
+  description: {
+    en: "A short description about the blog.",
+    fr: "A short description about the blog.",
+  },
+  id: "any-blog",
+  meta: {
+    inLanguages: ["en"],
+    publishedOn: new Date(),
+    updatedOn: new Date(),
+  },
+  title: "The blog title",
+  url: "#molestiae-eum-facere",
+}
+---
+<CollectionCard entry={blog} headingLvl="h4" />`}
+      label="Showing a blogroll entry"
+      lang="astro"
     >
-    <CollectionCardComponent entry={blogCategory} headingLvl="h4" isCentered />
-    <Box
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced><Heading as="h3">Blog Post</Heading></Box
+      <CollectionCardComponent entry={blog} headingLvl="h4" />
+    </CodePreview>
+    <Heading as="h3">Blog categories</Heading>
+    <CodePreview
+      code={`---
+const blogCategory = {
+  collection: "blog.categories",
+  description: "An excerpt about the blog category.",
+  id: "category-card",
+  locale: "en",
+  route: "#et-perferendis-qui",
+  slug: "et-perferendis-qui",
+  title: "The blog category title",
+}
+---
+<CollectionCard entry={blogCategory} headingLvl="h4" />`}
+      label="Showing a blog category"
+      lang="astro"
     >
-    <CollectionCardComponent entry={blogPost} headingLvl="h4" isCentered />
-    <Box
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced><Heading as="h3">Bookmark</Heading></Box
+      <CollectionCardComponent entry={blogCategory} headingLvl="h4" />
+    </CodePreview>
+    <Heading as="h3">Blog posts</Heading>
+    <CodePreview
+      code={`---
+const blogPost = {
+  collection: "blog.posts",
+  description: "An excerpt about the blog post.",
+  id: "post-card",
+  locale: "en",
+  meta: {
+    category: {
+      title: "A category",
+      route: "#quisquam-itaque-provident",
+    },
+    publishedOn: new Date("2024-09-16"),
+    updatedOn: new Date(),
+  },
+  route: "#et-perferendis-qui",
+  slug: "et-perferendis-qui",
+  title: "The blog post title",
+}
+---
+<CollectionCard entry={blogPost} headingLvl="h4" />`}
+      label="Showing a blog post"
+      lang="astro"
     >
-    <CollectionCardComponent entry={bookmark} headingLvl="h4" isCentered />
-    <Box
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced><Heading as="h3">Guide</Heading></Box
+      <CollectionCardComponent entry={blogPost} headingLvl="h4" />
+    </CodePreview>
+    <Heading as="h3">Bookmarks</Heading>
+    <CodePreview
+      code={`---
+const bookmark = {
+  collection: "bookmarks",
+  description: "A short description about the bookmark.",
+  id: "bookmark-card",
+  isQuote: false,
+  meta: {
+    inLanguage: "en",
+    publishedOn: new Date(),
+  },
+  title: "The bookmark title",
+  url: "#molestiae-eum-facere",
+}
+---
+<CollectionCard entry={bookmark} headingLvl="h4" />`}
+      label="Showing a bookmark"
+      lang="astro"
     >
-    <CollectionCardComponent entry={guide} headingLvl="h4" isCentered />
-    <Box
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced><Heading as="h3">Notes</Heading></Box
+      <CollectionCardComponent entry={bookmark} headingLvl="h4" />
+    </CodePreview>
+    <Heading as="h3">Guides</Heading>
+    <CodePreview
+      code={`---
+const guide = {
+  collection: "guides",
+  description: "An excerpt about the guide.",
+  id: "guide-card",
+  locale: "en",
+  meta: {
+    publishedOn: new Date("2024-09-16"),
+    updatedOn: new Date("2024-09-16"),
+  },
+  route: "#et-perferendis-qui",
+  slug: "et-perferendis-qui",
+  title: "The guide title",
+}
+---
+<CollectionCard entry={guide} headingLvl="h4" />`}
+      label="Showing a guide"
+      lang="astro"
     >
-    <CollectionCardComponent entry={note} headingLvl="h4" isCentered />
-    <Box
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced><Heading as="h3">Page</Heading></Box
+      <CollectionCardComponent entry={guide} headingLvl="h4" />
+    </CodePreview>
+    <Heading as="h3">Notes</Heading>
+    <CodePreview
+      code={`---
+const note = {
+  collection: "notes",
+  description: "An excerpt about the note.",
+  id: "note-card",
+  locale: "en",
+  meta: {
+    publishedOn: new Date("2024-09-16"),
+    updatedOn: new Date("2024-09-16"),
+  },
+  route: "#et-perferendis-qui",
+  slug: "et-perferendis-qui",
+  title: "The note title",
+}
+---
+<CollectionCard entry={note} headingLvl="h4" />`}
+      label="Showing a note"
+      lang="astro"
     >
-    <CollectionCardComponent entry={page} headingLvl="h4" isCentered />
-    <Box
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced><Heading as="h3">Project</Heading></Box
+      <CollectionCardComponent entry={note} headingLvl="h4" />
+    </CodePreview>
+    <Heading as="h3">Pages</Heading>
+    <CodePreview
+      code={`---
+const page = {
+  collection: "pages",
+  description: "An excerpt about the page.",
+  id: "page-card",
+  locale: "en",
+  route: "#et-perferendis-qui",
+  slug: "et-perferendis-qui",
+  title: "The page title",
+}
+---
+<CollectionCard entry={page} headingLvl="h4" />`}
+      label="Showing a page"
+      lang="astro"
     >
-    <CollectionCardComponent entry={project} headingLvl="h4" isCentered />
-    <Box
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced><Heading as="h3">Tag</Heading></Box
+      <CollectionCardComponent entry={page} headingLvl="h4" />
+    </CodePreview>
+    <Heading as="h3">Projects</Heading>
+    <CodePreview
+      code={`---
+const project = {
+  collection: "projects",
+  description: "An excerpt about the project.",
+  id: "project-card",
+  locale: "en",
+  meta: {
+    kind: "site",
+    repository: {
+      name: "repo",
+      url: "https://github.com/user/repo",
+    },
+    publishedOn: new Date("2024-09-16"),
+    updatedOn: new Date("2024-09-16"),
+  },
+  route: "#et-perferendis-qui",
+  slug: "et-perferendis-qui",
+  title: "The project title",
+}
+---
+<CollectionCard entry={project} headingLvl="h4" />`}
+      label="Showing a project"
+      lang="astro"
     >
-    <CollectionCardComponent entry={tag} headingLvl="h4" isCentered />
+      <CollectionCardComponent entry={project} headingLvl="h4" />
+    </CodePreview>
+    <Heading as="h3">Tags</Heading>
+    <CodePreview
+      code={`---
+const tag = {
+  collection: "tags",
+  description: "An excerpt about the tag.",
+  id: "tag-card",
+  locale: "en",
+  route: "#et-perferendis-qui",
+  slug: "et-perferendis-qui",
+  title: "The tag title",
+}
+---
+<CollectionCard entry={tag} headingLvl="h4" />`}
+      label="Showing a tag"
+      lang="astro"
+    >
+      <CollectionCardComponent entry={tag} headingLvl="h4" />
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/organisms/collection-card/collection-card.stories.astro
+++ b/src/components/organisms/collection-card/collection-card.stories.astro
@@ -1,27 +1,19 @@
 ---
 import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import Box from "../../atoms/box/box.astro";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import CollectionCardComponent from "./collection-card.astro";
 
 const title = "CollectionCard";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Organisms", url: "/design-system/components/organisms" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "organisms",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 
 const basicCard = {
   collection: "pages",

--- a/src/components/organisms/collection-meta/collection-meta.stories.astro
+++ b/src/components/organisms/collection-meta/collection-meta.stories.astro
@@ -1,26 +1,18 @@
 ---
 import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import CollectionMetaComponent from "./collection-meta.astro";
 
 const title = "CollectionMeta";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Organisms", url: "/design-system/components/organisms" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "organisms",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 
 const meta = {
   publishedOn: new Date(),

--- a/src/components/organisms/collection-meta/collection-meta.stories.astro
+++ b/src/components/organisms/collection-meta/collection-meta.stories.astro
@@ -2,6 +2,7 @@
 import type { ComponentProps } from "astro/types";
 import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
+import CodePreview from "../../molecules/code-preview/code-preview.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import CollectionMetaComponent from "./collection-meta.astro";
 
@@ -13,14 +14,6 @@ const { breadcrumb, seo } = getStoryMeta({
     title,
   },
 });
-
-const meta = {
-  publishedOn: new Date(),
-} satisfies ComponentProps<typeof CollectionMetaComponent>["data"];
-
-const icons = {
-  publishedOn: { name: "success", size: 24 },
-} satisfies ComponentProps<typeof CollectionMetaComponent>["icons"];
 
 const blogPostMeta = {
   category: {
@@ -45,24 +38,89 @@ const projectMeta = {
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading as="h2">Usage</Heading>
+    <Heading as="h2">Introduction</Heading>
     <p>
       A <code>CollectionMeta</code> component should be used to display the meta
       of any collection configured in Astro.
     </p>
-    <CollectionMetaComponent data={meta} />
+    <CodePreview
+      code={`import CollectionMeta from "./components/organisms/collection-meta/collection-meta.astro";`}
+      label="How to import"
+      lang="ts"
+    />
+    <CodePreview
+      code={`<CollectionMeta data={{ publishedOn: new Date() }} />`}
+      label="Basic use"
+      lang="astro"
+    >
+      <CollectionMetaComponent data={{ publishedOn: new Date() }} />
+    </CodePreview>
+    <CollectionMetaComponent data={{ publishedOn: new Date() }} />
     <Heading as="h2">With hidden label</Heading>
-    <CollectionMetaComponent data={meta} hideLabel />
+    <CodePreview
+      code={`<CollectionMeta data={{ publishedOn: new Date() }} hideLabel />`}
+      label="Hiding the labels"
+      lang="astro"
+    >
+      <CollectionMetaComponent data={{ publishedOn: new Date() }} hideLabel />
+    </CodePreview>
     <Heading as="h2">With icons</Heading>
-    <CollectionMetaComponent data={meta} icons={icons} />
+    <CodePreview
+      code={`<CollectionMeta
+  data={{ publishedOn: new Date() }}
+  icons={{ publishedOn: { name: "blog", size: 24 } }}
+/>`}
+      label="Showing icons"
+      lang="astro"
+    >
+      <CollectionMetaComponent
+        data={{ publishedOn: new Date() }}
+        icons={{ publishedOn: { name: "blog", size: 24 } }}
+      />
+    </CodePreview>
     <Heading as="h2">Specific to a collection</Heading>
     <p>
       The component also handles meta specific to some collections. Check out
       the following examples.
     </p>
     <Heading as="h3">Blog post meta</Heading>
+    <CodePreview
+      code={`---
+const blogPostMeta = {
+  category: {
+    route: "#quisquam-itaque-provident",
+    title: "A category",
+  },
+  publishedOn: new Date("2024-09-16"),
+  tags: [
+    { route: "#tag1", title: "Tag 1" },
+    { route: "#tag2", title: "Tag 2" },
+  ],
+  updatedOn: new Date(),
+}
+---
+<CollectionMeta data={blogPostMeta} />`}
+      label="Showing blog post meta"
+      lang="astro"
+    >
+      <CollectionMetaComponent data={blogPostMeta} />
+    </CodePreview>
     <CollectionMetaComponent data={blogPostMeta} />
     <Heading as="h3">Project meta</Heading>
-    <CollectionMetaComponent data={projectMeta} />
+    <CodePreview
+      code={`---
+const projectMeta = {
+  kind: "site",
+  publishedOn: new Date("2024-09-16"),
+  updatedOn: new Date("2024-09-16"),
+  isArchived: true,
+}
+---
+<CollectionMeta data={projectMeta} />`}
+      label="Showing project meta"
+      lang="astro"
+    >
+      <CollectionMetaComponent data={projectMeta} />
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/organisms/contact-card/contact-card.stories.astro
+++ b/src/components/organisms/contact-card/contact-card.stories.astro
@@ -1,23 +1,19 @@
 ---
 import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import Box from "../../atoms/box/box.astro";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import ContactCardComponent from "./contact-card.astro";
 
 const title = "ContactCard";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Organisms", url: "/design-system/components/organisms" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: `Design system / Components / Organisms / ${title}`,
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "organisms",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 
 const socialMedia = {
   diaspora: "#diaspora",

--- a/src/components/organisms/contact-card/contact-card.stories.astro
+++ b/src/components/organisms/contact-card/contact-card.stories.astro
@@ -1,8 +1,7 @@
 ---
-import type { ComponentProps } from "astro/types";
 import { getStoryMeta } from "../../../utils/stories";
-import Box from "../../atoms/box/box.astro";
 import Heading from "../../atoms/heading/heading.astro";
+import CodePreview from "../../molecules/code-preview/code-preview.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import ContactCardComponent from "./contact-card.astro";
 
@@ -14,68 +13,82 @@ const { breadcrumb, seo } = getStoryMeta({
     title,
   },
 });
+---
 
+<PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
+  <Fragment slot="body">
+    <Heading as="h2">Introduction</Heading>
+    <p>
+      An <code>ContactCard</code> component should be used to display contact methods.
+    </p>
+    <CodePreview
+      code={`import ContactCard from "./components/organisms/contact-card/contact-card.astro";`}
+      label="How to import"
+      lang="ts"
+    />
+    <CodePreview
+      code={`<ContactCard contactPageRoute="#contact" />`}
+      label="Basic use"
+      lang="astro"
+    >
+      <ContactCardComponent contactPageRoute="#contact" />
+    </CodePreview>
+    <Heading>With social links</Heading>
+    <CodePreview
+      code={`import ContactCard from "./components/organisms/contact-card/contact-card.astro";`}
+      label="How to import"
+      lang="ts"
+    />
+    <CodePreview
+      code={`---
 const socialMedia = {
   diaspora: "#diaspora",
   github: "#github",
   linkedin: "#linkedin",
   stackoverflow: "#stackoverflow",
-} satisfies ComponentProps<typeof ContactCardComponent>["socialMedia"];
+}
 ---
-
-<PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
-  <Fragment slot="body">
-    <Heading as="h2">Usage</Heading>
-    <p>
-      An <code>ContactCard</code> component should be used to display contact methods.
-    </p>
-  </Fragment>
-  <Fragment slot="disconnected-body">
-    <Box
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced
+<ContactCard contactPageRoute="#contact" socialMedia={socialMedia} />`}
+      label="Showing social media"
+      lang="astro"
     >
-      <Heading>Default</Heading>
-    </Box>
-    <ContactCardComponent contactPageRoute="#contact" isCentered />
-    <Box
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced
+      <ContactCardComponent
+        contactPageRoute="#contact"
+        socialMedia={{
+          diaspora: "#diaspora",
+          github: "#github",
+          linkedin: "#linkedin",
+          stackoverflow: "#stackoverflow",
+        }}
+      />
+    </CodePreview>
+    <Heading>With heading</Heading>
+    <CodePreview
+      code={`---
+const socialMedia = {
+  diaspora: "#diaspora",
+  github: "#github",
+  linkedin: "#linkedin",
+  stackoverflow: "#stackoverflow",
+}
+---
+<ContactCard contactPageRoute="#contact" socialMedia={socialMedia}>
+  <Heading as="h3" slot="heading">Contact</Heading>
+</ContactCard>`}
+      label="Adding a heading"
+      lang="astro"
     >
-      <Heading>With social links</Heading>
-    </Box>
-    <ContactCardComponent
-      contactPageRoute="#contact"
-      isCentered
-      socialMedia={socialMedia}
-    />
-    <Box
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced
-    >
-      <Heading>With heading</Heading>
-    </Box>
-    <ContactCardComponent
-      contactPageRoute="#contact"
-      isCentered
-      socialMedia={socialMedia}
-    >
-      <Heading as="h3" slot="heading">Contact</Heading>
-    </ContactCardComponent>
+      <ContactCardComponent
+        contactPageRoute="#contact"
+        socialMedia={{
+          diaspora: "#diaspora",
+          github: "#github",
+          linkedin: "#linkedin",
+          stackoverflow: "#stackoverflow",
+        }}
+      >
+        <Heading as="h3" slot="heading">Contact</Heading>
+      </ContactCardComponent>
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/organisms/contact-form/contact-form.stories.astro
+++ b/src/components/organisms/contact-form/contact-form.stories.astro
@@ -1,6 +1,7 @@
 ---
 import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
+import CodePreview from "../../molecules/code-preview/code-preview.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import ContactFormComponent from "./contact-form.astro";
 
@@ -16,11 +17,22 @@ const { breadcrumb, seo } = getStoryMeta({
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
   <Fragment slot="body">
-    <Heading>Usage</Heading>
+    <Heading>Introduction</Heading>
     <p>
       A <code>ContactForm</code> component should be used to authorize the user to
       contact you by email.
     </p>
-    <ContactFormComponent id="usage-example" />
+    <CodePreview
+      code={`import ContactForm from "./components/organisms/contact-form/contact-form.astro";`}
+      label="How to import"
+      lang="ts"
+    />
+    <CodePreview
+      code={`<ContactForm id="usage-example" />`}
+      label="Basic use"
+      lang="astro"
+    >
+      <ContactFormComponent id="usage-example" />
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/organisms/contact-form/contact-form.stories.astro
+++ b/src/components/organisms/contact-form/contact-form.stories.astro
@@ -1,26 +1,17 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import ContactFormComponent from "./contact-form.astro";
 
 const title = "ContactForm";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Organisms", url: "/design-system/components/organisms" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "organisms",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>

--- a/src/components/organisms/identity-card/identity-card.stories.astro
+++ b/src/components/organisms/identity-card/identity-card.stories.astro
@@ -1,23 +1,19 @@
 ---
 import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import Box from "../../atoms/box/box.astro";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import IdentityCardComponent from "./identity-card.astro";
 
 const title = "IdentityCard";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Organisms", url: "/design-system/components/organisms" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: `Design system / Components / Organisms / ${title}`,
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "organisms",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 
 const authorPreview = {
   name: "John Doe",

--- a/src/components/organisms/identity-card/identity-card.stories.astro
+++ b/src/components/organisms/identity-card/identity-card.stories.astro
@@ -1,8 +1,7 @@
 ---
-import type { ComponentProps } from "astro/types";
 import { getStoryMeta } from "../../../utils/stories";
-import Box from "../../atoms/box/box.astro";
 import Heading from "../../atoms/heading/heading.astro";
+import CodePreview from "../../molecules/code-preview/code-preview.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import IdentityCardComponent from "./identity-card.astro";
 
@@ -15,22 +14,61 @@ const { breadcrumb, seo } = getStoryMeta({
   },
 });
 
-const authorPreview = {
-  name: "John Doe",
-} satisfies ComponentProps<typeof IdentityCardComponent>["author"];
+// cSpell:ignore ˈdʒɑn ˈdoʊ
+---
 
+<PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
+  <Fragment slot="body">
+    <Heading as="h2">Introduction</Heading>
+    <p>
+      An <code>IdentityCard</code> component should be used to display information
+      about an author.
+    </p>
+    <CodePreview
+      code={`import IdentityCard from "./components/organisms/identity-card/identity-card.astro";`}
+      label="How to import"
+      lang="ts"
+    />
+    <CodePreview
+      code={`<IdentityCard author={{ name: "John Doe" }} />`}
+      label="Basic use"
+      lang="astro"
+    >
+      <IdentityCardComponent author={{ name: "John Doe" }} />
+    </CodePreview>
+    <Heading>With avatar</Heading>
+    <CodePreview
+      code={`---
 const authorPreviewWithAvatar = {
-  ...authorPreview,
   avatar: {
     format: "jpg",
     height: 200,
     src: "https://picsum.photos/150/200",
     width: 150,
   },
-} satisfies ComponentProps<typeof IdentityCardComponent>["author"];
-
+  name: "John Doe"
+}
+---
+<IdentityCard author={authorPreviewWithAvatar} />`}
+      label="Adding an avatar"
+      lang="astro"
+    >
+      <IdentityCardComponent
+        author={{
+          avatar: {
+            format: "jpg",
+            height: 200,
+            src: "https://picsum.photos/150/200",
+            width: 150,
+          },
+          name: "John Doe",
+        }}
+      />
+    </CodePreview>
+    <Heading>With all available data</Heading>
+    <CodePreview
+      code={`---
 const authorPreviewWithAllInfo = {
-  ...authorPreview,
   avatar: {
     format: "jpg",
     height: 200,
@@ -39,71 +77,75 @@ const authorPreviewWithAllInfo = {
   },
   country: "FR",
   job: "Astronaut",
-  // cSpell:ignore ˈdʒɑn ˈdoʊ
-  nameIPA: `/ˈdʒɑn/ /ˈdoʊ/`,
+  name: "John Doe",
+  nameIPA: "/ˈdʒɑn/ /ˈdoʊ/",
   nationality: "FR",
   spokenLanguages: ["en", "fr"],
-} satisfies ComponentProps<typeof IdentityCardComponent>["author"];
+}
 ---
-
-<PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
-  <Fragment slot="body">
-    <Heading as="h2">Usage</Heading>
-    <p>
-      An <code>IdentityCard</code> component should be used to display information
-      about an author.
-    </p>
-  </Fragment>
-  <Fragment slot="disconnected-body">
-    <Box
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced
+<IdentityCard author={authorPreviewWithAvatar} />`}
+      label="Using all supported data"
+      lang="astro"
     >
-      <Heading>Default</Heading>
-    </Box>
-    <IdentityCardComponent author={authorPreview} isCentered />
-    <Box
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced
+      <IdentityCardComponent
+        author={{
+          avatar: {
+            format: "jpg",
+            height: 200,
+            src: "https://picsum.photos/150/200",
+            width: 150,
+          },
+          country: "FR",
+          job: "Astronaut",
+          name: "John Doe",
+          nameIPA: "/ˈdʒɑn/ /ˈdoʊ/",
+          nationality: "FR",
+          spokenLanguages: ["en", "fr"],
+        }}
+      />
+    </CodePreview>
+    <Heading>With a heading</Heading>
+    <CodePreview
+      code={`---
+const authorPreviewWithAllInfo = {
+  avatar: {
+    format: "jpg",
+    height: 200,
+    src: "https://picsum.photos/150/200",
+    width: 150,
+  },
+  country: "FR",
+  job: "Astronaut",
+  name: "John Doe",
+  nameIPA: "/ˈdʒɑn/ /ˈdoʊ/",
+  nationality: "FR",
+  spokenLanguages: ["en", "fr"],
+}
+---
+<IdentityCard author={authorPreviewWithAvatar}>
+  <Heading as="h3" slot="heading">About John Doe</Heading>
+</IdentityCard>`}
+      label="Using all supported data"
+      lang="astro"
     >
-      <Heading>With avatar</Heading>
-    </Box>
-    <IdentityCardComponent author={authorPreviewWithAvatar} isCentered />
-    <Box
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced
-    >
-      <Heading>With all available data</Heading>
-    </Box>
-    <IdentityCardComponent author={authorPreviewWithAllInfo} isCentered />
-    <Box
-      elevation="raised"
-      isBordered
-      isCentered
-      isPadded
-      isProse
-      isRounded
-      isSpaced
-    >
-      <Heading>With heading</Heading>
-    </Box>
-    <IdentityCardComponent author={authorPreviewWithAllInfo} isCentered>
-      <Heading as="h3" slot="heading">About {authorPreview.name}</Heading>
-    </IdentityCardComponent>
+      <IdentityCardComponent
+        author={{
+          avatar: {
+            format: "jpg",
+            height: 200,
+            src: "https://picsum.photos/150/200",
+            width: 150,
+          },
+          country: "FR",
+          job: "Astronaut",
+          name: "John Doe",
+          nameIPA: "/ˈdʒɑn/ /ˈdoʊ/",
+          nationality: "FR",
+          spokenLanguages: ["en", "fr"],
+        }}
+      >
+        <Heading as="h3" slot="heading">About John Doe</Heading>
+      </IdentityCardComponent>
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/organisms/main-nav/main-nav.stories.astro
+++ b/src/components/organisms/main-nav/main-nav.stories.astro
@@ -1,26 +1,18 @@
 ---
 import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import MainNavComponent from "./main-nav.astro";
 
 const title = "MainNav";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Organisms", url: "/design-system/components/organisms" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "organisms",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 
 const items = [
   { label: "Item 1", url: "#item-1" },

--- a/src/components/organisms/main-nav/main-nav.stories.astro
+++ b/src/components/organisms/main-nav/main-nav.stories.astro
@@ -1,7 +1,7 @@
 ---
-import type { ComponentProps } from "astro/types";
 import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
+import CodePreview from "../../molecules/code-preview/code-preview.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import MainNavComponent from "./main-nav.astro";
 
@@ -13,20 +13,40 @@ const { breadcrumb, seo } = getStoryMeta({
     title,
   },
 });
+---
 
+<PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
+  <Fragment slot="body">
+    <Heading as="h2">Introduction</Heading>
+    <p>This component is used to display the main navigation.</p>
+    <CodePreview
+      code={`import MainNav from "./components/organisms/main-nav/main-nav.astro";`}
+      label="How to import"
+      lang="ts"
+    />
+    <CodePreview
+      code={`---
 const items = [
   { label: "Item 1", url: "#item-1" },
   { label: "Item 2", url: "#item-2" },
   { label: "Item 3", url: "#item-3" },
   { label: "Item 4", url: "#item-4" },
   { label: "Item 5", url: "#item-5" },
-] satisfies ComponentProps<typeof MainNavComponent>["items"];
+]
 ---
-
-<PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
-  <Fragment slot="body">
-    <Heading as="h2">Usage</Heading>
-    <p>This component is used to display the main navigation.</p>
-    <MainNavComponent items={items} />
+<MainNav items={items} />`}
+      label="Basic use"
+      lang="astro"
+    >
+      <MainNavComponent
+        items={[
+          { label: "Item 1", url: "#item-1" },
+          { label: "Item 2", url: "#item-2" },
+          { label: "Item 3", url: "#item-3" },
+          { label: "Item 4", url: "#item-4" },
+          { label: "Item 5", url: "#item-5" },
+        ]}
+      />
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/organisms/navbar/navbar.stories.astro
+++ b/src/components/organisms/navbar/navbar.stories.astro
@@ -1,28 +1,17 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import NavbarComponent from "./navbar.astro";
 
 const title = "Navbar";
-
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Organisms", url: "/design-system/components/organisms" },
-  { label: title, url: Astro.url.href },
-];
-
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "organisms",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>

--- a/src/components/organisms/navbar/navbar.stories.astro
+++ b/src/components/organisms/navbar/navbar.stories.astro
@@ -1,6 +1,7 @@
 ---
 import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
+import CodePreview from "../../molecules/code-preview/code-preview.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import NavbarComponent from "./navbar.astro";
 
@@ -21,10 +22,25 @@ const { breadcrumb, seo } = getStoryMeta({
       A <code>Navbar</code> component should be used in the website layout to provide
       navigation items to the user.
     </p>
-    <NavbarComponent id="usage-example">
-      <div slot="nav">Nav</div>
-      <div slot="search">Search</div>
-      <div slot="settings">Settings</div>
-    </NavbarComponent>
+    <CodePreview
+      code={`import Navbar from "./components/organisms/navbar/navbar.astro";`}
+      label="How to import"
+      lang="ts"
+    />
+    <CodePreview
+      code={`<Navbar id="usage-example">
+  <div slot="nav">Nav</div>
+  <div slot="search">Search</div>
+  <div slot="settings">Settings</div>
+</Navbar>`}
+      label="Basic use"
+      lang="astro"
+    >
+      <NavbarComponent id="usage-example">
+        <div slot="nav">Nav</div>
+        <div slot="search">Search</div>
+        <div slot="settings">Settings</div>
+      </NavbarComponent>
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/organisms/page/stories/index.stories.astro
+++ b/src/components/organisms/page/stories/index.stories.astro
@@ -1,5 +1,5 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../../utils/stories";
 import Heading from "../../../atoms/heading/heading.astro";
 import Link from "../../../atoms/link/link.astro";
 import ListItem from "../../../atoms/list/list-item.astro";
@@ -7,22 +7,13 @@ import List from "../../../atoms/list/list.astro";
 import PageLayout from "../../../templates/page-layout/page-layout.astro";
 
 const title = "Page";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Organisms", url: "/design-system/components/organisms" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "organisms",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>

--- a/src/components/organisms/pagination/pagination.stories.astro
+++ b/src/components/organisms/pagination/pagination.stories.astro
@@ -2,6 +2,7 @@
 import type { ComponentProps } from "astro/types";
 import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
+import CodePreview from "../../molecules/code-preview/code-preview.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import PaginationComponent from "./pagination.astro";
 
@@ -26,22 +27,61 @@ const renderLink: ComponentProps<typeof PaginationComponent>["renderLink"] = (
       A <code>Pagination</code> component should be used when a collection of items
       is divided in multiple pages.
     </p>
-    <Heading as="h2">With few pages</Heading>
-    <PaginationComponent current={1} last={4} renderLink={renderLink} />
+    <CodePreview
+      code={`import Pagination from "./components/organisms/pagination/pagination.astro";`}
+      label="How to import"
+      lang="ts"
+    />
+    <CodePreview
+      code={`<Pagination current={1} last={4} renderLink={renderLink} />`}
+      label="Basic use"
+      lang="astro"
+    >
+      <PaginationComponent current={1} last={4} renderLink={renderLink} />
+    </CodePreview>
     <Heading as="h2">With ellipsis and current page is first page</Heading>
-    <PaginationComponent current={1} last={10} renderLink={renderLink} />
+    <CodePreview
+      code={`<Pagination current={1} last={10} renderLink={renderLink} />`}
+      label="Showing ellipsis when current page is the first one"
+      lang="astro"
+    >
+      <PaginationComponent current={1} last={10} renderLink={renderLink} />
+    </CodePreview>
     <Heading as="h2">With ellipsis and current page is last page</Heading>
-    <PaginationComponent current={10} last={10} renderLink={renderLink} />
+    <CodePreview
+      code={`<Pagination current={10} last={10} renderLink={renderLink} />`}
+      label="Showing ellipsis when current page is the last one"
+      lang="astro"
+    >
+      <PaginationComponent current={10} last={10} renderLink={renderLink} />
+    </CodePreview>
     <Heading as="h2">
       With both ellipsis and current page is in the middle
     </Heading>
-    <PaginationComponent current={25} last={50} renderLink={renderLink} />
-    <Heading as="h2"> With custom siblings number </Heading>
-    <PaginationComponent
-      current={25}
-      last={50}
-      renderLink={renderLink}
-      siblings={3}
-    />
+    <CodePreview
+      code={`<Pagination current={25} last={50} renderLink={renderLink} />`}
+      label="Showing ellipsis on both side when current page is in the middle"
+      lang="astro"
+    >
+      <PaginationComponent current={25} last={50} renderLink={renderLink} />
+    </CodePreview>
+    <Heading as="h2">With custom siblings count</Heading>
+    <CodePreview
+      code={`<PaginationComponent
+  current={25}
+  last={50}
+  renderLink={renderLink}
+  siblings={3}
+/>`}
+      label="Using a custom siblings count"
+      lang="astro"
+    >
+      <PaginationComponent
+        current={25}
+        last={50}
+        renderLink={renderLink}
+        siblings={3}
+      />
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/organisms/pagination/pagination.stories.astro
+++ b/src/components/organisms/pagination/pagination.stories.astro
@@ -1,26 +1,18 @@
 ---
 import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import PaginationComponent from "./pagination.astro";
 
 const title = "Pagination";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Molecules", url: "/design-system/components/molecules" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "organisms",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 
 const renderLink: ComponentProps<typeof PaginationComponent>["renderLink"] = (
   page

--- a/src/components/organisms/search-form/search-form.stories.astro
+++ b/src/components/organisms/search-form/search-form.stories.astro
@@ -1,6 +1,7 @@
 ---
 import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
+import CodePreview from "../../molecules/code-preview/code-preview.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import SearchFormComponent from "./search-form.astro";
 
@@ -21,18 +22,35 @@ const { breadcrumb, seo } = getStoryMeta({
       A <code>SearchForm</code> component should be used to authorize the user to
       search a page on the website using keywords.
     </p>
-    <SearchFormComponent
-      id="usage-example"
-      queryParam="query"
-      resultsPage="/#results"
+    <CodePreview
+      code={`import SearchForm from "./components/organisms/search-form/search-form.astro";`}
+      label="How to import"
+      lang="ts"
     />
+    <CodePreview
+      code={`<SearchForm id="use-example" queryParam="query" resultsPage="/#results" />`}
+      label="Basic use"
+      lang="astro"
+    >
+      <SearchFormComponent
+        id="use-example"
+        queryParam="query"
+        resultsPage="/#results"
+      />
+    </CodePreview>
     <Heading as="h2">Options</Heading>
     <Heading as="h3"><code>isInline</code></Heading>
-    <SearchFormComponent
-      id="inline-example"
-      isInline
-      queryParam="query"
-      resultsPage="/#results"
-    />
+    <CodePreview
+      code={`<SearchForm id="inlined-example" isInline queryParam="query" resultsPage="/#results" />`}
+      label="Using an inlined search form"
+      lang="astro"
+    >
+      <SearchFormComponent
+        id="inlined-example"
+        isInline
+        queryParam="query"
+        resultsPage="/#results"
+      />
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/organisms/search-form/search-form.stories.astro
+++ b/src/components/organisms/search-form/search-form.stories.astro
@@ -1,28 +1,17 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import SearchFormComponent from "./search-form.astro";
 
-const title = "Search Form";
-
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Organisms", url: "/design-system/components/organisms" },
-  { label: title, url: Astro.url.href },
-];
-
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const title = "SearchForm";
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "organisms",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>

--- a/src/components/organisms/settings-form/settings-form.stories.astro
+++ b/src/components/organisms/settings-form/settings-form.stories.astro
@@ -1,27 +1,18 @@
 ---
 import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import SettingsFormComponent from "./settings-form.astro";
 
 const title = "SettingsForm";
-
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Organisms", url: "/design-system/components/organisms" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "organisms",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 const altLanguages: ComponentProps<
   typeof SettingsFormComponent
 >["altLanguages"] = [

--- a/src/components/organisms/settings-form/settings-form.stories.astro
+++ b/src/components/organisms/settings-form/settings-form.stories.astro
@@ -1,7 +1,7 @@
 ---
-import type { ComponentProps } from "astro/types";
 import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
+import CodePreview from "../../molecules/code-preview/code-preview.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import SettingsFormComponent from "./settings-form.astro";
 
@@ -13,12 +13,6 @@ const { breadcrumb, seo } = getStoryMeta({
     title,
   },
 });
-const altLanguages: ComponentProps<
-  typeof SettingsFormComponent
->["altLanguages"] = [
-  { locale: "en", route: "#my-en-route" },
-  { locale: "fr", route: "#ma-route-fr" },
-];
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>
@@ -28,16 +22,42 @@ const altLanguages: ComponentProps<
       A <code>SettingsForm</code> component should be used to authorize the user
       to customize the website.
     </p>
-    <SettingsFormComponent id="usage-example" />
+    <CodePreview
+      code={`import SettingsForm from "./components/organisms/settings-form/settings-form.astro";`}
+      label="How to import"
+      lang="ts"
+    />
+    <CodePreview
+      code={`<SettingsForm id="usage-example" />`}
+      label="Basic use"
+      lang="astro"
+    >
+      <SettingsFormComponent id="usage-example" />
+    </CodePreview>
     <Heading as="h2">Alternatives languages</Heading>
     <p>
       You can provide the routes to use for the alternative languages using the <code
         >altLanguages</code
       > property.
     </p>
-    <SettingsFormComponent
-      altLanguages={altLanguages}
-      id="alt-languages-example"
-    />
+    <CodePreview
+      code={`<SettingsForm
+  altLanguages={[
+    { locale: "en", route: "#my-en-route" },
+    { locale: "fr", route: "#ma-route-fr" },
+  ]}
+  id="alt-languages-example"
+/>`}
+      label="Basic use"
+      lang="astro"
+    >
+      <SettingsFormComponent
+        altLanguages={[
+          { locale: "en", route: "#my-en-route" },
+          { locale: "fr", route: "#ma-route-fr" },
+        ]}
+        id="alt-languages-example"
+      />
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/organisms/table-of-contents/table-of-contents.stories.astro
+++ b/src/components/organisms/table-of-contents/table-of-contents.stories.astro
@@ -1,22 +1,17 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import TOC from "./table-of-contents.astro";
 
 const title = "TableOfContents";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Molecules", url: "/design-system/components/molecules" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: `Design system / Components / Molecules / ${title}`,
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "organisms",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>

--- a/src/components/organisms/table-of-contents/table-of-contents.stories.astro
+++ b/src/components/organisms/table-of-contents/table-of-contents.stories.astro
@@ -1,6 +1,7 @@
 ---
 import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
+import CodePreview from "../../molecules/code-preview/code-preview.astro";
 import PageLayout from "../../templates/page-layout/page-layout.astro";
 import TOC from "./table-of-contents.astro";
 
@@ -21,49 +22,105 @@ const { breadcrumb, seo } = getStoryMeta({
       A <code>TableOfContents</code> component should be used on a page to help user
       navigates through that page using headings.
     </p>
-    <Heading as="h2">Flat structure</Heading>
-    <TOC
-      headings={[
-        { label: "qui velit ratione", slug: "#rerum-velit-dolorem" },
-        { label: "dolorem sit omnis", slug: "#quam-fuga-voluptas" },
-        { label: "inventore qui suscipit", slug: "#culpa-asperiores-atque" },
-      ]}
+    <CodePreview
+      code={`import TableOfContents from "./components/organisms/table-of-contents/table-of-contents.astro";`}
+      label="How to import"
+      lang="ts"
     />
+    <CodePreview
+      code={`<TableOfContents
+  headings={[
+    { label: "qui velit ratione", slug: "#rerum-velit-dolorem" },
+    { label: "dolorem sit omnis", slug: "#quam-fuga-voluptas" },
+    { label: "inventore qui suscipit", slug: "#culpa-asperiores-atque" },
+  ]}
+/>`}
+      label="Basic use"
+      lang="astro"
+    >
+      <TOC
+        headings={[
+          { label: "qui velit ratione", slug: "#rerum-velit-dolorem" },
+          { label: "dolorem sit omnis", slug: "#quam-fuga-voluptas" },
+          { label: "inventore qui suscipit", slug: "#culpa-asperiores-atque" },
+        ]}
+      />
+    </CodePreview>
     <Heading as="h2">Nested structure</Heading>
-    <TOC
-      headings={[
-        { label: "dolorum nihil nobis", slug: "#dignissimos-ipsa-ex" },
+    <CodePreview
+      code={`<TableOfContents
+  headings={[
+    { label: "dolorum nihil nobis", slug: "#dignissimos-ipsa-ex" },
+    {
+      label: "quam eum corrupti",
+      slug: "#et-blanditiis-ducimus",
+      children: [
         {
-          label: "quam eum corrupti",
-          slug: "#et-blanditiis-ducimus",
+          label: "nam explicabo facere",
+          slug: "#voluptates-minus-molestiae",
+        },
+        { label: "minus non aut", slug: "#doloremque-cum-neque" },
+      ],
+    },
+    {
+      label: "cupiditate atque reprehenderit",
+      slug: "#eum-vero-consequatur",
+      children: [
+        {
+          label: "similique soluta adipisci",
+          slug: "#aperiam-autem-aut",
           children: [
             {
-              label: "nam explicabo facere",
-              slug: "#voluptates-minus-molestiae",
+              label: "doloribus molestiae eos",
+              slug: "#molestias-sint-et",
             },
-            { label: "minus non aut", slug: "#doloremque-cum-neque" },
+            { label: "aut illo quibusdam", slug: "#a-cum-eum" },
           ],
         },
-        {
-          label: "cupiditate atque reprehenderit",
-          slug: "#eum-vero-consequatur",
-          children: [
-            {
-              label: "similique soluta adipisci",
-              slug: "#aperiam-autem-aut",
-              children: [
-                {
-                  label: "doloribus molestiae eos",
-                  slug: "#molestias-sint-et",
-                },
-                { label: "aut illo quibusdam", slug: "#a-cum-eum" },
-              ],
-            },
-            { label: "labore labore qui", slug: "#quaerat-et-amet" },
-          ],
-        },
-        { label: "laudantium quia recusandae", slug: "#iste-accusamus-quod" },
-      ]}
-    />
+        { label: "labore labore qui", slug: "#quaerat-et-amet" },
+      ],
+    },
+    { label: "laudantium quia recusandae", slug: "#iste-accusamus-quod" },
+  ]}
+/>`}
+      label="Basic use"
+      lang="astro"
+    >
+      <TOC
+        headings={[
+          { label: "dolorum nihil nobis", slug: "#dignissimos-ipsa-ex" },
+          {
+            label: "quam eum corrupti",
+            slug: "#et-blanditiis-ducimus",
+            children: [
+              {
+                label: "nam explicabo facere",
+                slug: "#voluptates-minus-molestiae",
+              },
+              { label: "minus non aut", slug: "#doloremque-cum-neque" },
+            ],
+          },
+          {
+            label: "cupiditate atque reprehenderit",
+            slug: "#eum-vero-consequatur",
+            children: [
+              {
+                label: "similique soluta adipisci",
+                slug: "#aperiam-autem-aut",
+                children: [
+                  {
+                    label: "doloribus molestiae eos",
+                    slug: "#molestias-sint-et",
+                  },
+                  { label: "aut illo quibusdam", slug: "#a-cum-eum" },
+                ],
+              },
+              { label: "labore labore qui", slug: "#quaerat-et-amet" },
+            ],
+          },
+          { label: "laudantium quia recusandae", slug: "#iste-accusamus-quod" },
+        ]}
+      />
+    </CodePreview>
   </Fragment>
 </PageLayout>

--- a/src/components/templates/layout/layout.stories.astro
+++ b/src/components/templates/layout/layout.stories.astro
@@ -1,15 +1,16 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../utils/stories";
 import Heading from "../../atoms/heading/heading.astro";
 import LayoutComponent from "./layout.astro";
 
 const title = "Layout";
-
-const seo: ComponentProps<typeof LayoutComponent>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: `${title} | Templates | Components | Design system`,
-};
+const { seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "templates",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 ---
 
 <LayoutComponent seo={seo}>

--- a/src/components/templates/page-layout/stories/index.stories.astro
+++ b/src/components/templates/page-layout/stories/index.stories.astro
@@ -1,5 +1,5 @@
 ---
-import type { ComponentProps } from "astro/types";
+import { getStoryMeta } from "../../../../utils/stories";
 import Heading from "../../../atoms/heading/heading.astro";
 import Link from "../../../atoms/link/link.astro";
 import ListItem from "../../../atoms/list/list-item.astro";
@@ -7,22 +7,13 @@ import List from "../../../atoms/list/list.astro";
 import PageLayout from "../page-layout.astro";
 
 const title = "PageLayout";
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Components", url: "/design-system/components" },
-  { label: "Templates", url: "/design-system/components/templates" },
-  { label: title, url: Astro.url.href },
-];
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "templates",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 ---
 
 <PageLayout breadcrumb={breadcrumb} seo={seo} title={title}>

--- a/src/utils/stories.test.ts
+++ b/src/utils/stories.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getStoryNameFromSlug, getStoryRoute } from "./stories";
+import { getStoryMeta, getStoryNameFromSlug, getStoryRoute } from "./stories";
 
 describe("get-story-route", () => {
   it("returns the story route from its path", () => {
@@ -45,5 +45,66 @@ describe("get-story-name-from-slug", () => {
     expect(() => getStoryNameFromSlug(slug)).toThrowErrorMatchingInlineSnapshot(
       `[Error: Could not retrieve the story name from its slug. Are you sure this slug match a story?]`
     );
+  });
+});
+
+describe("get-story-meta", () => {
+  it("builds breadcrumb and seo for a component story", () => {
+    const meta = getStoryMeta({
+      breadcrumb: {
+        kind: "atoms",
+        route: "/design-system/components/atoms/story",
+        title: "Story",
+      },
+    });
+
+    expect(meta.breadcrumb).toStrictEqual([
+      { label: "Home", url: "/" },
+      { label: "Design system", url: "/design-system" },
+      { label: "Components", url: "/design-system/components" },
+      { label: "Atoms", url: "/design-system/components/atoms" },
+      { label: "Story", url: "/design-system/components/atoms/story" },
+    ]);
+    expect(meta.seo).toStrictEqual({
+      title: "Story | Atoms | Components | Design system",
+      noindex: true,
+      nofollow: true,
+    });
+  });
+
+  it("builds breadcrumb and seo for a views story", () => {
+    const meta = getStoryMeta({
+      breadcrumb: {
+        kind: "views",
+        route: "/design-system/views/homepage",
+        title: "Homepage",
+      },
+    });
+
+    expect(meta.breadcrumb).toStrictEqual([
+      { label: "Home", url: "/" },
+      { label: "Design system", url: "/design-system" },
+      { label: "Views", url: "/design-system/views" },
+      { label: "Homepage", url: "/design-system/views/homepage" },
+    ]);
+    expect(meta.seo).toStrictEqual({
+      title: "Homepage | Views | Design system",
+      noindex: true,
+      nofollow: true,
+    });
+  });
+
+  it("allows overriding seo flags", () => {
+    const meta = getStoryMeta({
+      breadcrumb: {
+        kind: "organisms",
+        route: "/design-system/components/organisms/story",
+        title: "Story",
+      },
+      seo: { noindex: false, nofollow: false },
+    });
+
+    expect(meta.seo.noindex).toBe(false);
+    expect(meta.seo.nofollow).toBe(false);
   });
 });

--- a/src/utils/stories.ts
+++ b/src/utils/stories.ts
@@ -1,4 +1,5 @@
-import { STORIES_EXT, STORIES_SUFFIX } from "./constants";
+import type { Crumb, SEO } from "../types/data";
+import { COMPONENT_KINDS, STORIES_EXT, STORIES_SUFFIX } from "./constants";
 import { getParentDirPath, joinPaths } from "./paths";
 import { capitalizeFirstLetter } from "./strings";
 
@@ -50,4 +51,97 @@ export const getStoryNameFromSlug = (slug: string): string => {
     .split("-")
     .map((story) => capitalizeFirstLetter(story))
     .join("");
+};
+
+type ComponentKind = (typeof COMPONENT_KINDS)[number];
+
+type StoryBreadcrumbConfig = {
+  kind: ComponentKind | "views";
+  route: string;
+  title: string;
+};
+
+const STORY_KIND_META = {
+  atoms: { label: "Atoms", slug: "atoms" },
+  molecules: { label: "Molecules", slug: "molecules" },
+  organisms: { label: "Organisms", slug: "organisms" },
+  templates: { label: "Templates", slug: "templates" },
+  views: { label: "Views", slug: "views" },
+} satisfies Record<ComponentKind | "views", { label: string; slug: string }>;
+
+const ROOT_CRUMBS: Crumb[] = [
+  { label: "Home", url: "/" },
+  { label: "Design system", url: "/design-system" },
+];
+
+/**
+ * Build the breadcrumb trail for a design system story.
+ *
+ * @template K - The kind of story.
+ * @param {Extract<StoryBreadcrumbConfig, { kind: K }>} config - Story configuration.
+ * @returns {Crumb[]} An crumbs list for the story.
+ */
+const getStoryBreadcrumb = (config: StoryBreadcrumbConfig): Crumb[] => {
+  const { label, slug } = STORY_KIND_META[config.kind];
+  if (config.kind === "views") {
+    return [
+      ...ROOT_CRUMBS,
+      { label, url: `/design-system/${slug}` },
+      { label: config.title, url: config.route },
+    ];
+  }
+
+  return [
+    ...ROOT_CRUMBS,
+    { label: "Components", url: "/design-system/components" },
+    { label, url: `/design-system/components/${slug}` },
+    { label: config.title, url: config.route },
+  ];
+};
+
+/**
+ * Derive the `<title>` string for SEO purposes from a breadcrumb trail.
+ *
+ * @param {Crumb[]} breadcrumb - The breadcrumb trail for the page.
+ * @returns {string} A human-readable SEO title string.
+ */
+const getStorySeoTitle = (breadcrumb: Crumb[]): string =>
+  breadcrumb
+    .slice(1)
+    .reverse()
+    .map((crumb) => crumb.label)
+    .join(" | ");
+
+type StoryMetaOptions = {
+  breadcrumb: StoryBreadcrumbConfig;
+  seo?: Pick<SEO, "nofollow" | "noindex"> | null | undefined;
+};
+
+type StoryMeta = {
+  breadcrumb: Crumb[];
+  seo: Pick<SEO, "nofollow" | "noindex" | "title">;
+};
+
+/**
+ * Compute both breadcrumb and SEO metadata for a story in one call.
+ *
+ * - Breadcrumb is always derived from the provided story config.
+ * - SEO title is derived from the breadcrumb with some overridable data.
+ *
+ * @param {StoryMetaOptions} options - The story meta config.
+ * @returns {StoryMeta} An object containing `breadcrumb` and `seo` metadata.
+ */
+export const getStoryMeta = ({
+  breadcrumb: config,
+  seo,
+}: StoryMetaOptions): StoryMeta => {
+  const breadcrumb = getStoryBreadcrumb(config);
+  return {
+    breadcrumb,
+    seo: {
+      noindex: seo?.noindex ?? true,
+      nofollow: seo?.nofollow ?? true,
+      title: getStorySeoTitle(breadcrumb),
+    },
+  };
 };

--- a/src/views/blog-index-view/blog-index-view.stories.astro
+++ b/src/views/blog-index-view/blog-index-view.stories.astro
@@ -1,26 +1,16 @@
 ---
 import type { ComponentProps } from "astro/types";
-import PageLayout from "../../components/templates/page-layout/page-layout.astro";
+import { getStoryMeta } from "../../utils/stories";
 import BlogIndexViewComponent from "./blog-index-view.astro";
 
 const title = "BlogIndexView";
-
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Views", url: "/design-system/views" },
-  { label: title, url: Astro.url.href },
-];
-
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "views",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 
 const fakePage: ComponentProps<typeof BlogIndexViewComponent>["entry"] = {
   Content: Fragment,

--- a/src/views/collection-listing-view/collection-listing-view.stories.astro
+++ b/src/views/collection-listing-view/collection-listing-view.stories.astro
@@ -1,26 +1,16 @@
 ---
 import type { ComponentProps } from "astro/types";
-import PageLayout from "../../components/templates/page-layout/page-layout.astro";
+import { getStoryMeta } from "../../utils/stories";
 import CollectionListingViewComponent from "./collection-listing-view.astro";
 
 const title = "CollectionListingView";
-
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Views", url: "/design-system/views" },
-  { label: title, url: Astro.url.href },
-];
-
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "views",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 
 const fakePage: ComponentProps<typeof CollectionListingViewComponent>["entry"] =
   {

--- a/src/views/contact-view/contact-view.stories.astro
+++ b/src/views/contact-view/contact-view.stories.astro
@@ -1,26 +1,16 @@
 ---
 import type { ComponentProps } from "astro/types";
-import PageLayout from "../../components/templates/page-layout/page-layout.astro";
+import { getStoryMeta } from "../../utils/stories";
 import ContactViewComponent from "./contact-view.astro";
 
 const title = "ContactView";
-
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Views", url: "/design-system/views" },
-  { label: title, url: Astro.url.href },
-];
-
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "views",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 
 const fakePage: ComponentProps<typeof ContactViewComponent>["entry"] = {
   Content: Fragment,

--- a/src/views/default-page-view/default-page-view.stories.astro
+++ b/src/views/default-page-view/default-page-view.stories.astro
@@ -1,26 +1,16 @@
 ---
 import type { ComponentProps } from "astro/types";
-import PageLayout from "../../components/templates/page-layout/page-layout.astro";
+import { getStoryMeta } from "../../utils/stories";
 import DefaultPageViewComponent from "./default-page-view.astro";
 
 const title = "DefaultPageView";
-
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Views", url: "/design-system/views" },
-  { label: title, url: Astro.url.href },
-];
-
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "views",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 
 const fakePage: ComponentProps<typeof DefaultPageViewComponent>["entry"] = {
   Content: Fragment,

--- a/src/views/feeds-view/feeds-view.stories.astro
+++ b/src/views/feeds-view/feeds-view.stories.astro
@@ -1,26 +1,16 @@
 ---
 import type { ComponentProps } from "astro/types";
-import PageLayout from "../../components/templates/page-layout/page-layout.astro";
+import { getStoryMeta } from "../../utils/stories";
 import FeedsViewComponent from "./feeds-view.astro";
 
 const title = "FeedsView";
-
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Views", url: "/design-system/views" },
-  { label: title, url: Astro.url.href },
-];
-
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "views",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 
 const fakePage: ComponentProps<typeof FeedsViewComponent>["entry"] = {
   Content: Fragment,

--- a/src/views/homepage-view/homepage-view.stories.astro
+++ b/src/views/homepage-view/homepage-view.stories.astro
@@ -1,26 +1,16 @@
 ---
 import type { ComponentProps } from "astro/types";
-import PageLayout from "../../components/templates/page-layout/page-layout.astro";
+import { getStoryMeta } from "../../utils/stories";
 import HomepageViewComponent from "./homepage-view.astro";
 
 const title = "HomepageView";
-
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Views", url: "/design-system/views" },
-  { label: title, url: Astro.url.href },
-];
-
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "views",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 
 const fakePage: ComponentProps<typeof HomepageViewComponent>["entry"] = {
   Content: Fragment,

--- a/src/views/not-found-view/not-found.stories.astro
+++ b/src/views/not-found-view/not-found.stories.astro
@@ -1,26 +1,16 @@
 ---
 import type { ComponentProps } from "astro/types";
-import PageLayout from "../../components/templates/page-layout/page-layout.astro";
+import { getStoryMeta } from "../../utils/stories";
 import NotFoundViewComponent from "./not-found-view.astro";
 
 const title = "NotFoundView";
-
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Views", url: "/design-system/views" },
-  { label: title, url: Astro.url.href },
-];
-
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "views",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 
 const fakePage: ComponentProps<typeof NotFoundViewComponent>["entry"] = {
   Content: Fragment,

--- a/src/views/search-view/search-view.stories.astro
+++ b/src/views/search-view/search-view.stories.astro
@@ -1,26 +1,16 @@
 ---
 import type { ComponentProps } from "astro/types";
-import PageLayout from "../../components/templates/page-layout/page-layout.astro";
+import { getStoryMeta } from "../../utils/stories";
 import SearchViewComponent from "./search-view.astro";
 
 const title = "SearchView";
-
-const breadcrumb: ComponentProps<typeof PageLayout>["breadcrumb"] = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Views", url: "/design-system/views" },
-  { label: title, url: Astro.url.href },
-];
-
-const seo: ComponentProps<typeof PageLayout>["seo"] = {
-  nofollow: true,
-  noindex: true,
-  title: breadcrumb
-    .slice(1)
-    .reverse()
-    .map((crumb) => crumb.label)
-    .join(" | "),
-};
+const { breadcrumb, seo } = getStoryMeta({
+  breadcrumb: {
+    kind: "views",
+    route: Astro.url.pathname,
+    title,
+  },
+});
 
 const fakePage: ComponentProps<typeof SearchViewComponent>["entry"] = {
   Content: Fragment,


### PR DESCRIPTION
## Changes

* Extracts `breadcrumb` and `seo` logic for stories in an helper to reduce logic duplication,
* Adds a new `CodePreview` component (meant to be used in stories... by why not in future writings?)
* Updates stories to use both the helper and the new component.

**TODO:**
* explore other ways to write stories (while this makes things cleaner once rendered and reduce the needs of multiple components to write a story, I think the authoring experience is still bad... I wonder if I can use Markdown/MDX instead...)

## Tests

N/A regarding Vitest, but I checked visually each stories.

## Docs

N/A