### PR TITLE
fix: pagination should also have a trailing slash

### DIFF
--- a/src/components/organisms/listing-page/listing-page.test.ts
+++ b/src/components/organisms/listing-page/listing-page.test.ts
@@ -81,7 +81,7 @@ describe("ListingPage", () => {
 
     expect(result).toContain(props.route);
     expect(result).toContain("listing-page-pagination");
-    expect(result).toContain('href="/page-route/page/2"');
+    expect(result).toContain('href="/page-route/page/2/"');
   });
 
   it<LocalTestContext>("uses the default minimum card size when none is provided", async ({

--- a/src/services/pagination/pagination.test.ts
+++ b/src/services/pagination/pagination.test.ts
@@ -63,7 +63,7 @@ describe("render-pagination-link", () => {
   it("should return the given route suffixed with the page number of other pages", () => {
     const route = "/base-path/";
 
-    expect(renderPaginationLink(route)(10)).toBe("/base-path/page/10");
+    expect(renderPaginationLink(route)(10)).toBe("/base-path/page/10/");
   });
 });
 /* eslint-enable @typescript-eslint/no-magic-numbers */

--- a/src/services/pagination/pagination.ts
+++ b/src/services/pagination/pagination.ts
@@ -81,5 +81,5 @@ export const renderPaginationLink =
   (route: string): ((pageNumber: number) => string) =>
   (pageNumber: number): string => {
     if (pageNumber === 1) return route;
-    return joinPaths(route, "page", `${pageNumber}`);
+    return joinPaths(route, "page", `${pageNumber}/`);
   };


### PR DESCRIPTION
## Changes

Fixes missing trailing slash on pagination.

## Tests

Everything should be green.

## Docs

None, follow-up of https://github.com/ArmandPhilippot/apeu/pull/283