### PR TITLE
fix: always assign a default value as minimal card size

### DIFF
--- a/.changeset/short-areas-sink.md
+++ b/.changeset/short-areas-sink.md
@@ -4,4 +4,15 @@
 
 Adds support for setting card sizes at content level.
 
-Previously, the minimal card size used on index pages could have two fixed value: either `30em` or `22em`. Now, the size can be defined per content in the frontmatter of index pages using `minCardSize`.
+Previously, the minimal card size used on index pages could have two fixed value: either `30em` or `22em`. Now, the size can be defined per content in the frontmatter of index pages using `minCardSize` and the default value is always `30em`.
+
+If some of your content relied on the previous behavior, you can set `minCardSize` to `22em` in the frontmatter to keep the same card size as before.
+
+```diff
+---
+title: Tags
+description: "This is an excerpt of tags index page."
+publishedOn: "2024-11-11T17:40"
++minCardSize: "22em"
+---
+```

--- a/src/views/collection-listing-view/collection-listing-view.astro
+++ b/src/views/collection-listing-view/collection-listing-view.astro
@@ -72,7 +72,9 @@ const entries = await Promise.all(
     entries={entries}
     pagination={pagination}
     route={page.route}
-    sizeMinCols={page.collection === "index.pages" ? page.minCardSize : null}
+    sizeMinCols={page.collection === "index.pages"
+      ? page.minCardSize
+      : undefined}
     title={page.title}
     totalEntries={collectionMetaTotal}
   >


### PR DESCRIPTION
## Changes

Fixes a bug introduced in #234 where `null` prevented the default value from being applied.

## Tests

No changes, everything should pass.

## Docs

N/A, not yet released but I reworded the previous changeset to highlight an update might be required.