### PR TITLE
refactor: prevent image double processing in Img component

### DIFF
--- a/.changeset/brave-eels-jump.md
+++ b/.changeset/brave-eels-jump.md
@@ -1,0 +1,7 @@
+---
+"apeu": patch
+---
+
+Processes SVG source images through the image pipeline in dev.
+
+Fixing the double image processing in `Img.astro` surfaced an issue with SVG images that was previously swallowed silently. SVGs are now processed by Astro's image pipeline in dev through `image.dangerouslyProcessSVG`. This only applies in development. Production builds are unaffected as this can be a security risk.

--- a/.changeset/quiet-plums-invite.md
+++ b/.changeset/quiet-plums-invite.md
@@ -1,0 +1,5 @@
+---
+"apeu": patch
+---
+
+Fixes double image processing in `Img.astro`.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -16,6 +16,7 @@ import { mdastWordsCount } from "./src/lib/satteri/mdast/mdast-words-count";
 import { shikiTheme } from "./src/lib/shiki/theme";
 import { CONFIG } from "./src/utils/constants";
 
+const dangerouslyProcessSVG = import.meta.env.DEV;
 const imageDomains = import.meta.env.DEV ? ["placehold.co"] : [];
 
 // https://astro.build/config
@@ -111,6 +112,7 @@ export default defineConfig({
     objectFit: "cover",
     objectPosition: "top",
     responsiveStyles: true,
+    dangerouslyProcessSVG,
   },
   integrations: [
     astroStories({

--- a/src/components/atoms/img/img.astro
+++ b/src/components/atoms/img/img.astro
@@ -1,28 +1,15 @@
 ---
 import type { ComponentProps } from "astro/types";
-import { Picture as AstroPicture, getImage } from "astro:assets";
+import { Picture as AstroPicture } from "astro:assets";
+import { getImgSrc } from "../../../utils/images";
 import Link from "../link/link.astro";
 
-/* Without Pick, Typescript gives me an error when using the component. Not
- * sure which property is conflicting with exactOptionalPropertyTypes... */
-type PictureProps = Pick<
+/* `width`/`height` are excluded and redeclared below as plain numbers: Astro
+ * types them as `number | \`${number}\`` for HTML-attribute compatibility,
+ * which conflicts with exactOptionalPropertyTypes here. */
+type PictureProps = Omit<
   ComponentProps<typeof AstroPicture>,
-  | "alt"
-  | "class"
-  | "class:list"
-  | "decoding"
-  | "densities"
-  | "fit"
-  | "format"
-  | "formats"
-  | "layout"
-  | "loading"
-  | "pictureAttributes"
-  | "position"
-  | "quality"
-  | "src"
-  | "style"
-  | "widths"
+  "height" | "width"
 >;
 
 type Props = PictureProps & {
@@ -30,41 +17,24 @@ type Props = PictureProps & {
    * Should only be used with Remark/Rehype. It is an internal helper to wrap
    * images with a link pointing to the same file.
    *
-   * @see src/lib/rehype/rehype-images.ts
+   * @see src/lib/satteri/hast/hast-linked-images.ts
    */
   "data-clickable"?: `${boolean}` | null | undefined;
   height?: number | undefined;
-  inferSize?: boolean | null | undefined;
+  inferSize?: `${boolean}` | boolean | null | undefined;
   width?: number | undefined;
 };
 
 const {
   alt,
   "data-clickable": isClickable,
-  densities,
-  format,
   formats = ["avif", "webp"],
-  height,
-  inferSize,
   pictureAttributes,
-  quality,
   src,
-  width,
-  widths,
   ...attrs
 } = Astro.props;
 
-const img = await getImage({
-  densities,
-  format,
-  height,
-  ...(inferSize ? { inferSize } : {}),
-  quality,
-  src,
-  width,
-  widths,
-});
-const mergedAttrs = { ...img.attributes, ...attrs };
+const href = await getImgSrc({ src });
 const Wrapper = isClickable ? Link : Fragment;
 /* With `class:list` it seems the `picture` class is overridden... */
 const pictureClass = pictureAttributes?.class
@@ -72,17 +42,17 @@ const pictureClass = pictureAttributes?.class
   : "picture";
 ---
 
-<Wrapper href={img.src}>
-  {/* @ts-expect-error ts(2375) -- Not sure where the conflict comes from... */}
+<Wrapper href={href}>
+  {/* @ts-expect-error ts(2375) -- width/height type conflict */}
   <AstroPicture
-    {...mergedAttrs}
+    {...attrs}
     alt={alt}
     formats={formats}
     pictureAttributes={{
       ...pictureAttributes,
       class: pictureClass,
     }}
-    src={img.src}
+    src={src}
   />
 </Wrapper>
 

--- a/src/components/atoms/img/img.test.ts
+++ b/src/components/atoms/img/img.test.ts
@@ -1,5 +1,6 @@
 import { experimental_AstroContainer as AstroContainer } from "astro/container";
 import { beforeEach, describe, expect, it } from "vitest";
+import favicon from "../../../assets/favicon.png";
 import Img from "./img.astro";
 
 type LocalTestContext = {
@@ -30,7 +31,7 @@ describe("Img", () => {
     expect(result).toContain(`src="${optimizedSrc}`);
   });
 
-  it<LocalTestContext>("can wrap an image with a link", async ({
+  it<LocalTestContext>("wraps a remote image with a link to the original source", async ({
     container,
   }) => {
     /* eslint-disable-next-line @typescript-eslint/no-magic-numbers -- Self-explanatory. */
@@ -44,9 +45,25 @@ describe("Img", () => {
     });
 
     expect(result).toContain("<a");
-    expect(result).toContain(`href="${optimizedSrc}`);
+    expect(result).toContain(`href="${src}"`);
     expect(result).toContain("<img");
     expect(result).toContain(`alt="${alt}"`);
     expect(result).toContain(`src="${optimizedSrc}`);
+  });
+
+  it<LocalTestContext>("wraps a local image with a link to the original, unoptimized source", async ({
+    container,
+  }) => {
+    /* eslint-disable-next-line @typescript-eslint/no-magic-numbers -- Self-explanatory. */
+    expect.assertions(2);
+
+    const alt = "voluptas repellendus nobis";
+    const result = await container.renderToString(Img, {
+      props: { "data-clickable": "true", alt, src: favicon },
+    });
+    const expectedHref = favicon.src.replaceAll("&", "&amp;");
+
+    expect(result).toContain("<a");
+    expect(result).toContain(`href="${expectedHref}"`);
   });
 });


### PR DESCRIPTION
## Changes

* Removes redundant call to `getImage()` in `Img.astro`
* Enables `dangerouslyProcessSVG` in dev mode to be able to use SVG as image fixtures

## Tests

Everything should be green. `img.test.astro` has been updated.

## Docs

Changesets added.