### PR TITLE
fix: `<title>` incorrectly suffixed on some pages

### DIFF
--- a/.changeset/giant-eyes-count.md
+++ b/.changeset/giant-eyes-count.md
@@ -1,0 +1,7 @@
+---
+"apeu": patch
+---
+
+Fixes an issue where the title tag suffix wasn't correctly applied.
+
+The English homepage unexpectedly showing the site name suffix in its title, and stories were missing the suffix in their title tags. The homepage is now flagged explicitly by the view that renders it, instead of being inferred from a URL comparison.

--- a/src/components/templates/layout/layout.astro
+++ b/src/components/templates/layout/layout.astro
@@ -24,6 +24,12 @@ import Head from "./head.astro";
 type Props = Omit<HTMLAttributes<"main">, "id"> & {
   breadcrumb?: ComponentProps<typeof Breadcrumb>["items"] | null | undefined;
   graphs?: Graph["@graph"] | null | undefined;
+  /**
+   * Whether this page is the homepage.
+   *
+   * @default false
+   */
+  isHome?: boolean | undefined;
   pageTitle: string;
   seo: SEO;
 };
@@ -32,6 +38,7 @@ const {
   breadcrumb,
   class: className,
   graphs,
+  isHome = false,
   pageTitle,
   seo,
   ...attrs
@@ -90,7 +97,6 @@ const footerRoutes = [
   ...(import.meta.env.DEV ? devOnlyRoutes : []),
 ];
 
-const isHome = Astro.url.pathname === pagesRoutes.home.path;
 const contentsId = translate("anchor.site.content");
 const topId = translate("anchor.site.top");
 ---

--- a/src/components/templates/story-layout/story-layout.test.ts
+++ b/src/components/templates/story-layout/story-layout.test.ts
@@ -135,7 +135,9 @@ describe("StoryLayout", () => {
       slots: { default: children },
     });
 
-    expect(result).toContain("<title>My SEO title for this story</title>");
+    expect(result).toContain(
+      "<title>My SEO title for this story | Armand Philippot</title>"
+    );
     expect(result).not.toContain("First story");
     expect(result).toContain(children);
   });

--- a/src/views/homepage-view/homepage-view.astro
+++ b/src/views/homepage-view/homepage-view.astro
@@ -75,6 +75,7 @@ const { entries: collections } = await queryCollection(
 <Layout
   class="homepage"
   graphs={graphs}
+  isHome
   pageTitle={page.title}
   seo={page.seo}
   {...props}

--- a/tests/e2e/home.test.ts
+++ b/tests/e2e/home.test.ts
@@ -57,10 +57,7 @@ test.describe("Homepage", () => {
   }) => {
     await page.goto("/en/");
 
-    /* TODO: Unlike the default locale, the English homepage currently renders
-     * with the site-name suffix (isHome mismatch in layout.astro)
-     */
-    await expect(page).toHaveTitle("Home | Armand Philippot");
+    await expect(page).toHaveTitle("Home");
     await expect(page.getByRole("heading", { level: 1 })).toHaveText(
       "Armand Philippot."
     );


### PR DESCRIPTION
## Changes

The English homepage rendered with the site-name suffix, and stories weren't correctly suffixed. This update the `isHome` logic by passing a prop from the view to the layout instead of inferring it from the path.

## Tests

Updated some tests that were wrong, everything should be green.

## Docs

Changeset added.