### PR TITLE
refactor: consistent shape to describe routes

### DIFF
--- a/.changeset/funny-icons-draw.md
+++ b/.changeset/funny-icons-draw.md
@@ -26,7 +26,7 @@ const mainNav = [
 -    label: translate("page.home.title"),
 +    label: homeRoute.label,
 -    url: route("home"),
-+    url: homeRoute.url,
++    path: homeRoute.path,
   },
   {
     icon: "blog",
@@ -34,7 +34,7 @@ const mainNav = [
 -    label: translate("page.blog.title"),
 +    label: blogRoute.label,
 -    url: route("blog"),
-+    url: blogRoute.url,
++    path: blogRoute.path,
   },
 ];
 ---

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ To use localized routing in your templates and components, you can import the `u
 import { useRouting } from "../services/routing";
 
 const { routeById } = await useRouting("fr");
-console.log(routeById("projects")) // { label: "Projets", url: "/projets" }
-console.log(routeById("projects/first-project")) // { label: "Premier projet", url: "/projets/premier-projet" }
+console.log(routeById("projects")) // { label: "Projets", path: "/projets" }
+console.log(routeById("projects/first-project")) // { label: "Premier projet", path: "/projets/premier-projet" }
 ---
 ```
 
@@ -95,8 +95,8 @@ You can also override the locale provided to `useRouting` per `routeById` call w
 import { useRouting } from "../services/routing";
 
 const { routeById } = await useRouting("fr");
-console.log(routeById("projects", "en")) // { label: "Projects", url: "/en/projects" }
-console.log(routeById("projects/first-project", "en")) // { label: "First project", url: "/en/projects/first-project" }
+console.log(routeById("projects", "en")) // { label: "Projects", path: "/en/projects" }
+console.log(routeById("projects/first-project", "en")) // { label: "First project", path: "/en/projects/first-project" }
 ---
 ```
 
@@ -491,7 +491,7 @@ const contactRoute = routeById("contact");
 ---
 
 <p>{translate("some.key.available.in.translations")}</p>
-<a href={contactRoute.url}>
+<a href={contactRoute.path}>
   {contactRoute.label}
 </a>
 <div>

--- a/src/components/atoms/head/head.astro
+++ b/src/components/atoms/head/head.astro
@@ -122,7 +122,7 @@ const feeds = await getCollectionsFeeds(locale);
         />
         {feeds.map((feed) => (
           <link
-            href={new URL(feed.slug, Astro.site)}
+            href={new URL(feed.path, Astro.site)}
             rel="alternate"
             title={feed.label}
             type="application/rss+xml"

--- a/src/components/molecules/breadcrumb/breadcrumb.astro
+++ b/src/components/molecules/breadcrumb/breadcrumb.astro
@@ -38,7 +38,7 @@ const scaleToRightTransition = {
 >
   <NavList class="breadcrumb-list" hideMarker isInline isOrdered items={items}>
     {
-      ({ label, url, ...item }, index, crumbs) => {
+      ({ label, path, ...item }, index, crumbs) => {
         const isFirstItem = index === 0;
         const isLastItem = index + 1 === crumbs.length;
 
@@ -56,7 +56,7 @@ const scaleToRightTransition = {
             <NavItem
               {...item}
               class="breadcrumb-item"
-              href={url}
+              href={path}
               isRounded
               transition:animate={scaleToRightTransition}
               transition:name={

--- a/src/components/molecules/breadcrumb/breadcrumb.stories.mdx
+++ b/src/components/molecules/breadcrumb/breadcrumb.stories.mdx
@@ -7,10 +7,10 @@ import Breadcrumb from "./breadcrumb.astro";
 
 export const components = mdxComponents;
 export const items = [
-{ label: "Home", url: "#item1" },
-{ label: "Blog", url: "#item2" },
-{ label: "Year", url: "#item3" },
-{ label: "A very very long post title", url: "#item4" },
+{ label: "Home", path: "#item1" },
+{ label: "Blog", path: "#item2" },
+{ label: "Year", path: "#item3" },
+{ label: "A very very long post title", path: "#item4" },
 ];
 
 ## Introduction
@@ -26,10 +26,10 @@ This component is used to display a breadcrumb on a page.
 <CodePreview
   code={`---
 const items = [
-{ label: "Home", url: "#item1" },
-{ label: "Blog", url: "#item2" },
-{ label: "Year", url: "#item3" },
-{ label: "A very very long post title", url: "#item4" },
+{ label: "Home", path: "#item1" },
+{ label: "Blog", path: "#item2" },
+{ label: "Year", path: "#item3" },
+{ label: "A very very long post title", path: "#item4" },
 ];
 ---
 <Breadcrumb items={items} />`}

--- a/src/components/molecules/breadcrumb/breadcrumb.test.ts
+++ b/src/components/molecules/breadcrumb/breadcrumb.test.ts
@@ -20,9 +20,9 @@ describe("Breadcrumb", () => {
 
     const props = {
       items: [
-        { label: "omnis assumenda aut", url: "#voluptate-est-sed" },
-        { label: "voluptas odio voluptatem", url: "#est-ducimus-sit" },
-        { label: "sunt ratione quis", url: "#sunt-illo-iusto" },
+        { label: "omnis assumenda aut", path: "#voluptate-est-sed" },
+        { label: "voluptas odio voluptatem", path: "#est-ducimus-sit" },
+        { label: "sunt ratione quis", path: "#sunt-illo-iusto" },
       ],
     } satisfies ComponentProps<typeof Breadcrumb>;
     const result = await container.renderToString(Breadcrumb, {
@@ -32,12 +32,12 @@ describe("Breadcrumb", () => {
     const listItems = [...result.matchAll(/<li[^>]*>[\S\s]*?<\/li>/g)];
 
     expect(listItems).toHaveLength(props.items.length);
-    expect(result).toContain(props.items[0]?.url);
-    expect(result).toContain(props.items[1]?.url);
-    /* eslint-disable-next-line @typescript-eslint/no-magic-numbers -- `url` index. */
+    expect(result).toContain(props.items[0]?.path);
+    expect(result).toContain(props.items[1]?.path);
+    /* eslint-disable-next-line @typescript-eslint/no-magic-numbers -- `path` index. */
     expect(result).toContain(props.items[2]?.label);
-    /* eslint-disable-next-line @typescript-eslint/no-magic-numbers -- `url` index. */
-    expect(result).not.toContain(props.items[2]?.url);
+    /* eslint-disable-next-line @typescript-eslint/no-magic-numbers -- `path` index. */
+    expect(result).not.toContain(props.items[2]?.path);
   });
 
   it<LocalTestContext>("can render the items centered", async ({
@@ -48,9 +48,9 @@ describe("Breadcrumb", () => {
     const props = {
       isCentered: true,
       items: [
-        { label: "omnis assumenda aut", url: "#voluptate-est-sed" },
-        { label: "voluptas odio voluptatem", url: "#est-ducimus-sit" },
-        { label: "sunt ratione quis", url: "#sunt-illo-iusto" },
+        { label: "omnis assumenda aut", path: "#voluptate-est-sed" },
+        { label: "voluptas odio voluptatem", path: "#est-ducimus-sit" },
+        { label: "sunt ratione quis", path: "#sunt-illo-iusto" },
       ],
     } satisfies ComponentProps<typeof Breadcrumb>;
     const result = await container.renderToString(Breadcrumb, {

--- a/src/components/molecules/language-picker/language-picker.astro
+++ b/src/components/molecules/language-picker/language-picker.astro
@@ -19,10 +19,6 @@ type Languages = Record<
 
 type Props = ComponentProps<typeof Fieldset> & {
   /**
-   * An object containing the alternative routes.
-   */
-  altRoutes?: Partial<Record<string, string>>;
-  /**
    * A locale key defined in `languages`.
    */
   current: string;

--- a/src/components/molecules/nav-list/nav-list.astro
+++ b/src/components/molecules/nav-list/nav-list.astro
@@ -1,14 +1,13 @@
 ---
 import type { ComponentProps } from "astro/types";
+import type { Route } from "../../../types/data";
 import type { IconName } from "../../../types/tokens";
 import ListItem from "../../atoms/list/list-item.astro";
 import List from "../../atoms/list/list.astro";
 
-type NavItem = {
+type NavItem = Route & {
   icon?: IconName | null | undefined;
   iconSize?: number | undefined;
-  label: string;
-  url: string;
 };
 
 type Props = Omit<ComponentProps<typeof List>, "as"> & {

--- a/src/components/molecules/nav-list/nav-list.stories.mdx
+++ b/src/components/molecules/nav-list/nav-list.stories.mdx
@@ -8,9 +8,9 @@ import NavList from "./nav-list.astro";
 
 export const components = mdxComponents;
 export const items = [
-  { label: "Item 1", url: "#item-1" },
-  { label: "Item 2", url: "#item-2" },
-  { label: "Item 3", url: "#item-3" },
+  { label: "Item 1", path: "#item-1" },
+  { label: "Item 2", path: "#item-2" },
+  { label: "Item 3", path: "#item-3" },
 ];
 
 ## Introduction
@@ -26,14 +26,14 @@ This component is used to define a navigation list. It accepts an `items` proper
 <CodePreview
   code={`<NavList
     items={[
-      { label: "Item 1", url: "#item-1" },
-      { label: "Item 2", url: "#item-2" },
-      { label: "Item 3", url: "#item-3" },
+      { label: "Item 1", path: "#item-1" },
+      { label: "Item 2", path: "#item-2" },
+      { label: "Item 3", path: "#item-3" },
     ]}
 >
     {
       (item) => (
-        <NavItem href={item.url} icon={item.icon} iconSize={item.iconSize}>
+        <NavItem href={item.path} icon={item.icon} iconSize={item.iconSize}>
           {item.label}
         </NavItem>
       )
@@ -44,14 +44,14 @@ This component is used to define a navigation list. It accepts an `items` proper
 >
   <NavList
     items={[
-      { label: "Item 1", url: "#item-1" },
-      { label: "Item 2", url: "#item-2" },
-      { label: "Item 3", url: "#item-3" },
+      { label: "Item 1", path: "#item-1" },
+      { label: "Item 2", path: "#item-2" },
+      { label: "Item 3", path: "#item-3" },
     ]}
   >
     {
       (item) => (
-        <NavItem href={item.url} icon={item.icon} iconSize={item.iconSize}>
+        <NavItem href={item.path} icon={item.icon} iconSize={item.iconSize}>
           {item.label}
         </NavItem>
       )

--- a/src/components/molecules/nav-list/nav-list.test.ts
+++ b/src/components/molecules/nav-list/nav-list.test.ts
@@ -17,8 +17,8 @@ describe("NavList", () => {
 
     const props = {
       items: [
-        { label: "Item 1", url: "#item-1" },
-        { label: "Item 2", url: "#item-2" },
+        { label: "Item 1", path: "#item-1" },
+        { label: "Item 2", path: "#item-2" },
       ],
     } satisfies Omit<ComponentProps<typeof NavList>, "children">;
     const body = "id quibusdam eius";
@@ -38,8 +38,8 @@ describe("NavList", () => {
     const props = {
       isOrdered: true,
       items: [
-        { label: "Item 1", url: "#item-1" },
-        { label: "Item 2", url: "#item-2" },
+        { label: "Item 1", path: "#item-1" },
+        { label: "Item 2", path: "#item-2" },
       ],
     } satisfies Omit<ComponentProps<typeof NavList>, "children">;
     const body = "id quibusdam eius";

--- a/src/components/organisms/collection-meta/collection-meta.astro
+++ b/src/components/organisms/collection-meta/collection-meta.astro
@@ -6,7 +6,7 @@ import {
   type PluralUIKey,
   type SingularUIKey,
 } from "../../../services/i18n";
-import type { CollectionMetaData } from "../../../types/data";
+import type { CollectionMetaData, Route } from "../../../types/data";
 import type { IconName } from "../../../types/tokens";
 import type { AllKeysOf, Blend } from "../../../types/utilities";
 import DescriptionList from "../../atoms/description-list/description-list.astro";
@@ -32,12 +32,7 @@ type Props = ComponentProps<typeof DescriptionList> & {
   icons?: CollectionMetaIcon;
 };
 
-type LinkValue = {
-  href: string;
-  text: string;
-};
-
-type MetaValue = string | Date | LinkValue;
+type MetaValue = string | Date | Route;
 
 type RenderConfig<K extends AllKeysOf<MetaData>> = {
   shouldRender: (value: MetaData[K]) => value is NonNullable<MetaData[K]>;
@@ -102,7 +97,7 @@ const configs: MetaDataConfigs = {
     },
     renderValue: (value) =>
       value.map(({ isWebsiteOwner, name, website }) =>
-        website && !isWebsiteOwner ? { href: website, text: name } : name
+        website && !isWebsiteOwner ? { label: name, path: website } : name
       ),
   },
   inLanguage: {
@@ -161,7 +156,7 @@ const configs: MetaDataConfigs = {
         token: "meta.label.repository",
       };
     },
-    renderValue: ({ name, url }) => [{ href: url, text: name }],
+    renderValue: ({ name, url }) => [{ label: name, path: url }],
   },
   category: {
     shouldRender: (value): value is NonNullable<MetaData["category"]> =>
@@ -171,7 +166,7 @@ const configs: MetaDataConfigs = {
         token: "meta.label.category",
       };
     },
-    renderValue: (value) => [{ href: value.route, text: value.title }],
+    renderValue: (value) => [value],
   },
   tags: {
     shouldRender: (value): value is NonNullable<MetaData["tags"]> =>
@@ -182,13 +177,7 @@ const configs: MetaDataConfigs = {
         isPlural: true,
       };
     },
-    renderValue: (value) =>
-      value.map((tag) => {
-        return {
-          href: tag.route,
-          text: tag.title,
-        };
-      }),
+    renderValue: (value) => value,
   },
   total: {
     shouldRender: (value): value is NonNullable<MetaData["total"]> => !!value,
@@ -240,7 +229,7 @@ const isMetaTranslationKey = (key: unknown): key is SingularUIKey =>
               if (item instanceof Date) {
                 content = <Time date={item} />;
               } else if (typeof item === "object") {
-                content = <Link href={item.href}>{item.text}</Link>;
+                content = <Link href={item.path}>{item.label}</Link>;
               } else if (isMetaTranslationKey(item)) {
                 content = translate(item);
               }

--- a/src/components/organisms/collection-meta/collection-meta.stories.mdx
+++ b/src/components/organisms/collection-meta/collection-meta.stories.mdx
@@ -14,13 +14,13 @@ export const icons = {
 };
 export const blogPostMeta = {
   category: {
-    route: "#quisquam-itaque-provident",
-    title: "A category",
+    label: "A category",
+    path: "#quisquam-itaque-provident",
   },
   publishedOn: new Date("2024-09-16"),
   tags: [
-    { route: "#tag1", title: "Tag 1" },
-    { route: "#tag2", title: "Tag 2" },
+    { label: "Tag 1", path: "#tag1" },
+    { label: "Tag 2", path: "#tag2" },
   ],
   updatedOn: new Date(),
 };
@@ -85,13 +85,13 @@ The component also handles meta specific to some collections. Check out the foll
   code={`---
 const blogPostMeta = {
     category: {
-      route: "#quisquam-itaque-provident",
-      title: "A category",
+      label: "A category",
+      path: "#quisquam-itaque-provident",
     },
     publishedOn: new Date("2024-09-16"),
     tags: [
-      { route: "#tag1", title: "Tag 1" },
-      { route: "#tag2", title: "Tag 2" },
+      { label: "Tag 1", path: "#tag1" },
+      { label: "Tag 2", path: "#tag2" },
     ],
     updatedOn: new Date(),
 }

--- a/src/components/organisms/collection-meta/collection-meta.test.ts
+++ b/src/components/organisms/collection-meta/collection-meta.test.ts
@@ -115,8 +115,8 @@ describe("CollectionMeta", () => {
     const props = {
       data: {
         tags: [
-          { title: "JavaScript", route: "/tags/javascript" },
-          { title: "TypeScript", route: "/tags/typescript" },
+          { label: "JavaScript", path: "/tags/javascript" },
+          { label: "TypeScript", path: "/tags/typescript" },
         ],
       },
     } as const satisfies ComponentProps<typeof CollectionMeta>;
@@ -124,10 +124,10 @@ describe("CollectionMeta", () => {
       props,
     });
 
-    expect(result).toContain(`href="${props.data.tags[0].route}"`);
-    expect(result).toContain(`href="${props.data.tags[1].route}"`);
-    expect(result).toContain(`>${props.data.tags[0].title}<`);
-    expect(result).toContain(`>${props.data.tags[1].title}<`);
+    expect(result).toContain(`href="${props.data.tags[0].path}"`);
+    expect(result).toContain(`href="${props.data.tags[1].path}"`);
+    expect(result).toContain(`>${props.data.tags[0].label}<`);
+    expect(result).toContain(`>${props.data.tags[1].label}<`);
   });
 
   it<LocalTestContext>("renders multiple metadata types together", async ({
@@ -147,7 +147,7 @@ describe("CollectionMeta", () => {
             isWebsiteOwner: false,
           },
         ],
-        tags: [{ title: "JavaScript", route: "/tags/javascript" }],
+        tags: [{ label: "JavaScript", path: "/tags/javascript" }],
       },
     } as const satisfies ComponentProps<typeof CollectionMeta>;
     const result = await container.renderToString(CollectionMeta, {
@@ -290,8 +290,8 @@ describe("CollectionMeta", () => {
     const props = {
       data: {
         category: {
-          title: "Development",
-          route: "/category/development",
+          label: "Development",
+          path: "/category/development",
         },
       },
     } as const satisfies ComponentProps<typeof CollectionMeta>;
@@ -299,8 +299,8 @@ describe("CollectionMeta", () => {
       props,
     });
 
-    expect(result).toContain(`href="${props.data.category.route}"`);
-    expect(result).toContain(`>${props.data.category.title}<`);
+    expect(result).toContain(`href="${props.data.category.path}"`);
+    expect(result).toContain(`>${props.data.category.label}<`);
   });
 
   it<LocalTestContext>("renders total metadata correctly", async ({

--- a/src/components/organisms/main-nav/main-nav.astro
+++ b/src/components/organisms/main-nav/main-nav.astro
@@ -29,16 +29,16 @@ const isCurrentRouteOrNested = (url: string) => {
   items={items}
 >
   {
-    ({ label, url, ...item }) => {
-      const isSelected = isCurrentRouteOrNested(url);
+    ({ label, path, ...item }) => {
+      const isSelected = isCurrentRouteOrNested(path);
 
       return (
         <NavItem
           {...item}
-          aria-current={url === Astro.url.pathname ? "page" : undefined}
+          aria-current={path === Astro.url.pathname ? "page" : undefined}
           class="main-nav-item"
           {...(isSelected && { "data-selected": true })}
-          href={url}
+          href={path}
           isBlock
           isBordered={isSelected}
           isRounded

--- a/src/components/organisms/main-nav/main-nav.stories.mdx
+++ b/src/components/organisms/main-nav/main-nav.stories.mdx
@@ -7,11 +7,11 @@ import MainNav from "./main-nav.astro";
 
 export const components = mdxComponents;
 export const items = [
-  { label: "Item 1", url: "#item-1" },
-  { label: "Item 2", url: "#item-2" },
-  { label: "Item 3", url: "#item-3" },
-  { label: "Item 4", url: "#item-4" },
-  { label: "Item 5", url: "#item-5" },
+  { label: "Item 1", path: "#item-1" },
+  { label: "Item 2", path: "#item-2" },
+  { label: "Item 3", path: "#item-3" },
+  { label: "Item 4", path: "#item-4" },
+  { label: "Item 5", path: "#item-5" },
 ]
 
 ## Introduction
@@ -27,11 +27,11 @@ This component is used to display the main navigation.
 <CodePreview
   code={`---
 const items = [
-    { label: "Item 1", url: "#item-1" },
-    { label: "Item 2", url: "#item-2" },
-    { label: "Item 3", url: "#item-3" },
-    { label: "Item 4", url: "#item-4" },
-    { label: "Item 5", url: "#item-5" },
+    { label: "Item 1", path: "#item-1" },
+    { label: "Item 2", path: "#item-2" },
+    { label: "Item 3", path: "#item-3" },
+    { label: "Item 4", path: "#item-4" },
+    { label: "Item 5", path: "#item-5" },
 ]
 ---
 <MainNav items={items} />`}
@@ -40,11 +40,11 @@ const items = [
 >
   <MainNav
     items={[
-      { label: "Item 1", url: "#item-1" },
-      { label: "Item 2", url: "#item-2" },
-      { label: "Item 3", url: "#item-3" },
-      { label: "Item 4", url: "#item-4" },
-      { label: "Item 5", url: "#item-5" },
+      { label: "Item 1", path: "#item-1" },
+      { label: "Item 2", path: "#item-2" },
+      { label: "Item 3", path: "#item-3" },
+      { label: "Item 4", path: "#item-4" },
+      { label: "Item 5", path: "#item-5" },
     ]}
   />
 </CodePreview>

--- a/src/components/organisms/main-nav/main-nav.test.ts
+++ b/src/components/organisms/main-nav/main-nav.test.ts
@@ -20,8 +20,8 @@ describe("MainNav", () => {
 
     const props = {
       items: [
-        { label: "quia voluptate atque", url: "#et-reprehenderit-et" },
-        { label: "odit accusamus quidem", url: "#quod-voluptas-earum" },
+        { label: "quia voluptate atque", path: "#et-reprehenderit-et" },
+        { label: "odit accusamus quidem", path: "#quod-voluptas-earum" },
       ] as const,
     } satisfies ComponentProps<typeof MainNav>;
     const label = "pariatur dolorem ipsum";
@@ -31,8 +31,8 @@ describe("MainNav", () => {
     });
 
     expect(result).toContain(props.items[0].label);
-    expect(result).toContain(props.items[0].url);
+    expect(result).toContain(props.items[0].path);
     expect(result).toContain(props.items[1].label);
-    expect(result).toContain(props.items[1].url);
+    expect(result).toContain(props.items[1].path);
   });
 });

--- a/src/components/organisms/settings-form/settings-form.astro
+++ b/src/components/organisms/settings-form/settings-form.astro
@@ -28,7 +28,7 @@ const languages = Object.fromEntries(
             lang === locale
               ? Astro.url.href
               : (altLanguages?.find((altLang) => altLang.locale === lang)
-                  ?.route ?? routeById("home", lang).url),
+                  ?.route ?? routeById("home", lang).path),
         },
       ];
     })

--- a/src/components/templates/layout/layout.astro
+++ b/src/components/templates/layout/layout.astro
@@ -31,70 +31,70 @@ const { class: className, seo, ...attrs } = Astro.props;
 const { locale, translate } = useI18n(Astro.currentLocale);
 const { routeById } = await useRouting(locale);
 const homeRoute = routeById("home");
-const isHome = Astro.url.pathname === homeRoute.url;
+const isHome = Astro.url.pathname === homeRoute.path;
 const mainNav = [
   {
     icon: "home",
     iconSize: 28,
     label: translate("page.home.title"),
-    url: homeRoute.url,
+    path: homeRoute.path,
   },
   {
     icon: "blog",
     iconSize: 28,
     label: translate("page.blog.title"),
-    url: routeById("blog").url,
+    path: routeById("blog").path,
   },
   {
     icon: "guide",
     iconSize: 28,
     label: translate("page.guides.title"),
-    url: routeById("guides").url,
+    path: routeById("guides").path,
   },
   {
     icon: "notepad",
     iconSize: 28,
     label: translate("page.notes.title"),
-    url: routeById("notes").url,
+    path: routeById("notes").path,
   },
   {
     icon: "project",
     iconSize: 28,
     label: translate("page.projects.title"),
-    url: routeById("projects").url,
+    path: routeById("projects").path,
   },
   {
     icon: "bookmark",
     iconSize: 28,
     label: translate("page.bookmarks.title"),
-    url: routeById("bookmarks").url,
+    path: routeById("bookmarks").path,
   },
   {
     icon: "globe",
     iconSize: 28,
     label: translate("page.blogroll.title"),
-    url: routeById("blogroll").url,
+    path: routeById("blogroll").path,
   },
   {
     icon: "contact",
     iconSize: 28,
     label: translate("page.contact.title"),
-    url: routeById("contact").url,
+    path: routeById("contact").path,
   },
 ] satisfies ComponentProps<typeof NavList>["items"];
 const devOnlyLinks = import.meta.env.DEV
-  ? [{ label: "Design system", url: "/design-system" }]
+  ? [{ label: "Design system", path: "/design-system" }]
   : [];
 const footerLinks = [
   {
     label: translate("page.legal.notice.title"),
-    url: routeById("legal-notice").url,
+    path: routeById("legal-notice").path,
   },
   {
     icon: "feed",
     iconSize: 17,
     label: translate("page.feeds.title"),
-    url: routeById("feeds").url,
+    path: routeById("feeds").path,
   },
   ...devOnlyLinks,
 ] satisfies ComponentProps<typeof NavList>["items"];
@@ -139,7 +139,7 @@ const topId = translate("anchor.site.top");
           </SkipTo>
           <header class="site-header">
             <div class="site-branding">
-              <Branding brand={CONFIG.BRAND} url={homeRoute.url} />
+              <Branding brand={CONFIG.BRAND} url={homeRoute.path} />
             </div>
             <Navbar
               aria-label={translate("nav.label.primary")}
@@ -151,7 +151,7 @@ const topId = translate("anchor.site.top");
                 id="site-search"
                 isInline
                 queryParam={CONFIG.SEARCH.QUERY_PARAM}
-                resultsPage={routeById("search").url}
+                resultsPage={routeById("search").path}
                 slot="search"
               />
               <SettingsForm
@@ -172,8 +172,8 @@ const topId = translate("anchor.site.top");
             <License />
             <NavList class="site-footer-nav" isInline items={footerLinks}>
               {
-                ({ label, url, ...item }) => (
-                  <NavItem {...item} href={url}>
+                ({ label, path, ...item }) => (
+                  <NavItem {...item} href={path}>
                     {label}
                   </NavItem>
                 )

--- a/src/components/templates/page-layout/page-layout.astro
+++ b/src/components/templates/page-layout/page-layout.astro
@@ -30,7 +30,7 @@ const { breadcrumb, description, headings, graphs, seo, title, ...attrs } =
   Astro.props;
 const { locale, translate } = useI18n(Astro.currentLocale);
 const { routeById } = await useRouting(locale);
-const isHome = Astro.url.pathname === routeById("home").url;
+const isHome = Astro.url.pathname === routeById("home").path;
 const ogHomeImgPath = isDefaultLocale(locale) ? "home" : `${locale}/home`;
 const ogImgPath = isHome ? ogHomeImgPath : Astro.url.pathname.slice(1);
 const socialImg = {

--- a/src/components/templates/page-layout/page-layout.test.ts
+++ b/src/components/templates/page-layout/page-layout.test.ts
@@ -103,9 +103,9 @@ describe("PageLayout", () => {
 
     const props = {
       breadcrumb: [
-        { label: "omnis assumenda aut", url: "#voluptate-est-sed" },
-        { label: "voluptas odio voluptatem", url: "#est-ducimus-sit" },
-        { label: "sunt ratione quis", url: "#sunt-illo-iusto" },
+        { label: "omnis assumenda aut", path: "#voluptate-est-sed" },
+        { label: "voluptas odio voluptatem", path: "#est-ducimus-sit" },
+        { label: "sunt ratione quis", path: "#sunt-illo-iusto" },
       ] as const,
       seo: {
         title: "est et fugiat",

--- a/src/components/templates/page-layout/stories/page-with-breadcrumb-and-aside.stories.mdx
+++ b/src/components/templates/page-layout/stories/page-with-breadcrumb-and-aside.stories.mdx
@@ -8,10 +8,10 @@ import PageLayout from "../page-layout.astro";
 export const components = mdxComponents;
 export const title = "Page with breadcrumb and aside";
 export const breadcrumb = [
-  { label: "Home", url: "#home" },
-  { label: "Blog", url: "#blog" },
-  { label: "Posts", url: "#posts" },
-  { label: title, url: "#current-page" },
+  { label: "Home", path: "#home" },
+  { label: "Blog", path: "#blog" },
+  { label: "Posts", path: "#posts" },
+  { label: title, path: "#current-page" },
 ];
 export const seo = {
   nofollow: true,

--- a/src/components/templates/page-layout/stories/page-with-breadcrumb.stories.mdx
+++ b/src/components/templates/page-layout/stories/page-with-breadcrumb.stories.mdx
@@ -8,10 +8,10 @@ import PageLayout from "../page-layout.astro";
 export const components = mdxComponents;
 export const title = "Page with breadcrumb";
 export const breadcrumb = [
-  { label: "Home", url: "#home" },
-  { label: "Blog", url: "#blog" },
-  { label: "Posts", url: "#posts" },
-  { label: title, url: "#current-page" },
+  { label: "Home", path: "#home" },
+  { label: "Blog", path: "#blog" },
+  { label: "Posts", path: "#posts" },
+  { label: title, path: "#current-page" },
 ];
 export const seo = {
   nofollow: true,

--- a/src/lib/astro/collections/formatters/blogroll.ts
+++ b/src/lib/astro/collections/formatters/blogroll.ts
@@ -1,7 +1,7 @@
 import type { Blog } from "../../../../types/data";
 import type { EntryByIdIndex } from "../indexes";
 import type { IndexedEntry } from "../types";
-import { getTagsFromReferences } from "./utils";
+import { getTagsRoutes } from "./utils";
 
 /**
  * Convert a blogroll collection entry to a formatted blogroll object.
@@ -17,7 +17,7 @@ export const getBlog = (
   const { collection, data, id } = blog.raw;
   const { meta, ...remainingData } = data;
   const { isDraft, tags, ...remainingMeta } = meta;
-  const resolvedTags = getTagsFromReferences(tags, indexById);
+  const resolvedTags = getTagsRoutes(tags, indexById);
 
   return {
     ...remainingData,

--- a/src/lib/astro/collections/formatters/bookmarks.ts
+++ b/src/lib/astro/collections/formatters/bookmarks.ts
@@ -1,7 +1,7 @@
 import type { Bookmark } from "../../../../types/data";
 import type { EntryByIdIndex } from "../indexes";
 import type { IndexedEntry } from "../types";
-import { getTagsFromReferences } from "./utils";
+import { getTagsRoutes } from "./utils";
 
 /**
  * Convert a bookmark collection entry to a Bookmark object.
@@ -17,7 +17,7 @@ export const getBookmark = (
   const { collection, data, id } = bookmark.raw;
   const { meta, ...remainingData } = data;
   const { isDraft, tags, ...remainingMeta } = meta;
-  const resolvedTags = getTagsFromReferences(tags, indexById);
+  const resolvedTags = getTagsRoutes(tags, indexById);
 
   return {
     ...remainingData,

--- a/src/lib/astro/collections/formatters/routable-entries.ts
+++ b/src/lib/astro/collections/formatters/routable-entries.ts
@@ -14,9 +14,9 @@ import type { EntryByIdIndex } from "../indexes";
 import type { IndexedEntry, RoutableCollectionKey } from "../types";
 import { getAuthorLink } from "./authors";
 import {
-  getCategoryFromReference,
+  getCategoryRoute,
   getMetaFromRemarkPluginFrontmatter,
-  getTagsFromReferences,
+  getTagsRoutes,
   resolveReferences,
   resolveTranslations,
 } from "./utils";
@@ -95,11 +95,11 @@ export async function getRoutableEntryPreview<T extends RoutableCollectionKey>(
       : {}),
     ...("category" in remainingMeta
       ? {
-          category: getCategoryFromReference(remainingMeta.category, indexById),
+          category: getCategoryRoute(remainingMeta.category, indexById),
         }
       : {}),
     ...("tags" in remainingMeta
-      ? { tags: getTagsFromReferences(remainingMeta.tags, indexById) }
+      ? { tags: getTagsRoutes(remainingMeta.tags, indexById) }
       : {}),
   };
 

--- a/src/lib/astro/collections/formatters/utils.test.ts
+++ b/src/lib/astro/collections/formatters/utils.test.ts
@@ -10,7 +10,7 @@ import {
 import type { IndexedEntry } from "../types";
 import {
   getMetaFromRemarkPluginFrontmatter,
-  getTaxonomyLink,
+  getTaxonomyRoute,
   resolveReferences,
   resolveTranslations,
 } from "./utils";
@@ -73,11 +73,11 @@ describe("get-taxonomy-link", () => {
       route: "/blog/category/micro-blog",
       slug: "micro-blog",
     };
-    const result = getTaxonomyLink(indexedEntry);
+    const result = getTaxonomyRoute(indexedEntry);
 
     expect(result).toMatchObject({
-      route: indexedEntry.route,
-      title: indexedEntry.raw.data.title,
+      label: indexedEntry.raw.data.title,
+      path: indexedEntry.route,
     });
   });
 
@@ -87,11 +87,11 @@ describe("get-taxonomy-link", () => {
       route: "/tags/catchall-tag",
       slug: "catchall-tag",
     };
-    const result = getTaxonomyLink(indexedEntry);
+    const result = getTaxonomyRoute(indexedEntry);
 
     expect(result).toMatchObject({
-      route: indexedEntry.route,
-      title: indexedEntry.raw.data.title,
+      label: indexedEntry.raw.data.title,
+      path: indexedEntry.route,
     });
   });
 });

--- a/src/lib/astro/collections/formatters/utils.ts
+++ b/src/lib/astro/collections/formatters/utils.ts
@@ -3,7 +3,8 @@ import type {
   AltLanguage,
   ReadingTime,
   RemarkPluginFrontmatterMeta,
-  TaxonomyLink,
+  Route,
+  TaxonomyCollectionKey,
 } from "../../../../types/data";
 import type { AvailableLocale } from "../../../../types/tokens";
 import { WORDS_PER_MINUTE } from "../../../../utils/constants";
@@ -106,19 +107,19 @@ export const getMetaFromRemarkPluginFrontmatter = (
 };
 
 /**
- * Convert a taxonomy indexed entry to a TaxonomyLink object.
+ * Convert a taxonomy indexed entry to a Route object.
  *
- * @param {IndexedEntry<"blog.categories" | "tags">} taxonomy - The taxonomy indexed entry.
- * @returns {Promise<TaxonomyLink>} An object describing the taxonomy link.
+ * @param {IndexedEntry<TaxonomyCollectionKey>} taxonomy - The taxonomy indexed entry.
+ * @returns {Promise<Route>} An object describing the taxonomy route.
  */
-export const getTaxonomyLink = (
-  taxonomy: IndexedEntry<"blog.categories" | "tags">
-): TaxonomyLink => {
+export const getTaxonomyRoute = (
+  taxonomy: IndexedEntry<TaxonomyCollectionKey>
+): Route => {
   const { route, raw } = taxonomy;
 
   return {
-    route,
-    title: raw.data.title,
+    label: raw.data.title,
+    path: route,
   };
 };
 
@@ -149,40 +150,40 @@ export const resolveReferences = <C extends CollectionKey>(
 };
 
 /**
- * Retrieve a category link from a `blog.categories` reference.
+ * Retrieve a category route from a `blog.categories` reference.
  *
  * @param {CollectionReference<"blog.categories"> | undefined} reference - A `blog.categories` reference.
  * @param {EntryByIdIndex} indexById - A map of indexed entries by id.
- * @returns {TaxonomyLink | null} An object describing the category link or null.
+ * @returns {Route | null} An object describing the category route or null.
  */
-export const getCategoryFromReference = (
+export const getCategoryRoute = (
   reference: CollectionReference<"blog.categories"> | undefined,
   indexById: EntryByIdIndex
-): TaxonomyLink | null => {
+): Route | null => {
   if (reference === undefined) return null;
 
   const category = indexById.get(reference.id);
 
   return category !== undefined &&
     isInCollection(category, reference.collection)
-    ? getTaxonomyLink(category)
+    ? getTaxonomyRoute(category)
     : null;
 };
 
 /**
- * Retrieve the tags links from a list of `tags` references.
+ * Retrieve the tags routes from a list of `tags` references.
  *
  * @param {CollectionReference<"tags">[] | undefined} references - An array of `tags` references.
  * @param {EntryByIdIndex} indexById - A map of indexed entries by id.
- * @returns {TaxonomyLink[] | null} An array of objects describing the tags links.
+ * @returns {Route[] | null} An array of objects describing the tags routes.
  */
-export const getTagsFromReferences = (
+export const getTagsRoutes = (
   references: CollectionReference<"tags">[] | undefined,
   indexById: EntryByIdIndex
-): TaxonomyLink[] | null => {
+): Route[] | null => {
   const resolvedTags = resolveReferences(references, indexById);
 
-  return resolvedTags?.map(getTaxonomyLink) ?? null;
+  return resolvedTags?.map(getTaxonomyRoute) ?? null;
 };
 
 /**

--- a/src/lib/astro/integrations/astro-stories/components/story-index.astro
+++ b/src/lib/astro/integrations/astro-stories/components/story-index.astro
@@ -11,9 +11,9 @@ const { ...index } = Astro.props;
   {
     index.children.length > 0 ? (
       <ul>
-        {index.children.map(({ label, route }) => (
+        {index.children.map(({ label, path }) => (
           <li>
-            <a href={route}>{label}</a>
+            <a href={path}>{label}</a>
           </li>
         ))}
       </ul>

--- a/src/lib/astro/integrations/astro-stories/components/story-index.test.ts
+++ b/src/lib/astro/integrations/astro-stories/components/story-index.test.ts
@@ -38,7 +38,7 @@ describe("StoryIndex", () => {
 
     const props = {
       breadcrumb: [],
-      children: [{ label: "A story", route: "/stories/a-story" }],
+      children: [{ label: "A story", path: "/stories/a-story" }],
       label: "My stories index",
       route: "/stories/my-index",
       type: "index",

--- a/src/lib/astro/integrations/astro-stories/types/internal.ts
+++ b/src/lib/astro/integrations/astro-stories/types/internal.ts
@@ -12,7 +12,7 @@ export type Story = {
 
 export type StoriesIndex = {
   breadcrumb: Route[];
-  children: { route: string; label: string }[];
+  children: Route[];
   label: string;
   route: string;
   type: "index";

--- a/src/lib/astro/integrations/astro-stories/utils.test.ts
+++ b/src/lib/astro/integrations/astro-stories/utils.test.ts
@@ -17,8 +17,8 @@ describe("getStories", () => {
     expect(result).toStrictEqual({
       base: {
         breadcrumb: [
-          { label: "Home", url: "/" },
-          { label: "Base", url: "/base" },
+          { label: "Home", path: "/" },
+          { label: "Base", path: "/base" },
         ],
         children: [],
         label: "Base",
@@ -37,9 +37,9 @@ describe("getStories", () => {
 
     expect(result.button).toStrictEqual({
       breadcrumb: [
-        { label: "Home", url: "/" },
-        { label: "Somewhere", url: "/somewhere" },
-        { label: "Button", url: "/somewhere/button" },
+        { label: "Home", path: "/" },
+        { label: "Somewhere", path: "/somewhere" },
+        { label: "Button", path: "/somewhere/button" },
       ],
       label: "Button",
       path: join(import.meta.dirname, "button.stories.mdx"),
@@ -59,9 +59,9 @@ describe("getStories", () => {
 
     expect(result.example).toStrictEqual({
       breadcrumb: [
-        { label: "Home", url: "/" },
-        { label: "Somewhere", url: "/somewhere" },
-        { label: "Example", url: "/somewhere/example" },
+        { label: "Home", path: "/" },
+        { label: "Somewhere", path: "/somewhere" },
+        { label: "Example", path: "/somewhere/example" },
       ],
       label: "Example",
       path: join(import.meta.dirname, "stories/example.mdx"),
@@ -81,13 +81,13 @@ describe("getStories", () => {
 
     expect(result.components).toStrictEqual({
       breadcrumb: [
-        { label: "Home", url: "/" },
-        { label: "Somewhere", url: "/somewhere" },
-        { label: "Components", url: "/somewhere/components" },
+        { label: "Home", path: "/" },
+        { label: "Somewhere", path: "/somewhere" },
+        { label: "Components", path: "/somewhere/components" },
       ],
       children: [
-        { route: "/somewhere/components/button", label: "Button" },
-        { route: "/somewhere/components/input", label: "Input" },
+        { label: "Button", path: "/somewhere/components/button" },
+        { label: "Input", path: "/somewhere/components/input" },
       ],
       label: "Components",
       route: "/somewhere/components",
@@ -103,13 +103,13 @@ describe("getStories", () => {
     });
 
     expect(result.components).toMatchObject({
-      children: [{ route: "/design-system/components/atoms", label: "Atoms" }],
+      children: [{ label: "Atoms", path: "/design-system/components/atoms" }],
     });
 
     expect(result["design-system"]).toMatchObject({
       children: expect.arrayContaining([
-        { route: "/design-system/components", label: "Components" },
-        { route: "/design-system/tokens", label: "Tokens" },
+        { label: "Components", path: "/design-system/components" },
+        { label: "Tokens", path: "/design-system/tokens" },
       ]),
     });
   });

--- a/src/lib/astro/integrations/astro-stories/utils.ts
+++ b/src/lib/astro/integrations/astro-stories/utils.ts
@@ -160,7 +160,7 @@ type GenerateBreadcrumbConfig = {
   /** The route to generate breadcrumbs for. */
   route: string;
   /** Map of routes to their labels. */
-  routeMap: Map<string, { label: string; route: string }>;
+  routeMap: Map<string, Route>;
 };
 
 /**
@@ -173,7 +173,7 @@ const generateBreadcrumb = ({
   route,
   routeMap,
 }: GenerateBreadcrumbConfig): Route[] => {
-  const breadcrumb: Route[] = [{ url: "/", label: "Home" }];
+  const breadcrumb: Route[] = [{ label: "Home", path: "/" }];
   const pathParts = route.split("/").filter(Boolean);
 
   for (let i = 0; i < pathParts.length; i++) {
@@ -181,10 +181,7 @@ const generateBreadcrumb = ({
     const routeInfo = routeMap.get(currentPath);
 
     if (routeInfo !== undefined) {
-      breadcrumb.push({
-        label: routeInfo.label,
-        url: routeInfo.route,
-      });
+      breadcrumb.push(routeInfo);
     }
   }
 
@@ -192,7 +189,7 @@ const generateBreadcrumb = ({
 };
 
 type FormatStoryConfig = {
-  routeMap: Map<string, { label: string; route: string }>;
+  routeMap: Map<string, Route>;
   story: StoryPathInfo;
 };
 
@@ -208,10 +205,10 @@ const formatStory = ({ routeMap, story }: FormatStoryConfig): Story => {
 
 const formatIndex = (
   currentIndex: IndexPathInfo,
-  routeMap: Map<string, { label: string; route: string }>
+  routeMap: Map<string, Route>
 ): StoriesIndex => {
   const { label, route } = currentIndex;
-  const children = [...routeMap.values()].filter(({ route: childRoute }) => {
+  const children = [...routeMap.values()].filter(({ path: childRoute }) => {
     if (childRoute === route) return false;
     const parentRoute = childRoute.slice(0, childRoute.lastIndexOf("/"));
     return parentRoute === route;
@@ -230,10 +227,10 @@ const formatStories = (
   stories: StoryPathInfo[],
   indexes: IndexPathInfo[]
 ): Stories => {
-  const routeMap = new Map<string, { label: string; route: string }>(
+  const routeMap = new Map<string, Route>(
     [...indexes, ...stories].map(({ label, route }) => [
       route,
-      { label, route },
+      { label, path: route },
     ])
   );
   const formattedStories = stories.map(

--- a/src/lib/schema-dts/graphs/article-graph.test.ts
+++ b/src/lib/schema-dts/graphs/article-graph.test.ts
@@ -252,8 +252,8 @@ describe("getArticleGraph", () => {
           publishedOn: new Date("2024-10-09T13:55:57.813Z"),
           updatedOn: new Date("2024-10-09T13:55:57.813Z"),
           tags: [
-            { title: "tenetur", route: "/tenetur" },
-            { title: "iste", route: "/iste" },
+            { label: "tenetur", path: "/tenetur" },
+            { label: "iste", path: "/iste" },
           ],
         },
         route: "/route",
@@ -276,7 +276,7 @@ describe("getArticleGraph", () => {
         locale: CONFIG.LANGUAGES.DEFAULT,
         meta: {
           authors: [{ isWebsiteOwner: false, name: "John Doe" }],
-          category: { title: "animi", route: "/animi" },
+          category: { label: "animi", path: "/animi" },
           publishedOn: new Date("2024-10-09T13:55:57.813Z"),
           updatedOn: new Date("2024-10-09T13:55:57.813Z"),
         },
@@ -320,8 +320,8 @@ describe("getArticleGraph", () => {
             wordsPerMinute: 80,
           },
           tags: [
-            { title: "tenetur", route: "/tenetur" },
-            { title: "iste", route: "/iste" },
+            { label: "tenetur", path: "/tenetur" },
+            { label: "iste", path: "/iste" },
           ],
           updatedOn: new Date("2024-10-09T13:55:57.813Z"),
         },

--- a/src/lib/schema-dts/graphs/article-graph.ts
+++ b/src/lib/schema-dts/graphs/article-graph.ts
@@ -72,13 +72,13 @@ export const getArticleGraph = async ({
     isAccessibleForFree: true,
     ...(isBlogPost && {
       isPartOf: {
-        "@id": `${WEBSITE_URL}${routeById("blog").url}#blog`,
+        "@id": `${WEBSITE_URL}${routeById("blog").path}#blog`,
       },
     }),
     ...(meta.tags !== null &&
       meta.tags !== undefined &&
       meta.tags.length > 0 && {
-        keywords: meta.tags.map((tag) => tag.title).join(","),
+        keywords: meta.tags.map((tag) => tag.label).join(","),
       }),
     license: translate("license.url"),
     mainEntityOfPage: { "@id": url },

--- a/src/lib/schema-dts/graphs/blog-graph.ts
+++ b/src/lib/schema-dts/graphs/blog-graph.ts
@@ -26,7 +26,7 @@ export const getBlogGraph = async ({
   const { translate } = useI18n(locale);
   const { routeById } = await useRouting(locale);
   const websiteAuthor = `${WEBSITE_URL}#author` as const;
-  const blogUrl = `${WEBSITE_URL}${routeById("blog").url}`;
+  const blogUrl = `${WEBSITE_URL}${routeById("blog").path}`;
 
   return {
     "@id": `${blogUrl}#blog`,
@@ -40,7 +40,7 @@ export const getBlogGraph = async ({
     editor: { "@id": websiteAuthor },
     headline: title,
     isAccessibleForFree: true,
-    isPartOf: { "@id": `${WEBSITE_URL}${routeById("home").url}` },
+    isPartOf: { "@id": `${WEBSITE_URL}${routeById("home").path}` },
     license: translate("license.url"),
     mainEntityOfPage: blogUrl,
     name: title,

--- a/src/lib/schema-dts/graphs/breadcrumb-list-graph.test.ts
+++ b/src/lib/schema-dts/graphs/breadcrumb-list-graph.test.ts
@@ -6,11 +6,11 @@ describe("get-breadcrumb-list-graph", () => {
     const graph = getBreadcrumbListGraph([
       {
         label: "magni",
-        url: "/magni",
+        path: "/magni",
       },
       {
         label: "quasi",
-        url: "/quasi",
+        path: "/quasi",
       },
     ]);
 

--- a/src/lib/schema-dts/graphs/breadcrumb-list-graph.ts
+++ b/src/lib/schema-dts/graphs/breadcrumb-list-graph.ts
@@ -13,7 +13,7 @@ export const getBreadcrumbListGraph = (breadcrumb: Route[]): BreadcrumbList => {
     "@type": "BreadcrumbList",
     itemListElement: breadcrumb.map((crumb, index) =>
       getListItemGraph({
-        id: crumb.url,
+        id: crumb.path,
         label: crumb.label,
         position: index + 1,
       })

--- a/src/lib/schema-dts/graphs/webpage-graph.test.ts
+++ b/src/lib/schema-dts/graphs/webpage-graph.test.ts
@@ -151,8 +151,8 @@ describe("getWebPageGraph", () => {
     expect.assertions(2);
 
     const breadcrumb = [
-      { label: "Home", url: "/" },
-      { label: "Category", url: "/category" },
+      { label: "Home", path: "/" },
+      { label: "Category", path: "/category" },
     ];
 
     const graph = await getWebPageGraph({
@@ -233,7 +233,7 @@ describe("getWebPageGraph", () => {
     // eslint-disable-next-line @typescript-eslint/no-magic-numbers -- Self-explanatory.
     expect.assertions(4);
 
-    const breadcrumb = [{ label: "Home", url: "/" }];
+    const breadcrumb = [{ label: "Home", path: "/" }];
     const cover = {
       alt: "Image description",
       height: 480,

--- a/src/lib/schema-dts/graphs/webpage-graph.ts
+++ b/src/lib/schema-dts/graphs/webpage-graph.ts
@@ -52,7 +52,7 @@ export const getWebPageGraph = async ({
     editor: { "@id": websiteAuthor },
     headline: title,
     isAccessibleForFree: true,
-    isPartOf: { "@id": `${WEBSITE_URL}${routeById("home").url}` },
+    isPartOf: { "@id": `${WEBSITE_URL}${routeById("home").path}` },
     lastReviewed: meta.updatedOn.toISOString(),
     license: translate("license.url"),
     name: title,

--- a/src/lib/schema-dts/graphs/website-graph.ts
+++ b/src/lib/schema-dts/graphs/website-graph.ts
@@ -34,12 +34,12 @@ export const getWebSiteGraph = async ({
     "@type": "SearchAction",
     query: "required",
     "query-input": "required name=query",
-    target: `${WEBSITE_URL}${routeById("search").url}?${CONFIG.SEARCH.QUERY_PARAM}={query}`,
+    target: `${WEBSITE_URL}${routeById("search").path}?${CONFIG.SEARCH.QUERY_PARAM}={query}`,
   };
 
   return {
     "@type": "WebSite",
-    "@id": `${WEBSITE_URL}${routeById("home").url}`,
+    "@id": `${WEBSITE_URL}${routeById("home").path}`,
     author: { "@id": websiteAuthor },
     copyrightHolder: { "@id": websiteAuthor },
     copyrightYear: CONFIG.CREATION_YEAR,
@@ -54,6 +54,6 @@ export const getWebSiteGraph = async ({
     potentialAction: searchAction,
     publisher: { "@id": websiteAuthor },
     thumbnailUrl: logo,
-    url: `${WEBSITE_URL}${routeById("home").url}`,
+    url: `${WEBSITE_URL}${routeById("home").path}`,
   };
 };

--- a/src/services/breadcrumb/breadcrumb.test.ts
+++ b/src/services/breadcrumb/breadcrumb.test.ts
@@ -93,7 +93,7 @@ describe("getBreadcrumb", () => {
 
     const result = await getBreadcrumb({ route: "/" });
 
-    expect(result).toStrictEqual([{ label: "Home", url: "/" }]);
+    expect(result).toStrictEqual([{ label: "Home", path: "/" }]);
   });
 
   it("returns breadcrumb for localized route", async () => {
@@ -102,9 +102,9 @@ describe("getBreadcrumb", () => {
     const result = await getBreadcrumb({ route: "/fr/blog/article" });
 
     expect(result).toStrictEqual([
-      { label: "Accueil", url: "/fr" },
-      { label: "Blog", url: "/fr/blog" },
-      { label: "Article", url: "/fr/blog/article" },
+      { label: "Accueil", path: "/fr" },
+      { label: "Blog", path: "/fr/blog" },
+      { label: "Article", path: "/fr/blog/article" },
     ]);
   });
 
@@ -114,8 +114,8 @@ describe("getBreadcrumb", () => {
     const result = await getBreadcrumb({ route: "/about" });
 
     expect(result).toStrictEqual([
-      { label: "Home", url: "/" },
-      { label: "About", url: "/about" },
+      { label: "Home", path: "/" },
+      { label: "About", path: "/about" },
     ]);
   });
 
@@ -127,7 +127,7 @@ describe("getBreadcrumb", () => {
     expect(result).toStrictEqual([
       {
         label: "Home",
-        url: "/",
+        path: "/",
       },
     ]);
   });
@@ -141,10 +141,10 @@ describe("getBreadcrumb", () => {
     });
 
     expect(result).toStrictEqual([
-      { label: "Home", url: "/" },
-      { label: "Blog", url: "/blog" },
-      { label: "Post", url: "/blog/post" },
-      { label: "Page 2", url: "/blog/post" },
+      { label: "Home", path: "/" },
+      { label: "Blog", path: "/blog" },
+      { label: "Post", path: "/blog/post" },
+      { label: "Page 2", path: "/blog/post" },
     ]);
   });
 });

--- a/src/services/breadcrumb/breadcrumb.ts
+++ b/src/services/breadcrumb/breadcrumb.ts
@@ -31,7 +31,7 @@ const getRouteCrumbs = (
     .map((segment) => routeIndex.get(segment))
     .filter((entry) => entry !== undefined)
     .map((entry) => {
-      return { label: entry.raw.data.title, url: entry.route };
+      return { label: entry.raw.data.title, path: entry.route };
     });
 };
 
@@ -66,7 +66,7 @@ export const getBreadcrumb = async ({
   if (paginationLabel !== undefined) {
     crumbs.push({
       label: paginationLabel,
-      url: route,
+      path: route,
     });
   }
 

--- a/src/services/feeds/build-feeds.test.ts
+++ b/src/services/feeds/build-feeds.test.ts
@@ -60,7 +60,7 @@ describe("get-rss-items-from-entries", () => {
       ...tagBaseFixture,
       meta: {
         ...tagBaseFixture.meta,
-        tags: [{ route: "/tag1", title: "Tag1" }],
+        tags: [{ label: "Tag1", path: "/tag1" }],
       },
     } satisfies FeedCompatibleEntry;
     const entries: FeedCompatibleEntry[] = [tag];
@@ -70,7 +70,7 @@ describe("get-rss-items-from-entries", () => {
     );
 
     expect(result).toHaveLength(entries.length);
-    expect(result[0]?.categories).toContain(tag.meta.tags[0]?.title);
+    expect(result[0]?.categories).toContain(tag.meta.tags[0]?.label);
   });
 });
 

--- a/src/services/feeds/build-feeds.ts
+++ b/src/services/feeds/build-feeds.ts
@@ -161,7 +161,7 @@ const getItemCategories = (entry: FeedCompatibleEntry) => {
     entry.meta.tags !== undefined &&
     entry.meta.tags.length > 0
   ) {
-    categories.push(...entry.meta.tags.map((tag) => tag.title));
+    categories.push(...entry.meta.tags.map((tag) => tag.label));
   }
 
   return categories;

--- a/src/services/feeds/collections-feeds.ts
+++ b/src/services/feeds/collections-feeds.ts
@@ -1,18 +1,17 @@
+import type { Route } from "../../types/data";
 import type { AvailableLocale } from "../../types/tokens";
 import { queryCollection } from "../collections";
 import { useI18n } from "../i18n";
-
-type FeedLink = { label: string; slug: string };
 
 /**
  * Retrieve the feeds data for each collection having a feed.
  *
  * @param {AvailableLocale} locale - The feed locale.
- * @returns {Promise<FeedLink[]>} The label and slug for each feed.
+ * @returns {Promise<Route[]>} The label and the path for each feed.
  */
 export const getCollectionsFeeds = async (
   locale: AvailableLocale
-): Promise<FeedLink[]> => {
+): Promise<Route[]> => {
   const { translate } = useI18n(locale);
   const pagesWithFeed = [
     `${locale}/blog/categories`,
@@ -45,7 +44,7 @@ export const getCollectionsFeeds = async (
   return entriesWithFeed.map((entry) => {
     return {
       label: translate("feed.link.title", { title: entry.title }),
-      slug: `${entry.route}/feed.xml`,
+      path: `${entry.route}/feed.xml`,
     };
   });
 };

--- a/src/services/routing/use-routing.test.ts
+++ b/src/services/routing/use-routing.test.ts
@@ -61,7 +61,7 @@ describe("use-routing", () => {
 
     expect(routeById("note1")).toStrictEqual({
       label: "Note 1",
-      url: "/note1",
+      path: "/note1",
     });
   });
 
@@ -72,7 +72,7 @@ describe("use-routing", () => {
 
     expect(routeById("project1", "fr")).toStrictEqual({
       label: "Projet 1",
-      url: "/fr/projet1",
+      path: "/fr/projet1",
     });
   });
 

--- a/src/services/routing/use-routing.ts
+++ b/src/services/routing/use-routing.ts
@@ -32,7 +32,7 @@ export const useRouting: UseRouting = async (
       );
     }
 
-    return { label: match.raw.data.title, url: match.route };
+    return { label: match.raw.data.title, path: match.route };
   };
 
   return { routeById };

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -9,8 +9,10 @@ import type { AvailableLocale, IconName } from "./tokens";
 import type { ConditionallyExtend, PatchExistingProperties } from "./utilities";
 
 export type Route = {
+  /** The label of the route. */
   label: string;
-  url: string;
+  /** The pathname of the route. */
+  path: string;
 };
 
 export type WithIcon<T> = T & {
@@ -173,8 +175,8 @@ type AddCollectionFeatures<T, K, Mode> = AddRenderedContentIfApplicable<
 
 type UpdatedMetaPropertiesTypes = {
   authors: AuthorLink[];
-  category: TaxonomyLink | null;
-  tags: TaxonomyLink[] | null;
+  category: Route | null;
+  tags: Route[] | null;
 };
 
 type UpdatedRootPropertiesTypes = {
@@ -307,11 +309,11 @@ export type Project = FormattedEntry<"projects", "full">;
 export type ProjectPreview = FormattedEntry<"projects">;
 export type ProjectMetaData = Project["meta"];
 
-export type RawTaxonomyEntry = CollectionEntry<"blog.categories" | "tags">;
-export type Taxonomy = FormattedEntry<"blog.categories" | "tags", "full">;
-export type TaxonomyPreview = FormattedEntry<"blog.categories" | "tags">;
+export type TaxonomyCollectionKey = "blog.categories" | "tags";
+export type RawTaxonomyEntry = CollectionEntry<TaxonomyCollectionKey>;
+export type Taxonomy = FormattedEntry<TaxonomyCollectionKey, "full">;
+export type TaxonomyPreview = FormattedEntry<TaxonomyCollectionKey>;
 export type TaxonomyMetaData = Taxonomy["meta"];
-export type TaxonomyLink = Pick<Taxonomy, "title"> & { route: string };
 
 export type CollectionMetaData =
   | BlogMetaData

--- a/src/utils/stories.test.ts
+++ b/src/utils/stories.test.ts
@@ -5,11 +5,11 @@ describe("get-story-seo", () => {
   it("computes seo meta from a breadcrumb", () => {
     const meta = getStorySeo({
       breadcrumb: [
-        { label: "Home", url: "/" },
-        { label: "Design system", url: "/design-system" },
-        { label: "Components", url: "/design-system/components" },
-        { label: "Atoms", url: "/design-system/components/atoms" },
-        { label: "Story", url: "/design-system/components/atoms/story" },
+        { label: "Home", path: "/" },
+        { label: "Design system", path: "/design-system" },
+        { label: "Components", path: "/design-system/components" },
+        { label: "Atoms", path: "/design-system/components/atoms" },
+        { label: "Story", path: "/design-system/components/atoms/story" },
       ],
     });
 
@@ -23,11 +23,11 @@ describe("get-story-seo", () => {
   it("allows overriding seo flags", () => {
     const meta = getStorySeo({
       breadcrumb: [
-        { label: "Home", url: "/" },
-        { label: "Design system", url: "/design-system" },
-        { label: "Components", url: "/design-system/components" },
-        { label: "Atoms", url: "/design-system/components/atoms" },
-        { label: "Story", url: "/design-system/components/atoms/story" },
+        { label: "Home", path: "/" },
+        { label: "Design system", path: "/design-system" },
+        { label: "Components", path: "/design-system/components" },
+        { label: "Atoms", path: "/design-system/components/atoms" },
+        { label: "Story", path: "/design-system/components/atoms/story" },
       ],
       seo: { noindex: false, nofollow: false, title: "Overridden" },
     });

--- a/src/views/blog-index-view/blog-index-view.astro
+++ b/src/views/blog-index-view/blog-index-view.astro
@@ -76,7 +76,7 @@ const getPostCTA = (
     >
       <Heading>{translate("page.blog.section.recent.posts.heading")}</Heading>
       <div class="blog-section-cta">
-        <Button as="a" href={routeById("blog/posts").url}>
+        <Button as="a" href={routeById("blog/posts").path}>
           {translatePlural("cta.see.all.posts", { count: totalPosts })}
         </Button>
         <Button
@@ -84,7 +84,7 @@ const getPostCTA = (
             title: translate("page.blog.posts.title"),
           })}
           as="a"
-          href={`${routeById("blog/posts").url}/feed.xml`}
+          href={`${routeById("blog/posts").path}/feed.xml`}
         >
           <Icon aria-hidden="true" name="feed" />
           {translate("cta.subscribe")}

--- a/src/views/blog-index-view/blog-index-view.stories.mdx
+++ b/src/views/blog-index-view/blog-index-view.stories.mdx
@@ -8,10 +8,10 @@ import BlogIndexView from "./blog-index-view.astro";
 export const components = mdxComponents;
 export const title = "BlogIndexView";
 export const breadcrumb = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Views", url: "/design-system/views" },
-  { label: title, url: "/design-system/views/blog-index-view" },
+  { label: "Home", path: "/" },
+  { label: "Design system", path: "/design-system" },
+  { label: "Views", path: "/design-system/views" },
+  { label: title, path: "/design-system/views/blog-index-view" },
 ];
 export const seo = {
   nofollow: true,

--- a/src/views/collection-listing-view/collection-listing-view.astro
+++ b/src/views/collection-listing-view/collection-listing-view.astro
@@ -40,7 +40,7 @@ const isTagPage = (
   entry: QueriedCollectionEntry<ListingPageCollection, "preview">
 ) => {
   if (!("tags" in entry.meta) || !entry.meta.tags) return false;
-  return entry.meta.tags.some((tag) => tag.route === page.route);
+  return entry.meta.tags.some((tag) => tag.path === page.route);
 };
 
 const filterCurrentTag = <
@@ -51,7 +51,7 @@ const filterCurrentTag = <
   if (!("tags" in meta) || !meta.tags) return meta;
   return {
     ...meta,
-    tags: meta.tags.filter((tag) => tag.route !== page.route),
+    tags: meta.tags.filter((tag) => tag.path !== page.route),
   };
 };
 
@@ -91,7 +91,7 @@ const config: CollectionConfigMap = {
       if ("category" in entry.meta) {
         const { authors, category, ...rest } = entry.meta;
         const filteredMeta = filterCurrentTag(rest);
-        return page.route === category?.route
+        return page.route === category?.path
           ? { ...entry, meta: { ...filteredMeta } }
           : { ...entry, meta: { ...filteredMeta, category } };
       }

--- a/src/views/collection-listing-view/collection-listing-view.stories.mdx
+++ b/src/views/collection-listing-view/collection-listing-view.stories.mdx
@@ -8,10 +8,10 @@ import CollectionListingView from "./collection-listing-view.astro";
 export const components = mdxComponents;
 export const title = "CollectionListingView";
 export const breadcrumb = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Views", url: "/design-system/views" },
-  { label: title, url: "/design-system/views/collection-listing-view" },
+  { label: "Home", path: "/" },
+  { label: "Design system", path: "/design-system" },
+  { label: "Views", path: "/design-system/views" },
+  { label: title, path: "/design-system/views/collection-listing-view" },
 ];
 export const seo = {
   nofollow: true,

--- a/src/views/contact-view/contact-view.stories.mdx
+++ b/src/views/contact-view/contact-view.stories.mdx
@@ -8,10 +8,10 @@ import ContactView from "./contact-view.astro";
 export const components = mdxComponents;
 export const title = "ContactView";
 export const breadcrumb = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Views", url: "/design-system/views" },
-  { label: title, url: "/design-system/views/contact-view" },
+  { label: "Home", path: "/" },
+  { label: "Design system", path: "/design-system" },
+  { label: "Views", path: "/design-system/views" },
+  { label: title, path: "/design-system/views/contact-view" },
 ];
 export const seo = {
   nofollow: true,

--- a/src/views/default-page-view/default-page-view.stories.mdx
+++ b/src/views/default-page-view/default-page-view.stories.mdx
@@ -8,10 +8,10 @@ import DefaultPageView from "./default-page-view.astro";
 export const components = mdxComponents;
 export const title = "DefaultPageView";
 export const breadcrumb = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Views", url: "/design-system/views" },
-  { label: title, url: "/design-system/views/default-page-view" },
+  { label: "Home", path: "/" },
+  { label: "Design system", path: "/design-system" },
+  { label: "Views", path: "/design-system/views" },
+  { label: title, path: "/design-system/views/default-page-view" },
 ];
 export const seo = {
   nofollow: true,

--- a/src/views/feeds-view/feeds-view.astro
+++ b/src/views/feeds-view/feeds-view.astro
@@ -43,7 +43,7 @@ const graphs: ComponentProps<typeof PageLayout>["graphs"] = [
     {hasContent && <Content />}
     <p>{translate("page.feeds.global.feed.introduction")}</p>
     <p>
-      <Button as="a" href={`${routeById("home").url}feed.xml`}>
+      <Button as="a" href={`${routeById("home").path}feed.xml`}>
         <Icon aria-hidden="true" name="feed" />
         {translate("cta.subscribe.to.website")}
       </Button>
@@ -53,7 +53,7 @@ const graphs: ComponentProps<typeof PageLayout>["graphs"] = [
       {
         feeds?.map((feed) => (
           <ListItem>
-            <Link href={feed.slug}>{feed.label}</Link>
+            <Link href={feed.path}>{feed.label}</Link>
           </ListItem>
         ))
       }

--- a/src/views/feeds-view/feeds-view.stories.mdx
+++ b/src/views/feeds-view/feeds-view.stories.mdx
@@ -8,10 +8,10 @@ import FeedsView from "./feeds-view.astro";
 export const components = mdxComponents;
 export const title = "FeedsView";
 export const breadcrumb = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Views", url: "/design-system/views" },
-  { label: title, url: "/design-system/views/feeds-view" },
+  { label: "Home", path: "/" },
+  { label: "Design system", path: "/design-system" },
+  { label: "Views", path: "/design-system/views" },
+  { label: title, path: "/design-system/views/feeds-view" },
 ];
 export const seo = {
   nofollow: true,

--- a/src/views/homepage-view/homepage-view.astro
+++ b/src/views/homepage-view/homepage-view.astro
@@ -103,7 +103,7 @@ const graphs: ComponentProps<typeof PageLayout>["graphs"] = [
             addRelMe
             as="section"
             class="homepage-contact"
-            contactPageRoute={routeById("contact").url}
+            contactPageRoute={routeById("contact").path}
             elevation="raised"
             isSpaced
             socialMedia={author.socialMedia}

--- a/src/views/homepage-view/homepage-view.stories.mdx
+++ b/src/views/homepage-view/homepage-view.stories.mdx
@@ -8,10 +8,10 @@ import HomepageView from "./homepage-view.astro";
 export const components = mdxComponents;
 export const title = "HomepageView";
 export const breadcrumb = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Views", url: "/design-system/views" },
-  { label: title, url: "/design-system/views/homepage-view" },
+  { label: "Home", path: "/" },
+  { label: "Design system", path: "/design-system" },
+  { label: "Views", path: "/design-system/views" },
+  { label: title, path: "/design-system/views/homepage-view" },
 ];
 export const seo = {
   nofollow: true,

--- a/src/views/not-found-view/not-found-view.astro
+++ b/src/views/not-found-view/not-found-view.astro
@@ -37,7 +37,7 @@ const graphs: ComponentProps<typeof PageLayout>["graphs"] = [
     <SearchForm
       id="not-found-search"
       queryParam={CONFIG.SEARCH.QUERY_PARAM}
-      resultsPage={routeById("search").url}
+      resultsPage={routeById("search").path}
     />
   </Fragment>
 </PageLayout>

--- a/src/views/not-found-view/not-found-view.stories.mdx
+++ b/src/views/not-found-view/not-found-view.stories.mdx
@@ -8,10 +8,10 @@ import NotFoundView from "./not-found-view.astro";
 export const components = mdxComponents;
 export const title = "NotFoundView";
 export const breadcrumb = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Views", url: "/design-system/views" },
-  { label: title, url: "/design-system/views/not-found-view" },
+  { label: "Home", path: "/" },
+  { label: "Design system", path: "/design-system" },
+  { label: "Views", path: "/design-system/views" },
+  { label: title, path: "/design-system/views/not-found-view" },
 ];
 export const seo = {
   nofollow: true,

--- a/src/views/search-view/search-view.stories.mdx
+++ b/src/views/search-view/search-view.stories.mdx
@@ -8,10 +8,10 @@ import SearchView from "./search-view.astro";
 export const components = mdxComponents;
 export const title = "SearchView";
 export const breadcrumb = [
-  { label: "Home", url: "/" },
-  { label: "Design system", url: "/design-system" },
-  { label: "Views", url: "/design-system/views" },
-  { label: title, url: "/design-system/views/search-view" },
+  { label: "Home", path: "/" },
+  { label: "Design system", path: "/design-system" },
+  { label: "Views", path: "/design-system/views" },
+  { label: title, path: "/design-system/views/search-view" },
 ];
 export const seo = {
   nofollow: true,


### PR DESCRIPTION
## Changes

Objects were used in multiple places to describe a route but the properties was using different names. For consistency, I updated them to use the new `Route` type.

## Tests

Everything should still pass, I just updated some tests to match the new shape.

## Docs

I don't think this needs a changeset.