### PR TITLE
feat: trailing slash normalization

### DIFF
--- a/.changeset/major-brooms-know.md
+++ b/.changeset/major-brooms-know.md
@@ -1,0 +1,11 @@
+---
+"apeu": minor
+---
+
+Enforces trailing slash on routes.
+
+Previously, trailing slashes were not enforced. This meant that routes could be accessed with or without a trailing slash. This change enforces trailing slashes on all routes (except file endpoints such as `feed.xml`), which can help with SEO and consistency.
+
+However, due to a bug in Astro, `trailingSlash` cannot be set to `always`. This means that while the intention is to have trailing slashes for all routes, it may not be fully enforced until the bug is resolved.
+
+If you have links pointing to routes without trailing slashes, you may need to update them to include the trailing slash or set up redirects at the hosting level to ensure they resolve correctly.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -151,6 +151,9 @@ export default defineConfig({
   },
   output: "static",
   site: `https://${CONFIG.HOST}`,
+  /* A bug in Astro prevents us to use this, but the aim is to have trailing
+   * slashes for all routes. */
+  //trailingSlash: "always",
   vite: {
     server: {
       watch: {

--- a/src/lib/astro/collections/indexes/entries-index.test.ts
+++ b/src/lib/astro/collections/indexes/entries-index.test.ts
@@ -121,12 +121,12 @@ describe("getEntriesIndex", () => {
 
     expect(indexedEntryById).toStrictEqual({
       raw: { ...mockEntry, id: normalizedId },
-      route: expectedRoute,
+      route: `${expectedRoute}/`,
       slug: expectedSlug,
     });
     expect(indexedEntryByRoute).toStrictEqual({
       raw: { ...mockEntry, id: normalizedId },
-      route: expectedRoute,
+      route: `${expectedRoute}/`,
       slug: expectedSlug,
     });
   });
@@ -166,7 +166,7 @@ describe("getEntriesIndex", () => {
     const indexedEntryById = result.byId.get(mockEntry.id);
 
     expect(indexedEntryById).toMatchObject({
-      route: "/blog/posts/post-1",
+      route: "/blog/posts/post-1/",
     });
   });
 
@@ -196,7 +196,7 @@ describe("getEntriesIndex", () => {
     expect(indexedEntryById.raw.data.locale).not.toBe(mockEntry.data.locale);
     expect(indexedEntryById).toMatchObject({
       raw: { ...mockEntry, data: { ...mockEntry.data, locale: "es" } },
-      route: "/es/blog/posts/post-1",
+      route: "/es/blog/posts/post-1/",
     });
   });
 
@@ -230,7 +230,7 @@ describe("getEntriesIndex", () => {
     const indexedEntryById = result.byId.get(normalizedId);
 
     expect(indexedEntryById).toMatchObject({
-      route: normalizedId.replace(/^en\//, "/"),
+      route: `${normalizedId.replace(/^en\//, "/")}/`,
       slug: normalizedId.split("/").at(-1),
     });
   });
@@ -249,7 +249,7 @@ describe("getEntriesIndex", () => {
     const indexedEntryById = result.byId.get(mockEntry.id);
 
     expect(indexedEntryById).toMatchObject({
-      route: "/blog/posts",
+      route: "/blog/posts/",
       slug: "posts",
     });
   });
@@ -363,7 +363,7 @@ describe("getEntriesIndex", () => {
 
     expect(indexedEntryById).toMatchObject({
       raw: { ...mockEntry, data: { ...mockEntry.data, locale: "fr" } },
-      route: `/${mockEntry.id.replace("blog", "journal")}`,
+      route: `/${mockEntry.id.replace("blog", "journal")}/`,
       slug: mockEntry.data.permaslug,
     });
   });

--- a/src/lib/astro/collections/indexes/entries-index.ts
+++ b/src/lib/astro/collections/indexes/entries-index.ts
@@ -148,7 +148,7 @@ const removeLeadingSlash = (path: string) => path.slice(1);
  * @param {AvailableLocale} locale - A supported entry's locale.
  * @param {string[]} segments - Path segments extracted from the entry ID.
  * @param {SlugInfoByIdMap} slugById - A map of entry IDs to slugs.
- * @returns {string} A route like `/fr/section/article`.
+ * @returns {string} A route like `/fr/section/article/`.
  */
 const buildEntryRoute = (
   locale: AvailableLocale,
@@ -166,7 +166,13 @@ const buildEntryRoute = (
     .filter((segment) => segment !== null);
   const route = `/${localizedSegments.join("/")}`;
 
-  return route === "/" ? route : removeTrailingSlashes(route);
+  /* The "home" slug resolves to an empty segment (see `getSlugFromEntry`).
+   * For the default locale that's the only segment, so `route` is already
+   * exactly "/" (handled above). For every other locale it's the *last* of
+   * several segments (e.g. ["en", ""]) so `route` already ends with a
+   * slash here (e.g. "/en/"): `removeTrailingSlashes` normalizes that back
+   * to zero before appending exactly one, instead of ending up with two. */
+  return route === "/" ? route : `${removeTrailingSlashes(route)}/`;
 };
 
 type RouteInfo = {
@@ -351,7 +357,14 @@ const buildEntriesIndexes = async (): Promise<EntriesIndexes> => {
     [...nonRoutable, ...routable],
     (entry) => entry.raw.id
   );
-  const entryByRoute = buildEntryIndex(routable, (entry) => entry.route);
+  /* Keyed without the trailing slash: `breadcrumb.ts` looks up ancestor
+   * routes by splitting/rejoining path segments, which can never reproduce
+   * one, so the lookup key must stay slash-free even though `entry.route`
+   * (the value) now always has one. */
+  const entryByRoute = buildEntryIndex(
+    routable,
+    (entry) => removeTrailingSlashes(entry.route) || "/"
+  );
 
   return {
     byId: entryById,

--- a/src/lib/astro/collections/indexes/entries-index.ts
+++ b/src/lib/astro/collections/indexes/entries-index.ts
@@ -166,12 +166,11 @@ const buildEntryRoute = (
     .filter((segment) => segment !== null);
   const route = `/${localizedSegments.join("/")}`;
 
-  /* The "home" slug resolves to an empty segment (see `getSlugFromEntry`).
-   * For the default locale that's the only segment, so `route` is already
-   * exactly "/" (handled above). For every other locale it's the *last* of
-   * several segments (e.g. ["en", ""]) so `route` already ends with a
-   * slash here (e.g. "/en/"): `removeTrailingSlashes` normalizes that back
-   * to zero before appending exactly one, instead of ending up with two. */
+  /* The "home" slug resolves to an empty segment. For the default locale
+   * that's the only segment and `route` is already exactly "/". For every
+   * other locale it's the last of several segments (e.g. ["en", ""]) so
+   * `route` already ends with a slash here (e.g. "/en/"). We normalize that
+   * back to zero before appending exactly one, instead of ending up with two. */
   return route === "/" ? route : `${removeTrailingSlashes(route)}/`;
 };
 
@@ -357,10 +356,6 @@ const buildEntriesIndexes = async (): Promise<EntriesIndexes> => {
     [...nonRoutable, ...routable],
     (entry) => entry.raw.id
   );
-  /* Keyed without the trailing slash: `breadcrumb.ts` looks up ancestor
-   * routes by splitting/rejoining path segments, which can never reproduce
-   * one, so the lookup key must stay slash-free even though `entry.route`
-   * (the value) now always has one. */
   const entryByRoute = buildEntryIndex(
     routable,
     (entry) => removeTrailingSlashes(entry.route) || "/"

--- a/src/lib/schema-dts/graphs/article-graph.test.ts
+++ b/src/lib/schema-dts/graphs/article-graph.test.ts
@@ -286,7 +286,7 @@ describe("getArticleGraph", () => {
 
       expect(graph["@type"]).toBe("BlogPosting");
       expect(graph.isPartOf).toStrictEqual({
-        "@id": "https://example.test/blog#blog",
+        "@id": "https://example.test/blog/#blog",
       });
       expect(graph.author).toHaveLength(1);
     });

--- a/src/lib/schema-dts/graphs/article-graph.ts
+++ b/src/lib/schema-dts/graphs/article-graph.ts
@@ -42,7 +42,7 @@ export const getArticleGraph = async ({
   const { translate } = useI18n(locale);
   const { routeById } = await useRouting(locale);
   const websiteAuthor = `${WEBSITE_URL}#author` as const;
-  const url = `${WEBSITE_URL}${articleRoute}`;
+  const url = new URL(articleRoute, WEBSITE_URL).href;
   const coverUrl = isNullish(cover) ? null : await getImgSrc(cover);
   const isBlogPost = collection === "blog.posts";
   const authors =
@@ -74,7 +74,7 @@ export const getArticleGraph = async ({
     isAccessibleForFree: true,
     ...(isBlogPost && {
       isPartOf: {
-        "@id": `${WEBSITE_URL}${routeById("blog").path}#blog`,
+        "@id": `${new URL(routeById("blog").path, WEBSITE_URL).href}#blog`,
       },
     }),
     ...(meta.tags !== null &&

--- a/src/lib/schema-dts/graphs/blog-graph.test.ts
+++ b/src/lib/schema-dts/graphs/blog-graph.test.ts
@@ -59,7 +59,7 @@ describe("get-blog-graph", () => {
 
     expect(graph).toMatchInlineSnapshot(`
       {
-        "@id": "https://example.test/blog#blog",
+        "@id": "https://example.test/blog/#blog",
         "@type": "Blog",
         "author": {
           "@id": "https://example.test#author",
@@ -80,12 +80,12 @@ describe("get-blog-graph", () => {
           "@id": "https://example.test/",
         },
         "license": "https://creativecommons.org/licenses/by-sa/4.0/deed",
-        "mainEntityOfPage": "https://example.test/blog",
+        "mainEntityOfPage": "https://example.test/blog/",
         "name": "beatae autem in",
         "publisher": {
           "@id": "https://example.test#author",
         },
-        "url": "https://example.test/blog",
+        "url": "https://example.test/blog/",
       }
     `);
   });
@@ -111,7 +111,7 @@ describe("get-blog-graph", () => {
 
     expect(graph).toMatchInlineSnapshot(`
       {
-        "@id": "https://example.test/blog#blog",
+        "@id": "https://example.test/blog/#blog",
         "@type": "Blog",
         "author": {
           "@id": "https://example.test#author",
@@ -132,13 +132,13 @@ describe("get-blog-graph", () => {
           "@id": "https://example.test/",
         },
         "license": "https://creativecommons.org/licenses/by-sa/4.0/deed",
-        "mainEntityOfPage": "https://example.test/blog",
+        "mainEntityOfPage": "https://example.test/blog/",
         "name": "beatae autem in",
         "publisher": {
           "@id": "https://example.test#author",
         },
         "thumbnailUrl": "https://placehold.co/600x400",
-        "url": "https://example.test/blog",
+        "url": "https://example.test/blog/",
       }
     `);
   });

--- a/src/lib/schema-dts/graphs/blog-graph.ts
+++ b/src/lib/schema-dts/graphs/blog-graph.ts
@@ -26,7 +26,7 @@ export const getBlogGraph = async ({
   const { translate } = useI18n(locale);
   const { routeById } = await useRouting(locale);
   const websiteAuthor = `${WEBSITE_URL}#author` as const;
-  const blogUrl = `${WEBSITE_URL}${routeById("blog").path}`;
+  const blogUrl = new URL(routeById("blog").path, WEBSITE_URL).href;
 
   return {
     "@id": `${blogUrl}#blog`,
@@ -40,7 +40,7 @@ export const getBlogGraph = async ({
     editor: { "@id": websiteAuthor },
     headline: title,
     isAccessibleForFree: true,
-    isPartOf: { "@id": `${WEBSITE_URL}${routeById("home").path}` },
+    isPartOf: { "@id": new URL(routeById("home").path, WEBSITE_URL).href },
     license: translate("license.url"),
     mainEntityOfPage: blogUrl,
     name: title,

--- a/src/lib/schema-dts/graphs/webpage-graph.ts
+++ b/src/lib/schema-dts/graphs/webpage-graph.ts
@@ -34,7 +34,7 @@ export const getWebPageGraph = async ({
   const { translate } = useI18n(locale);
   const { routeById } = await useRouting(locale);
   const websiteAuthor = `${WEBSITE_URL}#author` as const;
-  const url = `${WEBSITE_URL}${pageRoute}`;
+  const url = new URL(pageRoute, WEBSITE_URL).href;
 
   return {
     "@id": url,
@@ -52,7 +52,7 @@ export const getWebPageGraph = async ({
     editor: { "@id": websiteAuthor },
     headline: title,
     isAccessibleForFree: true,
-    isPartOf: { "@id": `${WEBSITE_URL}${routeById("home").path}` },
+    isPartOf: { "@id": new URL(routeById("home").path, WEBSITE_URL).href },
     lastReviewed: meta.updatedOn.toISOString(),
     license: translate("license.url"),
     name: title,

--- a/src/lib/schema-dts/graphs/website-graph.test.ts
+++ b/src/lib/schema-dts/graphs/website-graph.test.ts
@@ -84,7 +84,7 @@ describe("get-website-graph", () => {
           "@type": "SearchAction",
           "query": "required",
           "query-input": "required name=query",
-          "target": "https://example.test/search?q={query}",
+          "target": "https://example.test/search/?q={query}",
         },
         "publisher": {
           "@id": "https://example.test#author",

--- a/src/lib/schema-dts/graphs/website-graph.ts
+++ b/src/lib/schema-dts/graphs/website-graph.ts
@@ -34,12 +34,13 @@ export const getWebSiteGraph = async ({
     "@type": "SearchAction",
     query: "required",
     "query-input": "required name=query",
-    target: `${WEBSITE_URL}${routeById("search").path}?${CONFIG.SEARCH.QUERY_PARAM}={query}`,
+    target: `${new URL(routeById("search").path, WEBSITE_URL).href}?${CONFIG.SEARCH.QUERY_PARAM}={query}`,
   };
+  const homeUrl = new URL(routeById("home").path, WEBSITE_URL).href;
 
   return {
     "@type": "WebSite",
-    "@id": `${WEBSITE_URL}${routeById("home").path}`,
+    "@id": homeUrl,
     author: { "@id": websiteAuthor },
     copyrightHolder: { "@id": websiteAuthor },
     copyrightYear: CONFIG.CREATION_YEAR,
@@ -54,6 +55,6 @@ export const getWebSiteGraph = async ({
     potentialAction: searchAction,
     publisher: { "@id": websiteAuthor },
     thumbnailUrl: logo,
-    url: `${WEBSITE_URL}${routeById("home").path}`,
+    url: homeUrl,
   };
 };

--- a/src/pages/[...page]/feed.xml.ts
+++ b/src/pages/[...page]/feed.xml.ts
@@ -15,6 +15,7 @@ import {
 import { useI18n } from "../../services/i18n";
 import { CONFIG } from "../../utils/constants";
 import { MissingSiteConfigError } from "../../utils/exceptions";
+import { removeTrailingSlashes } from "../../utils/strings";
 
 export const getStaticPaths = (async () => {
   const { entries } = await queryCollection(
@@ -33,7 +34,14 @@ export const getStaticPaths = (async () => {
     const isDefaultLocale = CONFIG.LANGUAGES.DEFAULT === entry.locale;
     return {
       params: {
-        page: isHomepage && isDefaultLocale ? undefined : entry.route.slice(1),
+        /* The "page" rest-param is an internal detail of how this file
+         * generates static paths, decoupled from the public route string,
+         * which now always ends with a slash — double-slashes (and fails
+         * to build) if not normalized back to a slash-free form first. */
+        page:
+          isHomepage && isDefaultLocale
+            ? undefined
+            : removeTrailingSlashes(entry.route).slice(1),
       },
       props: entry,
     };

--- a/src/pages/[...page]/feed.xml.ts
+++ b/src/pages/[...page]/feed.xml.ts
@@ -34,10 +34,6 @@ export const getStaticPaths = (async () => {
     const isDefaultLocale = CONFIG.LANGUAGES.DEFAULT === entry.locale;
     return {
       params: {
-        /* The "page" rest-param is an internal detail of how this file
-         * generates static paths, decoupled from the public route string,
-         * which now always ends with a slash — double-slashes (and fails
-         * to build) if not normalized back to a slash-free form first. */
         page:
           isHomepage && isDefaultLocale
             ? undefined

--- a/src/pages/[...page]/index.astro
+++ b/src/pages/[...page]/index.astro
@@ -44,11 +44,9 @@ export const getStaticPaths = (async ({ paginate }) => {
     nonPaginatedListingPages,
     { format: "preview" }
   );
-  /* `route` now always ends with a trailing slash (except the literal "/"),
-   * but the `page` rest-param is an internal detail of how this file
-   * generates static paths, decoupled from that public route string —
-   * left as-is it double-slashes (and fails to build), so it's normalized
-   * back to a slash-free form before use everywhere below. */
+  /* `route` always ends with a trailing slash (except the literal "/"), but
+   * the `page` rest-param determines how this file generates static paths, so
+   * it's normalized back to a slash-free form before use. */
   const paginatedPaths = enrichedPaginatedListings.flatMap(
     (enrichedPaginatedPage) => {
       const route = removeTrailingSlashes(enrichedPaginatedPage.route);

--- a/src/pages/[...page]/index.astro
+++ b/src/pages/[...page]/index.astro
@@ -11,6 +11,7 @@ import {
 } from "../../services/collections";
 import { partitionByType } from "../../utils/arrays";
 import { CONFIG } from "../../utils/constants";
+import { removeTrailingSlashes } from "../../utils/strings";
 import BlogIndexView from "../../views/blog-index-view/blog-index-view.astro";
 import CollectionListingView from "../../views/collection-listing-view/collection-listing-view.astro";
 import ContactView from "../../views/contact-view/contact-view.astro";
@@ -43,17 +44,24 @@ export const getStaticPaths = (async ({ paginate }) => {
     nonPaginatedListingPages,
     { format: "preview" }
   );
+  /* `route` now always ends with a trailing slash (except the literal "/"),
+   * but the `page` rest-param is an internal detail of how this file
+   * generates static paths, decoupled from that public route string —
+   * left as-is it double-slashes (and fails to build), so it's normalized
+   * back to a slash-free form before use everywhere below. */
   const paginatedPaths = enrichedPaginatedListings.flatMap(
-    (enrichedPaginatedPage) =>
-      paginate(enrichedPaginatedPage.related.entries, {
+    (enrichedPaginatedPage) => {
+      const route = removeTrailingSlashes(enrichedPaginatedPage.route);
+
+      return paginate(enrichedPaginatedPage.related.entries, {
         pageSize: CONFIG.ITEMS_PER_PAGE,
       }).map((paginatedItem) => {
         const { data, url, ...paginationData } = paginatedItem.props.page;
         return {
           params: {
             page: paginatedItem.params.page
-              ? `${enrichedPaginatedPage.route}/page/${paginatedItem.params.page}`
-              : enrichedPaginatedPage.route,
+              ? `${route}/page/${paginatedItem.params.page}`
+              : route,
           },
           props: {
             ...enrichedPaginatedPage,
@@ -64,13 +72,14 @@ export const getStaticPaths = (async ({ paginate }) => {
             },
           },
         };
-      })
+      });
+    }
   );
   const nonPaginatedListingPaths = enrichedNonPaginatedListings.map(
     (listingPage) => {
       return {
         params: {
-          page: listingPage.route.slice(1),
+          page: removeTrailingSlashes(listingPage.route).slice(1),
         },
         props: listingPage,
       };
@@ -83,7 +92,9 @@ export const getStaticPaths = (async ({ paginate }) => {
 
     return {
       params: {
-        page: isDefaultLocaleHome ? undefined : regularPage.route.slice(1),
+        page: isDefaultLocaleHome
+          ? undefined
+          : removeTrailingSlashes(regularPage.route).slice(1),
       },
       props: regularPage,
     };

--- a/src/pages/og/[...slug].ts
+++ b/src/pages/og/[...slug].ts
@@ -8,6 +8,7 @@ import logo from "../../assets/logo-unpressed.svg?url";
 import bg from "../../assets/paper-light.svg?inline";
 import { queryCollection } from "../../services/collections";
 import { CONFIG } from "../../utils/constants";
+import { removeTrailingSlashes } from "../../utils/strings";
 
 const collections = await queryCollection([
   "blog.categories",
@@ -21,21 +22,21 @@ const collections = await queryCollection([
 ]);
 const addPngExtension = (path: string) => `${path}.png`;
 const getPageIdFromRoute = (route: string) => {
-  const routeWithoutLeadingSlash = route.slice(1);
-  const isDefaultHomePage = !routeWithoutLeadingSlash;
+  /* `route` always ends with a trailing slash (except the literal "/"), so
+   * both slashes are stripped here to get a bare id like "" or "en" or
+   * "en/blog" — this also makes the locale-home check below reliable, since
+   * `CONFIG.LANGUAGES.AVAILABLE` entries never have a trailing slash. */
+  const routeId = removeTrailingSlashes(route).slice(1);
+  const isDefaultHomePage = !routeId;
   const isLocalizedHomePage = (
     CONFIG.LANGUAGES.AVAILABLE as readonly string[]
-  ).includes(routeWithoutLeadingSlash);
+  ).includes(routeId);
   const homeId = "home";
 
   if (isDefaultHomePage) return homeId;
-  if (isLocalizedHomePage) return `${routeWithoutLeadingSlash}/${homeId}`;
+  if (isLocalizedHomePage) return `${routeId}/${homeId}`;
 
-  const isOtherLocaleHomePage = routeWithoutLeadingSlash.endsWith("/");
-
-  if (isOtherLocaleHomePage) return `${routeWithoutLeadingSlash}${homeId}`;
-
-  return routeWithoutLeadingSlash;
+  return routeId;
 };
 const individualPages = collections.entries.map(
   ({ description, id, route, seo, title }) => {

--- a/src/services/breadcrumb/breadcrumb.test.ts
+++ b/src/services/breadcrumb/breadcrumb.test.ts
@@ -102,9 +102,9 @@ describe("getBreadcrumb", () => {
     const result = await getBreadcrumb({ route: "/fr/blog/article" });
 
     expect(result).toStrictEqual([
-      { label: "Accueil", path: "/fr" },
-      { label: "Blog", path: "/fr/blog" },
-      { label: "Article", path: "/fr/blog/article" },
+      { label: "Accueil", path: "/fr/" },
+      { label: "Blog", path: "/fr/blog/" },
+      { label: "Article", path: "/fr/blog/article/" },
     ]);
   });
 
@@ -115,7 +115,7 @@ describe("getBreadcrumb", () => {
 
     expect(result).toStrictEqual([
       { label: "Home", path: "/" },
-      { label: "About", path: "/about" },
+      { label: "About", path: "/about/" },
     ]);
   });
 
@@ -142,8 +142,8 @@ describe("getBreadcrumb", () => {
 
     expect(result).toStrictEqual([
       { label: "Home", path: "/" },
-      { label: "Blog", path: "/blog" },
-      { label: "Post", path: "/blog/post" },
+      { label: "Blog", path: "/blog/" },
+      { label: "Post", path: "/blog/post/" },
       { label: "Page 2", path: "/blog/post" },
     ]);
   });

--- a/src/services/feeds/collections-feeds.ts
+++ b/src/services/feeds/collections-feeds.ts
@@ -1,5 +1,6 @@
 import type { Route } from "../../types/data";
 import type { AvailableLocale } from "../../types/tokens";
+import { joinPaths } from "../../utils/paths";
 import { queryCollection } from "../collections";
 import { useI18n } from "../i18n";
 
@@ -44,7 +45,7 @@ export const getCollectionsFeeds = async (
   return entriesWithFeed.map((entry) => {
     return {
       label: translate("feed.link.title", { title: entry.title }),
-      path: `${entry.route}/feed.xml`,
+      path: joinPaths(entry.route, "feed.xml"),
     };
   });
 };

--- a/src/services/routing/use-routing.test.ts
+++ b/src/services/routing/use-routing.test.ts
@@ -61,7 +61,7 @@ describe("use-routing", () => {
 
     expect(routeById("note1")).toStrictEqual({
       label: "Note 1",
-      path: "/note1",
+      path: "/note1/",
     });
   });
 
@@ -72,7 +72,7 @@ describe("use-routing", () => {
 
     expect(routeById("project1", "fr")).toStrictEqual({
       label: "Projet 1",
-      path: "/fr/projet1",
+      path: "/fr/projet1/",
     });
   });
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,5 +1,5 @@
 export const API_ROUTES = {
-  SEND_EMAIL: "/api/send-email",
+  SEND_EMAIL: "/api/send-email/",
 } as const;
 
 export const CALLOUT_TYPES = [

--- a/tests/e2e/blog-post.test.ts
+++ b/tests/e2e/blog-post.test.ts
@@ -5,7 +5,7 @@ import fr from "../../src/translations/fr.json" with { type: "json" };
 // cSpell:ignore Catégorie matières
 test.describe("Single blog post", () => {
   test("renders the French blog post with its content", async ({ page }) => {
-    await page.goto("/blog/articles/post1");
+    await page.goto("/blog/articles/post1/");
 
     const main = page.getByRole("main");
 
@@ -30,18 +30,18 @@ test.describe("Single blog post", () => {
   test("navigates to its category page when clicking the category link (French)", async ({
     page,
   }) => {
-    await page.goto("/blog/articles/post1");
+    await page.goto("/blog/articles/post1/");
 
     await page
       .getByRole("main")
       .getByRole("link", { name: "Catégorie 1" })
       .click();
 
-    await expect(page).toHaveURL("/blog/categories/category1");
+    await expect(page).toHaveURL("/blog/categories/category1/");
   });
 
   test("renders the English blog post with its content", async ({ page }) => {
-    await page.goto("/en/blog/posts/post1");
+    await page.goto("/en/blog/posts/post1/");
 
     const main = page.getByRole("main");
 
@@ -64,13 +64,13 @@ test.describe("Single blog post", () => {
   test("navigates to its category page when clicking the category link (English)", async ({
     page,
   }) => {
-    await page.goto("/en/blog/posts/post1");
+    await page.goto("/en/blog/posts/post1/");
 
     await page
       .getByRole("main")
       .getByRole("link", { name: "Category 1" })
       .click();
 
-    await expect(page).toHaveURL("/en/blog/categories/category1");
+    await expect(page).toHaveURL("/en/blog/categories/category1/");
   });
 });

--- a/tests/e2e/contact-form.test.ts
+++ b/tests/e2e/contact-form.test.ts
@@ -48,7 +48,7 @@ test("submitting the contact form delivers the message through the real API and 
   const email = "e2e-tester@example.test";
   const message = `Hello from the contact form E2E test (${nonce}).`;
 
-  await page.goto("/en/contact");
+  await page.goto("/en/contact/");
 
   await page.getByLabel("Name").fill("E2E Tester");
   await page.getByLabel("Email").fill(email);

--- a/tests/e2e/feeds.test.ts
+++ b/tests/e2e/feeds.test.ts
@@ -10,7 +10,7 @@ test.describe("Feeds", () => {
   test("renders the French feeds page with its feed links", async ({
     page,
   }) => {
-    await page.goto("/flux");
+    await page.goto("/flux/");
 
     const main = page.getByRole("main");
 
@@ -34,7 +34,7 @@ test.describe("Feeds", () => {
   test("renders the English feeds page with its feed links", async ({
     page,
   }) => {
-    await page.goto("/en/feeds");
+    await page.goto("/en/feeds/");
 
     const main = page.getByRole("main");
 

--- a/tests/e2e/home.test.ts
+++ b/tests/e2e/home.test.ts
@@ -49,7 +49,7 @@ test.describe("Homepage", () => {
       .getByRole("link", { name: "Blog", exact: true })
       .click();
 
-    await expect(page).toHaveURL("/blog");
+    await expect(page).toHaveURL("/blog/");
   });
 
   test("renders the English homepage with its main sections", async ({
@@ -94,6 +94,6 @@ test.describe("Homepage", () => {
       .getByRole("link", { name: "Blog", exact: true })
       .click();
 
-    await expect(page).toHaveURL("/en/blog");
+    await expect(page).toHaveURL("/en/blog/");
   });
 });

--- a/tests/e2e/language-switcher.test.ts
+++ b/tests/e2e/language-switcher.test.ts
@@ -7,24 +7,24 @@ test.describe("Language switcher", () => {
   test("switches from the English post to its French translation", async ({
     page,
   }) => {
-    await page.goto("/en/blog/posts/post1");
+    await page.goto("/en/blog/posts/post1/");
 
     await page
       .getByRole("combobox", { name: en["form.settings.label.language"] })
       .selectOption({ label: LOCALE_DISPLAY_NAMES.fr });
 
-    await expect(page).toHaveURL("/blog/articles/post1");
+    await expect(page).toHaveURL("/blog/articles/post1/");
   });
 
   test("switches from the French post to its English translation", async ({
     page,
   }) => {
-    await page.goto("/blog/articles/post1");
+    await page.goto("/blog/articles/post1/");
 
     await page
       .getByRole("combobox", { name: fr["form.settings.label.language"] })
       .selectOption({ label: LOCALE_DISPLAY_NAMES.en });
 
-    await expect(page).toHaveURL("/en/blog/posts/post1");
+    await expect(page).toHaveURL("/en/blog/posts/post1/");
   });
 });

--- a/tests/e2e/notes-listing.test.ts
+++ b/tests/e2e/notes-listing.test.ts
@@ -6,7 +6,7 @@ import fr from "../../src/translations/fr.json" with { type: "json" };
  * pattern, at least one card) */
 test.describe("Notes listing", () => {
   test("renders the French notes listing", async ({ page }) => {
-    await page.goto("/notes");
+    await page.goto("/notes/");
 
     const main = page.getByRole("main");
 
@@ -19,7 +19,7 @@ test.describe("Notes listing", () => {
   test("navigates to a note's page when clicking its read-more link (French)", async ({
     page,
   }) => {
-    await page.goto("/notes");
+    await page.goto("/notes/");
 
     /* ListingPage itself renders as an <article>, and each card does too,
      * so the cards must be queried as nested articles to skip the wrapper. */
@@ -36,7 +36,7 @@ test.describe("Notes listing", () => {
   });
 
   test("renders the English notes listing", async ({ page }) => {
-    await page.goto("/en/notes");
+    await page.goto("/en/notes/");
 
     const main = page.getByRole("main");
 
@@ -49,7 +49,7 @@ test.describe("Notes listing", () => {
   test("navigates to a note's page when clicking its read-more link (English)", async ({
     page,
   }) => {
-    await page.goto("/en/notes");
+    await page.goto("/en/notes/");
 
     await page
       .getByRole("main")

--- a/tests/e2e/search.test.ts
+++ b/tests/e2e/search.test.ts
@@ -6,7 +6,7 @@ test.describe("Search", () => {
   test("renders the French search page with the search widget", async ({
     page,
   }) => {
-    await page.goto("/recherche");
+    await page.goto("/recherche/");
 
     await expect(page).toHaveTitle("Recherche | Armand Philippot");
     await expect(
@@ -16,7 +16,7 @@ test.describe("Search", () => {
   });
 
   test("shows results when typing a query (French)", async ({ page }) => {
-    await page.goto("/recherche");
+    await page.goto("/recherche/");
 
     await page.locator(".pagefind-ui__search-input").fill("Blog");
 
@@ -28,7 +28,7 @@ test.describe("Search", () => {
   test("renders the English search page with the search widget", async ({
     page,
   }) => {
-    await page.goto("/en/search");
+    await page.goto("/en/search/");
 
     await expect(page).toHaveTitle("Search | Armand Philippot");
     await expect(
@@ -38,7 +38,7 @@ test.describe("Search", () => {
   });
 
   test("shows results for a query passed via the URL", async ({ page }) => {
-    await page.goto("/en/search?q=Blog");
+    await page.goto("/en/search/?q=Blog");
 
     await expect(
       page.locator(".pagefind-ui__result-link").first()


### PR DESCRIPTION
## Changes

Enforces trailing slashes on all routes (except endpoints such as `feed.xml` obviously).

Because of a bug in Astro right now, `trailingSlash: "always"` can't be set. But, once fixed, we just need to uncomment it in the Astro config; no further changes should be required (unless additional logic in between).

## Tests

Updates a few tests; everything should be green!

## Docs

Changeset added (it might require an update if the Astro fix lands before I release the minor)