### PR TITLE
fix: prevent performance drop on smartphone because of SVG filters

### DIFF
--- a/.changeset/brown-keys-divide.md
+++ b/.changeset/brown-keys-divide.md
@@ -1,0 +1,9 @@
+---
+"apeu": patch
+---
+
+Fixes a performance issue on mobile devices caused by SVG filters.
+
+The SVG filters inlined in the HTML was causing different performance issue on mobile devices. With this fix:
+* Firefox should no longer struggle to display the text while scrolling
+* Chrome should no longer 

--- a/src/assets/paper-dark.svg
+++ b/src/assets/paper-dark.svg
@@ -4,31 +4,28 @@
     viewBox="0 0 100 100"
     xmlns="http://www.w3.org/2000/svg">
     <defs>
-        <filter
-            color-interpolation-filters="sRGB"
-            id='light-paper'>
+        <filter color-interpolation-filters="sRGB" id="dark-paper-filter">
             <feTurbulence
                 baseFrequency="0.020"
                 numOctaves="7"
                 result="noise"
                 seed="3"
-                type="fractalNoise" />
+                type="fractalNoise"></feTurbulence>
             <feDiffuseLighting
-                diffuseConstant="1.1"
-                lighting-color='hsl(200, 22%, 98%)'
+                diffuseConstant="1.2"
                 in="noise"
-                surfaceScale="0.600">
-                <feDistantLight
-                    azimuth="60"
-                    elevation="65" />
+                lighting-color="hsl(200deg 19% 12%)"
+                surfaceScale="1.1"
+            >
+                <feDistantLight azimuth="40" elevation="57"></feDistantLight>
             </feDiffuseLighting>
         </filter>
     </defs>
     <rect
-        filter="url(#light-paper)"
+        filter="url(#dark-paper-filter)"
         x="0"
         y="0"
         width="100"
         height="100"
-        id="rect2" />
+        id="dark-paper" />
 </svg>

--- a/src/assets/paper-light.svg
+++ b/src/assets/paper-light.svg
@@ -1,0 +1,34 @@
+<svg
+    width="100"
+    height="100"
+    xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <filter
+            color-interpolation-filters="sRGB"
+            id='light-paper-filter'>
+            <feTurbulence
+                baseFrequency="0.02"
+                numOctaves="10"
+                result="noise"
+                seed="5"
+                stitchTiles="stitch"
+                type="fractalNoise" />
+            <feDiffuseLighting
+                diffuseConstant="1.1"
+                lighting-color='hsl(200deg 22% 98%)'
+                in="noise"
+                surfaceScale="0.600">
+                <feDistantLight
+                    azimuth="80"
+                    elevation="65" />
+            </feDiffuseLighting>
+        </filter>
+    </defs>
+    <rect
+        filter="url(#light-paper-filter)"
+        x="0"
+        y="0"
+        width="100"
+        height="100"
+        id="light-paper" />
+</svg>

--- a/src/components/providers/svg-filters-provider.astro
+++ b/src/components/providers/svg-filters-provider.astro
@@ -3,45 +3,55 @@
 ---
 
 <slot />
-<svg
-  aria-hidden="true"
-  height="0"
-  viewBox="0 0 100 100"
-  width="0"
-  xmlns="http://www.w3.org/2000/svg"
->
-  <defs>
-    <filter color-interpolation-filters="sRGB" id="paper-filter">
-      <feTurbulence
-        baseFrequency="0.020"
-        numOctaves="7"
-        result="noise"
-        seed="3"
-        type="fractalNoise"></feTurbulence>
-      <feDiffuseLighting
-        diffuseConstant="1.1"
-        in="noise"
-        lighting-color="var(--color-regular)"
-        surfaceScale="0.600"
-      >
-        <feDistantLight azimuth="60" elevation="65"></feDistantLight>
-      </feDiffuseLighting>
-    </filter>
-    <filter color-interpolation-filters="sRGB" id="dark-paper-filter">
-      <feTurbulence
-        baseFrequency="0.020"
-        numOctaves="7"
-        result="noise"
-        seed="3"
-        type="fractalNoise"></feTurbulence>
-      <feDiffuseLighting
-        diffuseConstant="1.2"
-        in="noise"
-        lighting-color="var(--color-regular)"
-        surfaceScale="1.1"
-      >
-        <feDistantLight azimuth="40" elevation="57"></feDistantLight>
-      </feDiffuseLighting>
-    </filter>
-  </defs>
-</svg>
+
+<style is:global>
+  .svg-filter-paper,
+  .svg-filter-paper-dark {
+    position: relative;
+
+    &::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      z-index: -1;
+      clip-path: inset(0);
+      pointer-events: none;
+      user-select: none;
+      background: var(--bg-filter-lightning-color);
+
+      /* Fixes a Chromium bug where the SVG filter wasn't updated when
+       * switching the theme... */
+      transform: translate3d(0, 0, 0);
+    }
+  }
+
+  .svg-filter-paper::before {
+    --bg-filter-lightning-color: var(--color-regular);
+  }
+
+  .svg-filter-paper-dark::before {
+    --bg-filter-lightning-color: var(--color-regular-darker);
+  }
+
+  :where(html:not([data-theme="dark"])) {
+    .svg-filter-paper::before {
+      background-image: url("../../assets/paper-light.svg");
+    }
+
+    .svg-filter-paper-dark::before {
+      background-image: url("../../assets/paper-light.svg");
+      filter: brightness(0.985) contrast(98.5%) saturate(103%);
+    }
+  }
+
+  :where(html[data-theme="dark"]) {
+    .svg-filter-paper::before {
+      background-image: url("../../assets/paper-dark.svg");
+    }
+
+    .svg-filter-paper-dark::before {
+      background-image: url("../../assets/paper-dark.svg");
+      filter: brightness(0.85) contrast(103%) saturate(120%);
+    }
+  }
+</style>

--- a/src/components/templates/layout/layout.astro
+++ b/src/components/templates/layout/layout.astro
@@ -130,7 +130,7 @@ const topId = translate("anchor.site.top");
       </style>
     </noscript>
   </Head>
-  <body class="site" id={topId}>
+  <body class="site svg-filter-paper" id={topId}>
     <ThemeProvider>
       <SvgFiltersProvider>
         <PageTransitionProvider>
@@ -203,20 +203,6 @@ const topId = translate("anchor.site.top");
         minmax(calc(var(--one-px-in-rem) * 200), 22dvw)
         minmax(0, 1fr);
       grid-template-rows: minmax(0, 1fr) minmax(0, auto);
-    }
-
-    &::before {
-      content: "";
-      position: fixed;
-      inset: 0;
-      z-index: -1;
-      clip-path: inset(0);
-      pointer-events: none;
-      user-select: none;
-
-      /* Fixes a Chromium bug where the SVG filter wasn't updated when
-       * switching the theme... */
-      transform: translate3d(0, 0, 0);
     }
   }
 
@@ -331,20 +317,6 @@ const topId = translate("anchor.site.top");
     @media (--sm-or-above) {
       bottom: calc(1dvi + var(--spacing-md));
       right: calc(1dvi + var(--spacing-md));
-    }
-  }
-
-  :global(:where([data-theme="light"])) {
-    .site::before,
-    .site-navbar::before {
-      filter: url("#paper-filter");
-    }
-  }
-
-  :global(:where([data-theme="dark"])) {
-    .site::before,
-    .site-navbar::before {
-      filter: url("#dark-paper-filter");
     }
   }
 </style>

--- a/src/components/templates/page-layout/page-layout.astro
+++ b/src/components/templates/page-layout/page-layout.astro
@@ -79,7 +79,7 @@ const socialImg = {
       />
     ) : null
   }
-  <div class="page-layout-content">
+  <div class="page-layout-content svg-filter-paper-dark">
     <main class="page-layout-main" data-pagefind-body>
       <Page
         {...attrs}
@@ -143,17 +143,6 @@ const socialImg = {
       box-shadow: inset 0 0 var(--border-size-sm) var(--border-size-sm)
         var(--inset-shadow-color);
     }
-
-    &::before {
-      content: "";
-      position: absolute;
-      inset: 0;
-      z-index: -1;
-      background: var(--color-regular-dark);
-      clip-path: inset(0);
-      pointer-events: none;
-      user-select: none;
-    }
   }
 
   :where(.page-layout:not(:has(.page-layout-breadcrumb))) .page-layout-content {
@@ -171,15 +160,5 @@ const socialImg = {
     width: 100%;
     max-width: var(--size-prose);
     margin: var(--spacing-md) auto 0;
-  }
-
-  :global(:where([data-theme="light"])) .page-layout-content::before {
-    filter: url("#paper-filter") brightness(0.985) contrast(98.5%)
-      saturate(103%);
-  }
-
-  :global(:where([data-theme="dark"])) .page-layout-content::before {
-    filter: url("#dark-paper-filter") brightness(0.85) contrast(103%)
-      saturate(120%);
   }
 </style>


### PR DESCRIPTION
## Changes

When using Chrome on a mobile devices, the site was really slow to respond making a bad UX.
When using Firefox on a mobile devices, the text was disappearing while scrolling which is a bit inconvenient to see where to stop scrolling...
This PR:
* Replaces the SVG filters inlined in the HTML with SVG images in CSS.
* Adjusts the filters to make the repetition less visible.

## Tests

Manually on an Android device with Chrome and Firefox. Other tests should still pass.

## Docs

Changeset added.