### PR TITLE
feat: migrate the Pagefind integration to the Node.js API

### DIFF
--- a/.changeset/chubby-books-judge.md
+++ b/.changeset/chubby-books-judge.md
@@ -1,0 +1,7 @@
+---
+"apeu": patch
+---
+
+Fixes an incorrect note in the docs regarding the Search integration.
+
+The Search integration is still in use. The note belonged to the dev-only pages integration, which was removed in a previous release.

--- a/.changeset/quiet-actors-search.md
+++ b/.changeset/quiet-actors-search.md
@@ -1,0 +1,11 @@
+---
+"apeu": minor
+---
+
+Migrates the Pagefind integration to the Node.js API and builds the search index automatically in dev mode.
+
+The search index is now built using [Pagefind's Node.js API](https://pagefind.app/docs/node-api/) instead of spawning the `pagefind` CLI through `npx`. Build output is quieter as a result: a single summary line replaces the previous verbose CLI logs.
+
+In dev mode, if no search index is found, the project is now built once automatically before the dev server starts, instead of only warning that you need to run `pnpm build` manually. This means the first `pnpm dev` run after cloning (or after deleting `dist/`) takes longer, but search works out of the box afterwards.
+
+To use a fresh index in dev mode after making changes, you still need to run `pnpm build` before `pnpm dev`.

--- a/README.md
+++ b/README.md
@@ -114,12 +114,10 @@ The search is powered by [Pagefind](https://pagefind.app/), a fully static searc
 
 Therefore, there are some caveats in dev mode:
 
-- You need to run `pnpm build` once before executing `pnpm dev` to build the search index and to be able to use the search form.
+- If no search index is found, `pnpm dev` automatically builds the project once to generate it before starting the dev server. This only slows down the first run: once the index exists, subsequent `pnpm dev` runs use it as is.
+- If you want to run dev mode with a fresh index, you'll need to trigger a new build with `pnpm build` before running `pnpm dev`.
 - If you change the Pagefind config (like adding data attributes to filter the contents), the index will not be automatically rebuilt. You need to perform another build and to execute `pnpm dev` again.
 - The indexed images use the built URLs (the ones processed by Astro) so they can't be displayed in dev environment (so at the moment, they are fully deactivated).
-
-> [!NOTE]
-> This integration is no longer used, but is kept in the project in case we need it again later.
 
 ### Stories
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,7 +6,7 @@ import sitemap from "@astrojs/sitemap";
 import { defineConfig, envField, fontProviders } from "astro/config";
 import icon from "astro-icon";
 import { astroStories } from "./src/lib/astro/integrations/astro-stories";
-import { pagefind } from "./src/lib/astro/integrations/pagefind";
+import { pagefindSearch } from "./src/lib/astro/integrations/pagefind";
 import { hastInferRemoteImagesSize } from "./src/lib/satteri/hast/hast-infer-remote-images-size";
 import { hastLinkedImages } from "./src/lib/satteri/hast/hast-linked-images";
 import { hastMdxHtmlSyntax } from "./src/lib/satteri/hast/hast-mdx-html-syntax";
@@ -124,7 +124,7 @@ export default defineConfig({
       iconDir: "src/assets/icons",
     }),
     mdx({ syntaxHighlight: false }),
-    pagefind(),
+    pagefindSearch(),
     sitemap({
       i18n: {
         defaultLocale: CONFIG.LANGUAGES.DEFAULT,

--- a/knip.json
+++ b/knip.json
@@ -12,7 +12,6 @@
     "@typescript-eslint/parser",
     "baseline-browser-mapping",
     "modern-normalize",
-    "pagefind",
     "typescript-eslint"
   ],
   "postcss": true,

--- a/src/lib/astro/integrations/pagefind/pagefind.test.ts
+++ b/src/lib/astro/integrations/pagefind/pagefind.test.ts
@@ -1,17 +1,11 @@
-import { type ChildProcess, spawn } from "node:child_process";
+import type { PagefindIndex } from "pagefind";
 import { describe, expect, it, vi } from "vitest";
 import {
   createAstroBuildDoneMockContext,
   createAstroConfigSetupMockContext,
   createAstroServerSetupMockContext,
 } from "../../../../../tests/mocks/integrations";
-import { pagefind } from "./pagefind";
-
-vi.mock("node:child_process", () => {
-  return {
-    spawn: vi.fn(),
-  };
-});
+import { pagefindSearch } from "./pagefind";
 
 vi.mock("node:fs/promises", () => {
   return {
@@ -19,9 +13,16 @@ vi.mock("node:fs/promises", () => {
   };
 });
 
+vi.mock("pagefind", () => {
+  return {
+    createIndex: vi.fn(),
+    close: vi.fn(),
+  };
+});
+
 describe("pagefind", () => {
   it("should return an Astro integration", () => {
-    const integration = pagefind();
+    const integration = pagefindSearch();
 
     expect(integration.hooks["astro:config:setup"]).toBeDefined();
     expect(integration.hooks["astro:server:setup"]).toBeDefined();
@@ -33,7 +34,7 @@ describe("pagefind", () => {
     it("should do nothing in non-dev command", async () => {
       expect.assertions(1);
 
-      const integration = pagefind();
+      const integration = pagefindSearch();
       const mockContext = createAstroConfigSetupMockContext({
         command: "build",
       });
@@ -49,7 +50,7 @@ describe("pagefind", () => {
       const { access } = await import("node:fs/promises");
       vi.mocked(access).mockResolvedValueOnce();
 
-      const integration = pagefind();
+      const integration = pagefindSearch();
       const mockContext = createAstroConfigSetupMockContext();
 
       await integration.hooks["astro:config:setup"](mockContext);
@@ -65,7 +66,7 @@ describe("pagefind", () => {
       const { access } = await import("node:fs/promises");
       vi.mocked(access).mockRejectedValue(new Error("Not found"));
 
-      const integration = pagefind();
+      const integration = pagefindSearch();
       const mockContext = createAstroConfigSetupMockContext();
 
       await integration.hooks["astro:config:setup"](mockContext);
@@ -80,7 +81,7 @@ describe("pagefind", () => {
     it("should warn if outDir is not set", () => {
       expect.assertions(1);
 
-      const integration = pagefind();
+      const integration = pagefindSearch();
       const mockContext = createAstroServerSetupMockContext();
 
       integration.hooks["astro:server:setup"](mockContext);
@@ -92,31 +93,95 @@ describe("pagefind", () => {
   });
 
   describe("astro:build:done hook", () => {
-    it("should spawn pagefind process during build", async () => {
+    it("should index the output directory", async () => {
       expect.assertions(1);
 
-      const mockSpawn = vi.mocked(spawn).mockReturnValue({
-        on: vi.fn().mockImplementation((event, callback) => {
-          if (event === "close") {
-            callback();
-          }
-          return { on: vi.fn() };
-        }),
-      } as unknown as ChildProcess);
+      const pagefind = await import("pagefind");
+      const addDirectory = vi.fn().mockResolvedValue({ errors: [] });
+      const writeFiles = vi.fn().mockResolvedValue({ errors: [] });
+      vi.mocked(pagefind.createIndex).mockResolvedValue({
+        errors: [],
+        index: { addDirectory, writeFiles } as unknown as PagefindIndex,
+      });
 
-      const integration = pagefind();
+      const integration = pagefindSearch();
       const mockContext = createAstroBuildDoneMockContext();
 
       await integration.hooks["astro:build:done"](mockContext);
 
-      expect(mockSpawn).toHaveBeenCalledWith(
-        "npx",
-        expect.arrayContaining(["-y", "pagefind", "--site"]),
-        expect.objectContaining({
-          stdio: "inherit",
-          shell: true,
-        })
-      );
+      expect(addDirectory).toHaveBeenCalledWith({ path: "/mock/out/" });
+    });
+
+    it("should write the search index using the Node.js API", async () => {
+      expect.assertions(1);
+
+      const pagefind = await import("pagefind");
+      const addDirectory = vi.fn().mockResolvedValue({ errors: [] });
+      const writeFiles = vi.fn().mockResolvedValue({ errors: [] });
+      vi.mocked(pagefind.createIndex).mockResolvedValue({
+        errors: [],
+        index: { addDirectory, writeFiles } as unknown as PagefindIndex,
+      });
+
+      const integration = pagefindSearch();
+      const mockContext = createAstroBuildDoneMockContext();
+
+      await integration.hooks["astro:build:done"](mockContext);
+
+      expect(writeFiles).toHaveBeenCalledWith({
+        outputPath: "/mock/out/pagefind/",
+      });
+    });
+
+    it("should close the Pagefind service once the index is built", async () => {
+      expect.assertions(1);
+
+      const pagefind = await import("pagefind");
+      const addDirectory = vi.fn().mockResolvedValue({ errors: [] });
+      const writeFiles = vi.fn().mockResolvedValue({ errors: [] });
+      vi.mocked(pagefind.createIndex).mockResolvedValue({
+        errors: [],
+        index: { addDirectory, writeFiles } as unknown as PagefindIndex,
+      });
+
+      const integration = pagefindSearch();
+      const mockContext = createAstroBuildDoneMockContext();
+
+      await integration.hooks["astro:build:done"](mockContext);
+
+      expect(pagefind.close).toHaveBeenCalledWith();
+    });
+
+    it("should throw when the index cannot be created", async () => {
+      expect.assertions(1);
+
+      const pagefind = await import("pagefind");
+      vi.mocked(pagefind.createIndex).mockResolvedValue({
+        errors: ["boom"],
+      });
+
+      const integration = pagefindSearch();
+      const mockContext = createAstroBuildDoneMockContext();
+
+      await expect(
+        integration.hooks["astro:build:done"](mockContext)
+      ).rejects.toThrow("Failed to build the search index.");
+    });
+
+    it("should always close the Pagefind service, even on failure", async () => {
+      expect.assertions(1);
+
+      const pagefind = await import("pagefind");
+      vi.mocked(pagefind.createIndex).mockResolvedValue({
+        errors: ["boom"],
+      });
+
+      const integration = pagefindSearch();
+      const mockContext = createAstroBuildDoneMockContext();
+
+      await integration.hooks["astro:build:done"](mockContext).catch(() => undefined);
+
+      expect(pagefind.close).toHaveBeenCalledWith();
     });
   });
 });

--- a/src/lib/astro/integrations/pagefind/pagefind.test.ts
+++ b/src/lib/astro/integrations/pagefind/pagefind.test.ts
@@ -1,3 +1,4 @@
+import { type ChildProcess, spawn } from "node:child_process";
 import type { PagefindIndex } from "pagefind";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -6,6 +7,12 @@ import {
   createAstroServerSetupMockContext,
 } from "../../../../../tests/mocks/integrations";
 import { pagefindSearch } from "./pagefind";
+
+vi.mock("node:child_process", () => {
+  return {
+    spawn: vi.fn(),
+  };
+});
 
 vi.mock("node:fs/promises", () => {
   return {
@@ -19,6 +26,17 @@ vi.mock("pagefind", () => {
     close: vi.fn(),
   };
 });
+
+function mockSpawnClose(exitCode: number | null) {
+  return vi.mocked(spawn).mockReturnValue({
+    on: vi.fn().mockImplementation((event: string, callback: never) => {
+      if (event === "close") {
+        (callback as (code: number | null) => void)(exitCode);
+      }
+      return { on: vi.fn() };
+    }),
+  } as unknown as ChildProcess);
+}
 
 describe("pagefind", () => {
   it("should return an Astro integration", () => {
@@ -60,11 +78,12 @@ describe("pagefind", () => {
       );
     });
 
-    it("should log warning when pagefind directory is not accessible", async () => {
+    it("should warn when pagefind directory is not accessible", async () => {
       expect.assertions(1);
 
       const { access } = await import("node:fs/promises");
       vi.mocked(access).mockRejectedValue(new Error("Not found"));
+      mockSpawnClose(0);
 
       const integration = pagefindSearch();
       const mockContext = createAstroConfigSetupMockContext();
@@ -72,23 +91,95 @@ describe("pagefind", () => {
       await integration.hooks["astro:config:setup"](mockContext);
 
       expect(mockContext.logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining("You need to run `pnpm build`")
+        expect.stringContaining("No search index found")
+      );
+    });
+
+    it("should log info once the automatic build completes", async () => {
+      expect.assertions(1);
+
+      const { access } = await import("node:fs/promises");
+      vi.mocked(access).mockRejectedValue(new Error("Not found"));
+      mockSpawnClose(0);
+
+      const integration = pagefindSearch();
+      const mockContext = createAstroConfigSetupMockContext();
+
+      await integration.hooks["astro:config:setup"](mockContext);
+
+      expect(mockContext.logger.info).toHaveBeenCalledWith(
+        "Search index built!"
+      );
+    });
+
+    it("should spawn an isolated Node process to build the site", async () => {
+      expect.assertions(1);
+
+      const { access } = await import("node:fs/promises");
+      vi.mocked(access).mockRejectedValue(new Error("Not found"));
+      mockSpawnClose(0);
+
+      const integration = pagefindSearch();
+      const mockContext = createAstroConfigSetupMockContext();
+
+      await integration.hooks["astro:config:setup"](mockContext);
+
+      expect(spawn).toHaveBeenCalledWith(
+        process.execPath,
+        expect.arrayContaining(["--input-type=module", "/mock/build"]),
+        expect.objectContaining({ cwd: "/mock/build" })
+      );
+    });
+
+    it("should warn when the automatic build fails", async () => {
+      expect.assertions(1);
+
+      const { access } = await import("node:fs/promises");
+      vi.mocked(access).mockRejectedValue(new Error("Not found"));
+      mockSpawnClose(1);
+
+      const integration = pagefindSearch();
+      const mockContext = createAstroConfigSetupMockContext();
+
+      await integration.hooks["astro:config:setup"](mockContext);
+
+      expect(mockContext.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Failed to build the search index automatically"
+        )
       );
     });
   });
 
   describe("astro:server:setup hook", () => {
-    it("should warn if outDir is not set", () => {
-      expect.assertions(1);
+    it("should do nothing outside of dev mode", () => {
+      expect.assertions(0);
 
       const integration = pagefindSearch();
       const mockContext = createAstroServerSetupMockContext();
 
       integration.hooks["astro:server:setup"](mockContext);
+    });
 
-      expect(mockContext.logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining("Couldn't determine Pagefind output directory")
+    it("should register the Pagefind middleware once the index is available", async () => {
+      expect.assertions(1);
+
+      const { access } = await import("node:fs/promises");
+      vi.mocked(access).mockResolvedValueOnce();
+
+      const integration = pagefindSearch();
+      const use = vi.fn();
+
+      await integration.hooks["astro:config:setup"](
+        createAstroConfigSetupMockContext()
       );
+      integration.hooks["astro:server:setup"](
+        createAstroServerSetupMockContext({
+          server: { middlewares: { use } },
+        })
+      );
+
+      expect(use).toHaveBeenCalledWith(expect.any(Function));
     });
   });
 
@@ -179,7 +270,9 @@ describe("pagefind", () => {
       const integration = pagefindSearch();
       const mockContext = createAstroBuildDoneMockContext();
 
-      await integration.hooks["astro:build:done"](mockContext).catch(() => undefined);
+      await integration.hooks["astro:build:done"](mockContext).catch(
+        () => undefined
+      );
 
       expect(pagefind.close).toHaveBeenCalledWith();
     });

--- a/src/lib/astro/integrations/pagefind/pagefind.ts
+++ b/src/lib/astro/integrations/pagefind/pagefind.ts
@@ -1,14 +1,70 @@
-import { spawn } from "node:child_process";
 import { access } from "node:fs/promises";
-import { join, relative } from "node:path";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { AstroIntegration } from "astro";
+import type { AstroIntegration, AstroIntegrationLogger } from "astro";
+import * as pagefind from "pagefind";
 import sirv from "sirv";
 
 // `sirv` will most likely only be used in this file so:
 // cSpell:ignore -- sirv
 
-export const pagefind = (() => {
+const oneSecondInMs = 1000;
+const twoDecimals = 2;
+
+type PagefindResponse = {
+  errors: string[];
+};
+
+function assertPagefindResponse<T extends PagefindResponse>(
+  response: T,
+  logger: AstroIntegrationLogger
+): asserts response is Required<T> {
+  if (response.errors.length === 0) return;
+  for (const error of response.errors) {
+    logger.error(error);
+  }
+  throw new Error(
+    `Pagefind response contains errors: ${response.errors.join(", ")}`
+  );
+}
+
+function formatElapsedTime(elapsed: number): string {
+  return elapsed < oneSecondInMs
+    ? `${Math.round(elapsed)}ms`
+    : `${(elapsed / oneSecondInMs).toFixed(twoDecimals)}s`;
+}
+
+async function buildSearchIndex(dir: URL, logger: AstroIntegrationLogger) {
+  const targetDir = fileURLToPath(dir);
+  const outputPath = fileURLToPath(new URL("./pagefind/", dir));
+
+  try {
+    const start = performance.now();
+    logger.info("Building the search index...");
+
+    const indexResponse = await pagefind.createIndex();
+    assertPagefindResponse(indexResponse, logger);
+
+    const indexingResponse = await indexResponse.index.addDirectory({
+      path: targetDir,
+    });
+    assertPagefindResponse(indexingResponse, logger);
+
+    const writingResponse = await indexResponse.index.writeFiles({
+      outputPath,
+    });
+    assertPagefindResponse(writingResponse, logger);
+
+    const elapsed = performance.now() - start;
+    logger.info(`Search index built in ${formatElapsedTime(elapsed)}.`);
+  } catch (error) {
+    throw new Error("Failed to build the search index.", { cause: error });
+  } finally {
+    await pagefind.close();
+  }
+}
+
+export const pagefindSearch = (() => {
   let outDir: string | null = null;
 
   return {
@@ -58,23 +114,8 @@ export const pagefind = (() => {
           }
         });
       },
-      "astro:build:done": async ({ dir, logger }) => {
-        const targetDir = fileURLToPath(dir);
-        const cwd = import.meta.dirname;
-        const relativeDir = relative(cwd, targetDir);
-
-        logger.info("Building the search index...");
-
-        return new Promise<void>((resolve) => {
-          spawn("npx", ["-y", "pagefind", "--site", relativeDir], {
-            stdio: "inherit",
-            shell: true,
-            cwd,
-          }).on("close", () => {
-            resolve();
-          });
-        });
-      },
+      "astro:build:done": async ({ dir, logger }) =>
+        buildSearchIndex(dir, logger),
     },
   };
 }) satisfies () => AstroIntegration;

--- a/src/lib/astro/integrations/pagefind/pagefind.ts
+++ b/src/lib/astro/integrations/pagefind/pagefind.ts
@@ -1,7 +1,12 @@
+import { spawn } from "node:child_process";
 import { access } from "node:fs/promises";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { AstroIntegration, AstroIntegrationLogger } from "astro";
+import type {
+  AstroConfig,
+  AstroIntegration,
+  AstroIntegrationLogger,
+} from "astro";
 import * as pagefind from "pagefind";
 import sirv from "sirv";
 
@@ -15,6 +20,7 @@ type PagefindResponse = {
   errors: string[];
 };
 
+// Assertion function cannot use arrow function syntax because of a TypeScript limitation.
 function assertPagefindResponse<T extends PagefindResponse>(
   response: T,
   logger: AstroIntegrationLogger
@@ -28,13 +34,72 @@ function assertPagefindResponse<T extends PagefindResponse>(
   );
 }
 
-function formatElapsedTime(elapsed: number): string {
-  return elapsed < oneSecondInMs
+const formatElapsedTime = (elapsed: number): string =>
+  elapsed < oneSecondInMs
     ? `${Math.round(elapsed)}ms`
     : `${(elapsed / oneSecondInMs).toFixed(twoDecimals)}s`;
-}
 
-async function buildSearchIndex(dir: URL, logger: AstroIntegrationLogger) {
+// Runs in its own process: calling `build()` in-process here would tear down
+// the Vite module runner the running `astro dev` command still needs.
+const buildScript = `
+import { build } from "astro";
+await build({ root: process.argv[1] }, { devOutput: true });
+`;
+
+const runAstroBuild = async (root: string): Promise<void> => {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      ["--input-type=module", "--eval", buildScript, "--", root],
+      { cwd: root, stdio: "inherit" }
+    );
+
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`\`astro build\` exited with code ${String(code)}.`));
+      }
+    });
+  });
+};
+
+const ensureSearchIndex = async (
+  config: AstroConfig,
+  logger: AstroIntegrationLogger
+): Promise<string> => {
+  const outDir = fileURLToPath(
+    config.adapter?.name === "@astrojs/node" && config.output === "static"
+      ? config.build.client
+      : config.outDir
+  );
+  const pagefindDir = join(outDir, "/pagefind");
+
+  try {
+    await access(pagefindDir);
+    logger.info("Search index found!");
+    return outDir;
+  } catch {
+    logger.warn(
+      "No search index found. Building the site once to enable search in dev mode…"
+    );
+  }
+
+  try {
+    await runAstroBuild(fileURLToPath(config.root));
+    logger.info("Search index built!");
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    logger.warn(
+      `Failed to build the search index automatically: ${reason}. Run \`pnpm build\` manually to enable search in dev mode.`
+    );
+  }
+
+  return outDir;
+};
+
+const buildSearchIndex = async (dir: URL, logger: AstroIntegrationLogger) => {
   const targetDir = fileURLToPath(dir);
   const outputPath = fileURLToPath(new URL("./pagefind/", dir));
 
@@ -62,44 +127,36 @@ async function buildSearchIndex(dir: URL, logger: AstroIntegrationLogger) {
   } finally {
     await pagefind.close();
   }
-}
+};
 
+/**
+ * Pagefind search integration for Astro.
+ *
+ * @returns {AstroIntegration} An Astro integration that adds Pagefind search functionality.
+ */
 export const pagefindSearch = (() => {
   let outDir: string | null = null;
+  // `astro:server:setup` doesn't expose `command`, so we remember whether
+  // we're actually in `astro dev` here instead.
+  let isDevCommand = false;
 
   return {
     name: "pagefind",
     hooks: {
       "astro:config:setup": async ({ command, config, logger }) => {
-        if (command !== "dev") return;
+        isDevCommand = command === "dev";
+
+        if (!isDevCommand) return;
 
         logger.info("Checking if search index is available...");
 
-        outDir = fileURLToPath(
-          config.adapter?.name === "@astrojs/node" && config.output === "static"
-            ? config.build.client
-            : config.outDir
-        );
-
-        const pagefindDir = join(outDir, "/pagefind");
-
-        try {
-          await access(pagefindDir);
-          logger.info("Search index found!");
-        } catch {
-          logger.warn(
-            "You need to run `pnpm build` once to be able to use search features in dev mode."
-          );
-        }
+        outDir = await ensureSearchIndex(config, logger);
       },
-      "astro:server:setup": ({ logger, server }) => {
-        if (outDir === null) {
-          logger.warn(
-            "Couldn't determine Pagefind output directory. Search will not be available."
-          );
-
-          return;
-        }
+      "astro:server:setup": ({ server }) => {
+        // A `--devOutput` build (used by `runAstroBuild` above) makes Astro's
+        // internal Vite server report `isProduction: false`, so we need to
+        // check `isDevCommand` in addition to `outDir`.
+        if (!isDevCommand || outDir === null) return;
 
         const serve = sirv(outDir, {
           dev: true,

--- a/tests/mocks/integrations.ts
+++ b/tests/mocks/integrations.ts
@@ -23,7 +23,7 @@ export const createAstroBuildDoneMockContext = (
 ): HookParameters<"astro:build:done"> => {
   return {
     assets: new Map(),
-    dir: new URL("file:///mock/out"),
+    dir: new URL("file:///mock/out/"),
     logger,
     pages: [],
     ...overrides,


### PR DESCRIPTION
## Changes

- Migrates the Pagefind integration to the Node.js API
- Builds the search index automatically in dev mode if none are available.

## Tests

I updated the pagefind tests; everything should be green!

## Docs

- Changesets added.
- Readme updated.