### PR TITLE
fix: remote images in dev and tests

### DIFF
--- a/.changeset/pretty-suns-flash.md
+++ b/.changeset/pretty-suns-flash.md
@@ -1,0 +1,5 @@
+---
+"apeu": patch
+---
+
+Allows remote placeholder images in dev and tests.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -106,6 +106,7 @@ export default defineConfig({
     locales: [...CONFIG.LANGUAGES.AVAILABLE],
   },
   image: {
+    domains: import.meta.env.DEV ? ["placehold.co"] : [],
     layout: "constrained",
     objectFit: "cover",
     objectPosition: "top",

--- a/src/components/atoms/img/img.test.ts
+++ b/src/components/atoms/img/img.test.ts
@@ -6,6 +6,9 @@ type LocalTestContext = {
   container: AstroContainer;
 };
 
+const getAstroImagePrefix = (src: string) =>
+  `/_image?href=${encodeURIComponent(src)}`;
+
 describe("Img", () => {
   beforeEach<LocalTestContext>(async (context) => {
     context.container = await AstroContainer.create();
@@ -17,13 +20,14 @@ describe("Img", () => {
 
     const alt = "voluptas repellendus nobis";
     const src = "https://placehold.co/600x400";
+    const optimizedSrc = getAstroImagePrefix(src);
     const result = await container.renderToString(Img, {
       props: { alt, height: 480, src, width: 640 },
     });
 
     expect(result).toContain("<img");
     expect(result).toContain(`alt="${alt}"`);
-    expect(result).toContain(`src="${src}"`);
+    expect(result).toContain(`src="${optimizedSrc}`);
   });
 
   it<LocalTestContext>("can wrap an image with a link", async ({
@@ -34,14 +38,15 @@ describe("Img", () => {
 
     const alt = "voluptas repellendus nobis";
     const src = "https://placehold.co/600x400";
+    const optimizedSrc = getAstroImagePrefix(src);
     const result = await container.renderToString(Img, {
       props: { "data-clickable": "true", alt, height: 480, src, width: 640 },
     });
 
     expect(result).toContain("<a");
-    expect(result).toContain(`href="${src}"`);
+    expect(result).toContain(`href="${optimizedSrc}`);
     expect(result).toContain("<img");
     expect(result).toContain(`alt="${alt}"`);
-    expect(result).toContain(`src="${src}"`);
+    expect(result).toContain(`src="${optimizedSrc}`);
   });
 });

--- a/src/components/organisms/content-page/content-page.test.ts
+++ b/src/components/organisms/content-page/content-page.test.ts
@@ -7,6 +7,9 @@ type LocalTestContext = {
   container: AstroContainer;
 };
 
+const getAstroImagePrefix = (src: string) =>
+  `/_image?href=${encodeURIComponent(src)}`;
+
 describe("ContentPage", () => {
   beforeEach<LocalTestContext>(async (context) => {
     context.container = await AstroContainer.create();
@@ -44,7 +47,7 @@ describe("ContentPage", () => {
       props,
     });
 
-    expect(result).toContain(props.cover.src);
+    expect(result).toContain(getAstroImagePrefix(props.cover.src));
   });
 
   it<LocalTestContext>("can render the page meta", async ({ container }) => {


### PR DESCRIPTION
## Changes

Since Astro 6, remote images must opt-in to image optimization. The placeholders image used in dev were throwing. But using `image.domains`, remote images now use the Astro image endpoint and some tests were failing so I had to fix them.

This is not ideal, I'll need to revisit my images handling logic in a future PR.

## Tests

Fixes some test, everything should pass now.

## Docs

Changeset added.