### PR TITLE
feat: improve `useRouting` API

### DIFF
--- a/.changeset/funny-icons-draw.md
+++ b/.changeset/funny-icons-draw.md
@@ -6,7 +6,7 @@ Replaces the `route` helper from `useI18n` with `useRouting`.
 
 Routes are no longer handled statically in a translation file but dynamically in an index built from data provided in your content directory. Because of that, the `route` property has been removed from the object returned by `useI18n()`.
 
-If you need to display a route in your templates, you'll need to import and use the `useRouting()` utility instead. This returns an object containing a `routeById()` helper.
+If you need to display a route in your templates, you'll need to import and use the `useRouting()` utility instead. This returns an object containing a `routeById()` helper that uses a similar API than `route()`.
 
 ```diff
 ---
@@ -15,9 +15,9 @@ import { useI18n } from "../../../services/i18n";
 
 -const { locale, route, translate } = useI18n(Astro.currentLocale);
 +const { locale, translate } = useI18n(Astro.currentLocale);
-+const { routeById } = await useRouting();
-+const homeRoute = routeById(`${locale}/home`);
-+const blogRoute = routeById(`${locale}/blog`);
++const { routeById } = await useRouting(locale);
++const homeRoute = routeById("home");
++const blogRoute = routeById("blog");
 
 const mainNav = [
   {

--- a/.changeset/funny-icons-draw.md
+++ b/.changeset/funny-icons-draw.md
@@ -16,22 +16,28 @@ import { useI18n } from "../../../services/i18n";
 -const { locale, route, translate } = useI18n(Astro.currentLocale);
 +const { locale, translate } = useI18n(Astro.currentLocale);
 +const { routeById } = await useRouting();
++const homeRoute = routeById(`${locale}/home`);
++const blogRoute = routeById(`${locale}/blog`);
 
 const mainNav = [
   {
     icon: "home",
     iconSize: 28,
-    label: translate("page.home.title"),
+-    label: translate("page.home.title"),
++    label: homeRoute.label,
 -    url: route("home"),
-+    url: routeById(`${locale}/home`),
++    url: homeRoute.url,
   },
   {
     icon: "blog",
     iconSize: 28,
-    label: translate("page.blog.title"),
+-    label: translate("page.blog.title"),
++    label: blogRoute.label,
 -    url: route("blog"),
-+    url: routeById(`${locale}/blog`),
++    url: blogRoute.url,
   },
 ];
 ---
 ```
+
+The route label is based on the title you defined in your Markdown file. If this title is not suitable as a route label, you can continue to use your own label.

--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ To use localized routing in your templates and components, you can import the `u
 import { useRouting } from "../services/routing";
 
 const { routeById } = await useRouting();
-console.log(routeById("en/projects")) // "/en/projects"
-console.log(routeById("en/projects/first-project")) // "/en/projects/first-project"
-console.log(routeById("fr/projects")) // "/projets"
-console.log(routeById("fr/projects/first-project")) // "/projets/premier-projet"
+console.log(routeById("en/projects")) // { label: "Projects", url: "/en/projects" }
+console.log(routeById("en/projects/first-project")) // { label: "First project", url: "/en/projects/first-project" }
+console.log(routeById("fr/projects")) // { label: "Projets", url: "/projets" }
+console.log(routeById("fr/projects/first-project")) // { label: "Premier projet", url: "/projets/premier-projet" }
 ---
 ```
 
@@ -481,7 +481,7 @@ const { locale, translate, translatePlural } = useI18n(Astro.currentLocale);
 const { routeById } = await useRouting();
 ---
 
-<a href={routeById(`${locale}/contact`)}>
+<a href={routeById(`${locale}/contact`).url}>
   {translate("some.key.available.in.translations")}
 </a>
 <div>

--- a/README.md
+++ b/README.md
@@ -82,15 +82,23 @@ To use localized routing in your templates and components, you can import the `u
 ---
 import { useRouting } from "../services/routing";
 
-const { routeById } = await useRouting();
-console.log(routeById("en/projects")) // { label: "Projects", url: "/en/projects" }
-console.log(routeById("en/projects/first-project")) // { label: "First project", url: "/en/projects/first-project" }
-console.log(routeById("fr/projects")) // { label: "Projets", url: "/projets" }
-console.log(routeById("fr/projects/first-project")) // { label: "Premier projet", url: "/projets/premier-projet" }
+const { routeById } = await useRouting("fr");
+console.log(routeById("projects")) // { label: "Projets", url: "/projets" }
+console.log(routeById("projects/first-project")) // { label: "Premier projet", url: "/projets/premier-projet" }
 ---
 ```
 
-The `useRouting()` helper returns a `routeById()` function which is convenient when you use the same id in every locales for your contents. For example, You can then use the following: ``routeById(`${locale}/contact`)`` to display the contact page route in the current locale.
+You can also override the locale provided to `useRouting` per `routeById` call when you need a route in a different locale:
+
+```astro
+---
+import { useRouting } from "../services/routing";
+
+const { routeById } = await useRouting("fr");
+console.log(routeById("projects", "en")) // { label: "Projects", url: "/en/projects" }
+console.log(routeById("projects/first-project", "en")) // { label: "First project", url: "/en/projects/first-project" }
+---
+```
 
 #### Switching between languages
 
@@ -478,11 +486,13 @@ import { useRouting } from "src/services/routing";
 import { useI18n } from "src/utils/helpers/i18n";
 
 const { locale, translate, translatePlural } = useI18n(Astro.currentLocale);
-const { routeById } = await useRouting();
+const { routeById } = await useRouting(locale);
+const contactRoute = routeById("contact");
 ---
 
-<a href={routeById(`${locale}/contact`).url}>
-  {translate("some.key.available.in.translations")}
+<p>{translate("some.key.available.in.translations")}</p>
+<a href={contactRoute.url}>
+  {contactRoute.label}
 </a>
 <div>
   {translatePlural("some.key.supporting.pluralization", { count: 42 })}

--- a/src/components/molecules/breadcrumb/breadcrumb.astro
+++ b/src/components/molecules/breadcrumb/breadcrumb.astro
@@ -1,12 +1,12 @@
 ---
 import type { HTMLAttributes } from "astro/types";
-import type { Crumb } from "../../../types/data";
+import type { Route } from "../../../types/data";
 import NavItem from "../nav-item/nav-item.astro";
 import NavList from "../nav-list/nav-list.astro";
 
 type Props = HTMLAttributes<"nav"> & {
   isCentered?: boolean | null | undefined;
-  items: Crumb[];
+  items: Route[];
 };
 
 const { class: className, isCentered = false, items, ...attrs } = Astro.props;

--- a/src/components/organisms/settings-form/settings-form.astro
+++ b/src/components/organisms/settings-form/settings-form.astro
@@ -4,6 +4,7 @@ import { useI18n } from "../../../services/i18n";
 import { useRouting } from "../../../services/routing";
 import type { AltLanguage } from "../../../types/data";
 import { LOCALE_DISPLAY_NAMES } from "../../../utils/constants";
+import { isAvailableLocale } from "../../../utils/type-guards";
 import LanguagePicker from "../../molecules/language-picker/language-picker.astro";
 import ThemeSetting from "../../molecules/theme-setting/theme-setting.astro";
 
@@ -12,20 +13,26 @@ type Props = HTMLAttributes<"form"> & {
 };
 
 const { altLanguages, class: className, id, ...attrs } = Astro.props;
-const { routeById } = await useRouting();
 const { locale, translate } = useI18n(Astro.currentLocale);
+const { routeById } = await useRouting(locale);
 const languages = Object.fromEntries(
-  Object.entries(LOCALE_DISPLAY_NAMES).map(([lang, langName]) => [
-    lang,
-    {
-      name: langName,
-      route:
-        lang === locale
-          ? Astro.url.href
-          : (altLanguages?.find((altLang) => altLang.locale === lang)?.route ??
-            routeById(`${lang}/home`).url),
-    },
-  ])
+  Object.entries(LOCALE_DISPLAY_NAMES)
+    .map(([lang, langName]) => {
+      if (!isAvailableLocale(lang)) return null;
+
+      return [
+        lang,
+        {
+          name: langName,
+          route:
+            lang === locale
+              ? Astro.url.href
+              : (altLanguages?.find((altLang) => altLang.locale === lang)
+                  ?.route ?? routeById("home", lang).url),
+        },
+      ];
+    })
+    .filter((language) => language !== null)
 );
 ---
 

--- a/src/components/organisms/settings-form/settings-form.astro
+++ b/src/components/organisms/settings-form/settings-form.astro
@@ -23,7 +23,7 @@ const languages = Object.fromEntries(
         lang === locale
           ? Astro.url.href
           : (altLanguages?.find((altLang) => altLang.locale === lang)?.route ??
-            routeById(`${lang}/home`)),
+            routeById(`${lang}/home`).url),
     },
   ])
 );

--- a/src/components/templates/layout/layout.astro
+++ b/src/components/templates/layout/layout.astro
@@ -29,8 +29,8 @@ type Props = Pick<ComponentProps<typeof Head>, "seo"> &
 
 const { class: className, seo, ...attrs } = Astro.props;
 const { locale, translate } = useI18n(Astro.currentLocale);
-const { routeById } = await useRouting();
-const homeRoute = routeById(`${locale}/home`);
+const { routeById } = await useRouting(locale);
+const homeRoute = routeById("home");
 const isHome = Astro.url.pathname === homeRoute.url;
 const mainNav = [
   {
@@ -43,43 +43,43 @@ const mainNav = [
     icon: "blog",
     iconSize: 28,
     label: translate("page.blog.title"),
-    url: routeById(`${locale}/blog`).url,
+    url: routeById("blog").url,
   },
   {
     icon: "guide",
     iconSize: 28,
     label: translate("page.guides.title"),
-    url: routeById(`${locale}/guides`).url,
+    url: routeById("guides").url,
   },
   {
     icon: "notepad",
     iconSize: 28,
     label: translate("page.notes.title"),
-    url: routeById(`${locale}/notes`).url,
+    url: routeById("notes").url,
   },
   {
     icon: "project",
     iconSize: 28,
     label: translate("page.projects.title"),
-    url: routeById(`${locale}/projects`).url,
+    url: routeById("projects").url,
   },
   {
     icon: "bookmark",
     iconSize: 28,
     label: translate("page.bookmarks.title"),
-    url: routeById(`${locale}/bookmarks`).url,
+    url: routeById("bookmarks").url,
   },
   {
     icon: "globe",
     iconSize: 28,
     label: translate("page.blogroll.title"),
-    url: routeById(`${locale}/blogroll`).url,
+    url: routeById("blogroll").url,
   },
   {
     icon: "contact",
     iconSize: 28,
     label: translate("page.contact.title"),
-    url: routeById(`${locale}/contact`).url,
+    url: routeById("contact").url,
   },
 ] satisfies ComponentProps<typeof NavList>["items"];
 const devOnlyLinks = import.meta.env.DEV
@@ -88,13 +88,13 @@ const devOnlyLinks = import.meta.env.DEV
 const footerLinks = [
   {
     label: translate("page.legal.notice.title"),
-    url: routeById(`${locale}/legal-notice`).url,
+    url: routeById("legal-notice").url,
   },
   {
     icon: "feed",
     iconSize: 17,
     label: translate("page.feeds.title"),
-    url: routeById(`${locale}/feeds`).url,
+    url: routeById("feeds").url,
   },
   ...devOnlyLinks,
 ] satisfies ComponentProps<typeof NavList>["items"];
@@ -151,7 +151,7 @@ const topId = translate("anchor.site.top");
                 id="site-search"
                 isInline
                 queryParam={CONFIG.SEARCH.QUERY_PARAM}
-                resultsPage={routeById(`${locale}/search`).url}
+                resultsPage={routeById("search").url}
                 slot="search"
               />
               <SettingsForm

--- a/src/components/templates/layout/layout.astro
+++ b/src/components/templates/layout/layout.astro
@@ -30,55 +30,56 @@ type Props = Pick<ComponentProps<typeof Head>, "seo"> &
 const { class: className, seo, ...attrs } = Astro.props;
 const { locale, translate } = useI18n(Astro.currentLocale);
 const { routeById } = await useRouting();
-const isHome = Astro.url.pathname === routeById(`${locale}/home`);
+const homeRoute = routeById(`${locale}/home`);
+const isHome = Astro.url.pathname === homeRoute.url;
 const mainNav = [
   {
     icon: "home",
     iconSize: 28,
     label: translate("page.home.title"),
-    url: routeById(`${locale}/home`),
+    url: homeRoute.url,
   },
   {
     icon: "blog",
     iconSize: 28,
     label: translate("page.blog.title"),
-    url: routeById(`${locale}/blog`),
+    url: routeById(`${locale}/blog`).url,
   },
   {
     icon: "guide",
     iconSize: 28,
     label: translate("page.guides.title"),
-    url: routeById(`${locale}/guides`),
+    url: routeById(`${locale}/guides`).url,
   },
   {
     icon: "notepad",
     iconSize: 28,
     label: translate("page.notes.title"),
-    url: routeById(`${locale}/notes`),
+    url: routeById(`${locale}/notes`).url,
   },
   {
     icon: "project",
     iconSize: 28,
     label: translate("page.projects.title"),
-    url: routeById(`${locale}/projects`),
+    url: routeById(`${locale}/projects`).url,
   },
   {
     icon: "bookmark",
     iconSize: 28,
     label: translate("page.bookmarks.title"),
-    url: routeById(`${locale}/bookmarks`),
+    url: routeById(`${locale}/bookmarks`).url,
   },
   {
     icon: "globe",
     iconSize: 28,
     label: translate("page.blogroll.title"),
-    url: routeById(`${locale}/blogroll`),
+    url: routeById(`${locale}/blogroll`).url,
   },
   {
     icon: "contact",
     iconSize: 28,
     label: translate("page.contact.title"),
-    url: routeById(`${locale}/contact`),
+    url: routeById(`${locale}/contact`).url,
   },
 ] satisfies ComponentProps<typeof NavList>["items"];
 const devOnlyLinks = import.meta.env.DEV
@@ -87,13 +88,13 @@ const devOnlyLinks = import.meta.env.DEV
 const footerLinks = [
   {
     label: translate("page.legal.notice.title"),
-    url: routeById(`${locale}/legal-notice`),
+    url: routeById(`${locale}/legal-notice`).url,
   },
   {
     icon: "feed",
     iconSize: 17,
     label: translate("page.feeds.title"),
-    url: routeById(`${locale}/feeds`),
+    url: routeById(`${locale}/feeds`).url,
   },
   ...devOnlyLinks,
 ] satisfies ComponentProps<typeof NavList>["items"];
@@ -138,10 +139,7 @@ const topId = translate("anchor.site.top");
           </SkipTo>
           <header class="site-header">
             <div class="site-branding">
-              <Branding
-                brand={CONFIG.BRAND}
-                url={routeById(`${locale}/home`)}
-              />
+              <Branding brand={CONFIG.BRAND} url={homeRoute.url} />
             </div>
             <Navbar
               aria-label={translate("nav.label.primary")}
@@ -153,7 +151,7 @@ const topId = translate("anchor.site.top");
                 id="site-search"
                 isInline
                 queryParam={CONFIG.SEARCH.QUERY_PARAM}
-                resultsPage={routeById(`${locale}/search`)}
+                resultsPage={routeById(`${locale}/search`).url}
                 slot="search"
               />
               <SettingsForm

--- a/src/components/templates/page-layout/page-layout.astro
+++ b/src/components/templates/page-layout/page-layout.astro
@@ -29,10 +29,9 @@ type Props = Omit<ComponentProps<typeof Page>, "heading" | "title" | "toc"> &
 const { breadcrumb, description, headings, graphs, seo, title, ...attrs } =
   Astro.props;
 const { locale, translate } = useI18n(Astro.currentLocale);
-const { routeById } = await useRouting();
-const homeRouteId = `${locale}/home`;
-const isHome = Astro.url.pathname === routeById(homeRouteId).url;
-const ogHomeImgPath = isDefaultLocale(locale) ? "home" : homeRouteId;
+const { routeById } = await useRouting(locale);
+const isHome = Astro.url.pathname === routeById("home").url;
+const ogHomeImgPath = isDefaultLocale(locale) ? "home" : `${locale}/home`;
 const ogImgPath = isHome ? ogHomeImgPath : Astro.url.pathname.slice(1);
 const socialImg = {
   height: 630,

--- a/src/components/templates/page-layout/page-layout.astro
+++ b/src/components/templates/page-layout/page-layout.astro
@@ -31,7 +31,7 @@ const { breadcrumb, description, headings, graphs, seo, title, ...attrs } =
 const { locale, translate } = useI18n(Astro.currentLocale);
 const { routeById } = await useRouting();
 const homeRouteId = `${locale}/home`;
-const isHome = Astro.url.pathname === routeById(homeRouteId);
+const isHome = Astro.url.pathname === routeById(homeRouteId).url;
 const ogHomeImgPath = isDefaultLocale(locale) ? "home" : homeRouteId;
 const ogImgPath = isHome ? ogHomeImgPath : Astro.url.pathname.slice(1);
 const socialImg = {

--- a/src/lib/astro/integrations/astro-stories/types/internal.ts
+++ b/src/lib/astro/integrations/astro-stories/types/internal.ts
@@ -1,7 +1,7 @@
-import type { Crumb } from "../../../../../types/data";
+import type { Route } from "../../../../../types/data";
 
 export type Story = {
-  breadcrumb: Crumb[];
+  breadcrumb: Route[];
   label: string;
   path: string;
   route: string;
@@ -11,7 +11,7 @@ export type Story = {
 };
 
 export type StoriesIndex = {
-  breadcrumb: Crumb[];
+  breadcrumb: Route[];
   children: { route: string; label: string }[];
   label: string;
   route: string;

--- a/src/lib/astro/integrations/astro-stories/utils.ts
+++ b/src/lib/astro/integrations/astro-stories/utils.ts
@@ -1,5 +1,5 @@
 import { basename, join, parse } from "node:path";
-import type { Crumb } from "../../../../types/data";
+import type { Route } from "../../../../types/data";
 import { getCumulativePaths, splitPath } from "../../../../utils/paths";
 import { capitalizeFirstLetter } from "../../../../utils/strings";
 import type { Stories, StoriesIndex, Story } from "./types/internal";
@@ -167,13 +167,13 @@ type GenerateBreadcrumbConfig = {
  * Generate breadcrumb trail for a given route.
  *
  * @param {GenerateBreadcrumbConfig} config - The config to generate breadcrumbs.
- * @returns {Crumb[]} Array of breadcrumb items.
+ * @returns {Route[]} Array of breadcrumb items.
  */
 const generateBreadcrumb = ({
   route,
   routeMap,
-}: GenerateBreadcrumbConfig): Crumb[] => {
-  const breadcrumb: Crumb[] = [{ url: "/", label: "Home" }];
+}: GenerateBreadcrumbConfig): Route[] => {
+  const breadcrumb: Route[] = [{ url: "/", label: "Home" }];
   const pathParts = route.split("/").filter(Boolean);
 
   for (let i = 0; i < pathParts.length; i++) {

--- a/src/lib/schema-dts/graphs/article-graph.ts
+++ b/src/lib/schema-dts/graphs/article-graph.ts
@@ -40,7 +40,7 @@ export const getArticleGraph = async ({
   title,
 }: ArticleData): Promise<Article | BlogPosting> => {
   const { translate } = useI18n(locale);
-  const { routeById } = await useRouting();
+  const { routeById } = await useRouting(locale);
   const websiteAuthor = `${WEBSITE_URL}#author` as const;
   const url = `${WEBSITE_URL}${articleRoute}`;
   const coverUrl =
@@ -72,7 +72,7 @@ export const getArticleGraph = async ({
     isAccessibleForFree: true,
     ...(isBlogPost && {
       isPartOf: {
-        "@id": `${WEBSITE_URL}${routeById(`${locale}/blog`).url}#blog`,
+        "@id": `${WEBSITE_URL}${routeById("blog").url}#blog`,
       },
     }),
     ...(meta.tags !== null &&

--- a/src/lib/schema-dts/graphs/article-graph.ts
+++ b/src/lib/schema-dts/graphs/article-graph.ts
@@ -71,7 +71,9 @@ export const getArticleGraph = async ({
     inLanguage: getLanguageGraph(locale, locale),
     isAccessibleForFree: true,
     ...(isBlogPost && {
-      isPartOf: { "@id": `${WEBSITE_URL}${routeById(`${locale}/blog`)}#blog` },
+      isPartOf: {
+        "@id": `${WEBSITE_URL}${routeById(`${locale}/blog`).url}#blog`,
+      },
     }),
     ...(meta.tags !== null &&
       meta.tags !== undefined &&

--- a/src/lib/schema-dts/graphs/blog-graph.ts
+++ b/src/lib/schema-dts/graphs/blog-graph.ts
@@ -26,7 +26,7 @@ export const getBlogGraph = async ({
   const { translate } = useI18n(locale);
   const { routeById } = await useRouting();
   const websiteAuthor = `${WEBSITE_URL}#author` as const;
-  const blogUrl = `${WEBSITE_URL}${routeById(`${locale}/blog`)}`;
+  const blogUrl = `${WEBSITE_URL}${routeById(`${locale}/blog`).url}`;
 
   return {
     "@id": `${blogUrl}#blog`,
@@ -40,7 +40,7 @@ export const getBlogGraph = async ({
     editor: { "@id": websiteAuthor },
     headline: title,
     isAccessibleForFree: true,
-    isPartOf: { "@id": `${WEBSITE_URL}${routeById(`${locale}/home`)}` },
+    isPartOf: { "@id": `${WEBSITE_URL}${routeById(`${locale}/home`).url}` },
     license: translate("license.url"),
     mainEntityOfPage: blogUrl,
     name: title,

--- a/src/lib/schema-dts/graphs/blog-graph.ts
+++ b/src/lib/schema-dts/graphs/blog-graph.ts
@@ -24,9 +24,9 @@ export const getBlogGraph = async ({
   title,
 }: BlogData): Promise<Blog> => {
   const { translate } = useI18n(locale);
-  const { routeById } = await useRouting();
+  const { routeById } = await useRouting(locale);
   const websiteAuthor = `${WEBSITE_URL}#author` as const;
-  const blogUrl = `${WEBSITE_URL}${routeById(`${locale}/blog`).url}`;
+  const blogUrl = `${WEBSITE_URL}${routeById("blog").url}`;
 
   return {
     "@id": `${blogUrl}#blog`,
@@ -40,7 +40,7 @@ export const getBlogGraph = async ({
     editor: { "@id": websiteAuthor },
     headline: title,
     isAccessibleForFree: true,
-    isPartOf: { "@id": `${WEBSITE_URL}${routeById(`${locale}/home`).url}` },
+    isPartOf: { "@id": `${WEBSITE_URL}${routeById("home").url}` },
     license: translate("license.url"),
     mainEntityOfPage: blogUrl,
     name: title,

--- a/src/lib/schema-dts/graphs/breadcrumb-list-graph.ts
+++ b/src/lib/schema-dts/graphs/breadcrumb-list-graph.ts
@@ -1,14 +1,14 @@
 import type { BreadcrumbList } from "schema-dts";
-import type { Crumb } from "../../../types/data";
+import type { Route } from "../../../types/data";
 import { getListItemGraph } from "./list-item-graph";
 
 /**
  * Retrieve a BreadcrumbList graph from the given headings.
  *
- * @param {Crumb[]} breadcrumb - A list of heading objects.
+ * @param {Route[]} breadcrumb - A list of heading objects.
  * @returns {BreadcrumbList} A graph describing the breadcrumb list.
  */
-export const getBreadcrumbListGraph = (breadcrumb: Crumb[]): BreadcrumbList => {
+export const getBreadcrumbListGraph = (breadcrumb: Route[]): BreadcrumbList => {
   return {
     "@type": "BreadcrumbList",
     itemListElement: breadcrumb.map((crumb, index) =>

--- a/src/lib/schema-dts/graphs/webpage-graph.ts
+++ b/src/lib/schema-dts/graphs/webpage-graph.ts
@@ -32,7 +32,7 @@ export const getWebPageGraph = async ({
   type,
 }: PageData): Promise<WebPage> => {
   const { translate } = useI18n(locale);
-  const { routeById } = await useRouting();
+  const { routeById } = await useRouting(locale);
   const websiteAuthor = `${WEBSITE_URL}#author` as const;
   const url = `${WEBSITE_URL}${pageRoute}`;
 
@@ -52,7 +52,7 @@ export const getWebPageGraph = async ({
     editor: { "@id": websiteAuthor },
     headline: title,
     isAccessibleForFree: true,
-    isPartOf: { "@id": `${WEBSITE_URL}${routeById(`${locale}/home`).url}` },
+    isPartOf: { "@id": `${WEBSITE_URL}${routeById("home").url}` },
     lastReviewed: meta.updatedOn.toISOString(),
     license: translate("license.url"),
     name: title,

--- a/src/lib/schema-dts/graphs/webpage-graph.ts
+++ b/src/lib/schema-dts/graphs/webpage-graph.ts
@@ -1,7 +1,7 @@
 import type { WebPage } from "schema-dts";
 import { useI18n } from "../../../services/i18n";
 import { useRouting } from "../../../services/routing";
-import type { Crumb, Page } from "../../../types/data";
+import type { Route, Page } from "../../../types/data";
 import { WEBSITE_URL } from "../../../utils/constants";
 import { getImgSrc } from "../../../utils/images";
 import { getDurationFromReadingTime } from "../values/duration";
@@ -11,7 +11,7 @@ type PageData = Pick<
   Page,
   "cover" | "description" | "locale" | "meta" | "route" | "title"
 > & {
-  breadcrumb?: Crumb[] | null | undefined;
+  breadcrumb?: Route[] | null | undefined;
   type?: WebPage["@type"] | null | undefined;
 };
 
@@ -52,7 +52,7 @@ export const getWebPageGraph = async ({
     editor: { "@id": websiteAuthor },
     headline: title,
     isAccessibleForFree: true,
-    isPartOf: { "@id": `${WEBSITE_URL}${routeById(`${locale}/home`)}` },
+    isPartOf: { "@id": `${WEBSITE_URL}${routeById(`${locale}/home`).url}` },
     lastReviewed: meta.updatedOn.toISOString(),
     license: translate("license.url"),
     name: title,

--- a/src/lib/schema-dts/graphs/website-graph.ts
+++ b/src/lib/schema-dts/graphs/website-graph.ts
@@ -34,12 +34,12 @@ export const getWebSiteGraph = async ({
     "@type": "SearchAction",
     query: "required",
     "query-input": "required name=query",
-    target: `${WEBSITE_URL}${routeById(`${locale}/search`)}?${CONFIG.SEARCH.QUERY_PARAM}={query}`,
+    target: `${WEBSITE_URL}${routeById(`${locale}/search`).url}?${CONFIG.SEARCH.QUERY_PARAM}={query}`,
   };
 
   return {
     "@type": "WebSite",
-    "@id": `${WEBSITE_URL}${routeById(`${locale}/home`)}`,
+    "@id": `${WEBSITE_URL}${routeById(`${locale}/home`).url}`,
     author: { "@id": websiteAuthor },
     copyrightHolder: { "@id": websiteAuthor },
     copyrightYear: CONFIG.CREATION_YEAR,
@@ -54,6 +54,6 @@ export const getWebSiteGraph = async ({
     potentialAction: searchAction,
     publisher: { "@id": websiteAuthor },
     thumbnailUrl: logo,
-    url: `${WEBSITE_URL}${routeById(`${locale}/home`)}`,
+    url: `${WEBSITE_URL}${routeById(`${locale}/home`).url}`,
   };
 };

--- a/src/lib/schema-dts/graphs/website-graph.ts
+++ b/src/lib/schema-dts/graphs/website-graph.ts
@@ -28,18 +28,18 @@ export const getWebSiteGraph = async ({
   logo,
 }: WebSiteGraphData): Promise<WebSite> => {
   const { translate } = useI18n(locale);
-  const { routeById } = await useRouting();
+  const { routeById } = await useRouting(locale);
   const websiteAuthor = `${WEBSITE_URL}#author` as const;
   const searchAction: CustomSearchAction = {
     "@type": "SearchAction",
     query: "required",
     "query-input": "required name=query",
-    target: `${WEBSITE_URL}${routeById(`${locale}/search`).url}?${CONFIG.SEARCH.QUERY_PARAM}={query}`,
+    target: `${WEBSITE_URL}${routeById("search").url}?${CONFIG.SEARCH.QUERY_PARAM}={query}`,
   };
 
   return {
     "@type": "WebSite",
-    "@id": `${WEBSITE_URL}${routeById(`${locale}/home`).url}`,
+    "@id": `${WEBSITE_URL}${routeById("home").url}`,
     author: { "@id": websiteAuthor },
     copyrightHolder: { "@id": websiteAuthor },
     copyrightYear: CONFIG.CREATION_YEAR,
@@ -54,6 +54,6 @@ export const getWebSiteGraph = async ({
     potentialAction: searchAction,
     publisher: { "@id": websiteAuthor },
     thumbnailUrl: logo,
-    url: `${WEBSITE_URL}${routeById(`${locale}/home`).url}`,
+    url: `${WEBSITE_URL}${routeById("home").url}`,
   };
 };

--- a/src/services/breadcrumb/breadcrumb.ts
+++ b/src/services/breadcrumb/breadcrumb.ts
@@ -2,7 +2,7 @@ import {
   getEntriesIndex,
   type EntryByRouteIndex,
 } from "../../lib/astro/collections/indexes";
-import type { Crumb } from "../../types/data";
+import type { Route } from "../../types/data";
 import { getCumulativePaths } from "../../utils/paths";
 import { removeTrailingSlashes } from "../../utils/strings";
 import { isLocalizedRoute } from "../i18n";
@@ -24,7 +24,7 @@ const getRouteHierarchy = (route: string): string[] => {
 const getRouteCrumbs = (
   route: string,
   routeIndex: EntryByRouteIndex
-): Crumb[] => {
+): Route[] => {
   const segments = getRouteHierarchy(route);
 
   return segments
@@ -53,12 +53,12 @@ type BreadcrumbConfig = {
  * Retrieve the breadcrumb for the given page.
  *
  * @param {BreadcrumbConfig} config - A configuration object.
- * @returns {Promise<Crumb[]>} - The breadcrumb parts.
+ * @returns {Promise<Route[]>} - The breadcrumb parts.
  */
 export const getBreadcrumb = async ({
   paginationLabel,
   route,
-}: BreadcrumbConfig): Promise<Crumb[]> => {
+}: BreadcrumbConfig): Promise<Route[]> => {
   const { byRoute } = await getEntriesIndex();
   const normalizedRoute = normalizeRoute(route);
   const crumbs = getRouteCrumbs(normalizedRoute, byRoute);

--- a/src/services/routing/use-routing.test.ts
+++ b/src/services/routing/use-routing.test.ts
@@ -31,7 +31,7 @@ vi.mock("../../utils/constants", async (importOriginal) => {
 
 const mockEntries = createMockEntriesByCollection({
   authors: [{ collection: "authors", id: "john-doe" }],
-  notes: [{ collection: "notes", id: "en/note1" }],
+  notes: [{ collection: "notes", id: "en/note1", data: { title: "Note 1" } }],
 });
 
 describe("use-routing", () => {
@@ -50,7 +50,10 @@ describe("use-routing", () => {
 
     const { routeById } = await useRouting();
 
-    expect(routeById("en/note1")).toBe("/note1");
+    expect(routeById("en/note1")).toStrictEqual({
+      label: "Note 1",
+      url: "/note1",
+    });
   });
 
   it("throws an error when the entry does not have a route", async () => {

--- a/src/services/routing/use-routing.test.ts
+++ b/src/services/routing/use-routing.test.ts
@@ -29,9 +29,18 @@ vi.mock("../../utils/constants", async (importOriginal) => {
   };
 });
 
+// cSpell:ignore projet
 const mockEntries = createMockEntriesByCollection({
   authors: [{ collection: "authors", id: "john-doe" }],
   notes: [{ collection: "notes", id: "en/note1", data: { title: "Note 1" } }],
+  projects: [
+    { collection: "projects", id: "en/project1", data: { title: "Project 1" } },
+    {
+      collection: "projects",
+      id: "fr/project1",
+      data: { permaslug: "projet1", title: "Projet 1" },
+    },
+  ],
 });
 
 describe("use-routing", () => {
@@ -48,31 +57,42 @@ describe("use-routing", () => {
   it("can return a route by id", async () => {
     expect.assertions(1);
 
-    const { routeById } = await useRouting();
+    const { routeById } = await useRouting("en");
 
-    expect(routeById("en/note1")).toStrictEqual({
+    expect(routeById("note1")).toStrictEqual({
       label: "Note 1",
       url: "/note1",
     });
   });
 
-  it("throws an error when the entry does not have a route", async () => {
+  it("can return a route by id by overriding the default locale", async () => {
     expect.assertions(1);
 
-    const { routeById } = await useRouting();
+    const { routeById } = await useRouting("en");
 
-    expect(() => routeById("john-doe")).toThrowErrorMatchingInlineSnapshot(
-      `[Error: Cannot find a route for the given id, received: john-doe]`
+    expect(routeById("project1", "fr")).toStrictEqual({
+      label: "Projet 1",
+      url: "/fr/projet1",
+    });
+  });
+
+  it("throws an error when the entry exists but not for the given locale", async () => {
+    expect.assertions(1);
+
+    const { routeById } = await useRouting("fr");
+
+    expect(() => routeById("note1")).toThrowErrorMatchingInlineSnapshot(
+      `[Error: Cannot find a route for the given id using "fr" as locale. Received: note1]`
     );
   });
 
   it("throws an error when the entry does not exist", async () => {
     expect.assertions(1);
 
-    const { routeById } = await useRouting();
+    const { routeById } = await useRouting("en");
 
-    expect(() => routeById("en/post1")).toThrowErrorMatchingInlineSnapshot(
-      `[Error: Cannot find a route for the given id, received: en/post1]`
+    expect(() => routeById("post1")).toThrowErrorMatchingInlineSnapshot(
+      `[Error: Cannot find a route for the given id using "en" as locale. Received: post1]`
     );
   });
 });

--- a/src/services/routing/use-routing.ts
+++ b/src/services/routing/use-routing.ts
@@ -1,9 +1,10 @@
 import { getEntriesIndex } from "../../lib/astro/collections/indexes";
 import type { Route } from "../../types/data";
+import type { AvailableLocale } from "../../types/tokens";
 
-export type RouteById = (id: string) => Route;
+export type RouteById = (id: string, locale?: AvailableLocale) => Route;
 
-type UseRouting = () => Promise<{
+type UseRouting = (locale: AvailableLocale) => Promise<{
   /**
    * A method to retrieve a localized route for a given id.
    */
@@ -13,16 +14,22 @@ type UseRouting = () => Promise<{
 /**
  * Init routing functions.
  *
+ * @param {AvailableLocale} locale - The locale to use while fetching routes.
  * @returns {ReturnType<UseRouting>} An object containing the routing functions.
  */
-export const useRouting: UseRouting = async (): ReturnType<UseRouting> => {
+export const useRouting: UseRouting = async (
+  locale: AvailableLocale
+): ReturnType<UseRouting> => {
   const { byId } = await getEntriesIndex();
 
-  const routeById: RouteById = (id: string) => {
-    const match = byId.get(id);
+  const routeById: RouteById = (id, routeLocale = locale) => {
+    const fullId = `${routeLocale}/${id}`;
+    const match = byId.get(fullId);
 
     if (match === undefined || !("route" in match)) {
-      throw new Error(`Cannot find a route for the given id, received: ${id}`);
+      throw new Error(
+        `Cannot find a route for the given id using "${routeLocale}" as locale. Received: ${id}`
+      );
     }
 
     return { label: match.raw.data.title, url: match.route };

--- a/src/services/routing/use-routing.ts
+++ b/src/services/routing/use-routing.ts
@@ -1,6 +1,7 @@
 import { getEntriesIndex } from "../../lib/astro/collections/indexes";
+import type { Route } from "../../types/data";
 
-export type RouteById = (id: string) => string;
+export type RouteById = (id: string) => Route;
 
 type UseRouting = () => Promise<{
   /**
@@ -24,7 +25,7 @@ export const useRouting: UseRouting = async (): ReturnType<UseRouting> => {
       throw new Error(`Cannot find a route for the given id, received: ${id}`);
     }
 
-    return match.route;
+    return { label: match.raw.data.title, url: match.route };
   };
 
   return { routeById };

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -5,16 +5,22 @@ import type {
   RenderResult,
 } from "astro:content";
 import type { RoutableCollectionKey } from "../lib/astro/collections/types";
+import type { IconName } from "./tokens";
 import type { ConditionallyExtend, PatchExistingProperties } from "./utilities";
+
+export type Route = {
+  label: string;
+  url: string;
+};
+
+export type WithIcon<T> = T & {
+  icon?: IconName | null | undefined;
+  iconSize?: number | undefined;
+};
 
 export type AltLanguage = {
   locale: string;
   route: string;
-};
-
-export type Crumb = {
-  label: string;
-  url: string;
 };
 
 export type HeadingNode = {

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -5,7 +5,7 @@ import type {
   RenderResult,
 } from "astro:content";
 import type { RoutableCollectionKey } from "../lib/astro/collections/types";
-import type { IconName } from "./tokens";
+import type { AvailableLocale, IconName } from "./tokens";
 import type { ConditionallyExtend, PatchExistingProperties } from "./utilities";
 
 export type Route = {
@@ -19,7 +19,7 @@ export type WithIcon<T> = T & {
 };
 
 export type AltLanguage = {
-  locale: string;
+  locale: AvailableLocale;
   route: string;
 };
 

--- a/src/utils/stories.ts
+++ b/src/utils/stories.ts
@@ -1,12 +1,12 @@
-import type { Crumb, SEO } from "../types/data";
+import type { Route, SEO } from "../types/data";
 
 /**
  * Derive the `<title>` string for SEO purposes from a breadcrumb trail.
  *
- * @param {Crumb[]} breadcrumb - The breadcrumb trail for the page.
+ * @param {Route[]} breadcrumb - The breadcrumb trail for the page.
  * @returns {string} A human-readable SEO title string.
  */
-const getStorySeoTitle = (breadcrumb: Crumb[]): string =>
+const getStorySeoTitle = (breadcrumb: Route[]): string =>
   breadcrumb
     .slice(1)
     .reverse()
@@ -14,7 +14,7 @@ const getStorySeoTitle = (breadcrumb: Crumb[]): string =>
     .join(" | ");
 
 type GetStorySeoConfig = {
-  breadcrumb: Crumb[];
+  breadcrumb: Route[];
   seo?: Partial<SEO> | undefined | null;
 };
 

--- a/src/views/blog-index-view/blog-index-view.astro
+++ b/src/views/blog-index-view/blog-index-view.astro
@@ -22,7 +22,7 @@ const {
   ...props
 } = Astro.props;
 const { translate, translatePlural } = useI18n(page.locale);
-const { routeById } = await useRouting();
+const { routeById } = await useRouting(page.locale);
 const { entries: categories } = await queryCollection("blog.categories", {
   format: "preview",
   orderBy: { key: "title", order: "ASC" },
@@ -76,7 +76,7 @@ const getPostCTA = (
     >
       <Heading>{translate("page.blog.section.recent.posts.heading")}</Heading>
       <div class="blog-section-cta">
-        <Button as="a" href={routeById(`${page.locale}/blog/posts`).url}>
+        <Button as="a" href={routeById("blog/posts").url}>
           {translatePlural("cta.see.all.posts", { count: totalPosts })}
         </Button>
         <Button
@@ -84,7 +84,7 @@ const getPostCTA = (
             title: translate("page.blog.posts.title"),
           })}
           as="a"
-          href={`${routeById(`${page.locale}/blog/posts`).url}/feed.xml`}
+          href={`${routeById("blog/posts").url}/feed.xml`}
         >
           <Icon aria-hidden="true" name="feed" />
           {translate("cta.subscribe")}

--- a/src/views/blog-index-view/blog-index-view.astro
+++ b/src/views/blog-index-view/blog-index-view.astro
@@ -76,7 +76,7 @@ const getPostCTA = (
     >
       <Heading>{translate("page.blog.section.recent.posts.heading")}</Heading>
       <div class="blog-section-cta">
-        <Button as="a" href={routeById(`${page.locale}/blog/posts`)}>
+        <Button as="a" href={routeById(`${page.locale}/blog/posts`).url}>
           {translatePlural("cta.see.all.posts", { count: totalPosts })}
         </Button>
         <Button
@@ -84,7 +84,7 @@ const getPostCTA = (
             title: translate("page.blog.posts.title"),
           })}
           as="a"
-          href={`${routeById(`${page.locale}/blog/posts`)}/feed.xml`}
+          href={`${routeById(`${page.locale}/blog/posts`).url}/feed.xml`}
         >
           <Icon aria-hidden="true" name="feed" />
           {translate("cta.subscribe")}

--- a/src/views/feeds-view/feeds-view.astro
+++ b/src/views/feeds-view/feeds-view.astro
@@ -43,7 +43,7 @@ const graphs: ComponentProps<typeof PageLayout>["graphs"] = [
     {hasContent && <Content />}
     <p>{translate("page.feeds.global.feed.introduction")}</p>
     <p>
-      <Button as="a" href={`${routeById(`${page.locale}/home`)}feed.xml`}>
+      <Button as="a" href={`${routeById(`${page.locale}/home`).url}feed.xml`}>
         <Icon aria-hidden="true" name="feed" />
         {translate("cta.subscribe.to.website")}
       </Button>

--- a/src/views/feeds-view/feeds-view.astro
+++ b/src/views/feeds-view/feeds-view.astro
@@ -22,7 +22,7 @@ const {
   ...props
 } = Astro.props;
 const { translate } = useI18n(page.locale);
-const { routeById } = await useRouting();
+const { routeById } = await useRouting(page.locale);
 const feeds = await getCollectionsFeeds(page.locale);
 const breadcrumb = await getBreadcrumb({ route: Astro.url.pathname });
 const graphs: ComponentProps<typeof PageLayout>["graphs"] = [
@@ -43,7 +43,7 @@ const graphs: ComponentProps<typeof PageLayout>["graphs"] = [
     {hasContent && <Content />}
     <p>{translate("page.feeds.global.feed.introduction")}</p>
     <p>
-      <Button as="a" href={`${routeById(`${page.locale}/home`).url}feed.xml`}>
+      <Button as="a" href={`${routeById("home").url}feed.xml`}>
         <Icon aria-hidden="true" name="feed" />
         {translate("cta.subscribe.to.website")}
       </Button>

--- a/src/views/homepage-view/homepage-view.astro
+++ b/src/views/homepage-view/homepage-view.astro
@@ -103,7 +103,7 @@ const graphs: ComponentProps<typeof PageLayout>["graphs"] = [
             addRelMe
             as="section"
             class="homepage-contact"
-            contactPageRoute={routeById("fr/contact")}
+            contactPageRoute={routeById("fr/contact").url}
             elevation="raised"
             isSpaced
             socialMedia={author.socialMedia}

--- a/src/views/homepage-view/homepage-view.astro
+++ b/src/views/homepage-view/homepage-view.astro
@@ -32,7 +32,7 @@ const {
   ...props
 } = Astro.props;
 const { translate } = useI18n(Astro.currentLocale);
-const { routeById } = await useRouting();
+const { routeById } = await useRouting(page.locale);
 const author = await queryEntry({
   collection: "authors",
   id: "armand-philippot",
@@ -103,7 +103,7 @@ const graphs: ComponentProps<typeof PageLayout>["graphs"] = [
             addRelMe
             as="section"
             class="homepage-contact"
-            contactPageRoute={routeById("fr/contact").url}
+            contactPageRoute={routeById("contact").url}
             elevation="raised"
             isSpaced
             socialMedia={author.socialMedia}

--- a/src/views/not-found-view/not-found-view.astro
+++ b/src/views/not-found-view/not-found-view.astro
@@ -16,7 +16,7 @@ const {
   entry: { Content, hasContent, ...page },
   ...props
 } = Astro.props;
-const { routeById } = await useRouting();
+const { routeById } = await useRouting(page.locale);
 const breadcrumb = await getBreadcrumb({ route: Astro.url.pathname });
 const graphs: ComponentProps<typeof PageLayout>["graphs"] = [
   await getWebPageGraph({ ...page, breadcrumb }),
@@ -37,7 +37,7 @@ const graphs: ComponentProps<typeof PageLayout>["graphs"] = [
     <SearchForm
       id="not-found-search"
       queryParam={CONFIG.SEARCH.QUERY_PARAM}
-      resultsPage={routeById(`${page.locale}/search`).url}
+      resultsPage={routeById("search").url}
     />
   </Fragment>
 </PageLayout>

--- a/src/views/not-found-view/not-found-view.astro
+++ b/src/views/not-found-view/not-found-view.astro
@@ -37,7 +37,7 @@ const graphs: ComponentProps<typeof PageLayout>["graphs"] = [
     <SearchForm
       id="not-found-search"
       queryParam={CONFIG.SEARCH.QUERY_PARAM}
-      resultsPage={routeById(`${page.locale}/search`)}
+      resultsPage={routeById(`${page.locale}/search`).url}
     />
   </Fragment>
 </PageLayout>


### PR DESCRIPTION
## Changes

* Improves the routing API added in #123:
  * users can now define the locale once while initiating `useRouting`
  * users can now override the locale per `routeById` calls
  * `routeById` returns both a route path and a label since most of the time we would need both
* Replaces the `Crumb` type with a `Route` type to avoid having similar types for the same thing.

## Tests

* Updates some tests to match the new API
* Everything else should still pass

## Docs

I've updated the README and the `useRouting` changeset added in #123 (since this is not yet released). I don't think this needs a new changeset.