### PR TITLE
fix: missing spacing between elements inside callouts

### DIFF
--- a/.changeset/ripe-keys-make.md
+++ b/.changeset/ripe-keys-make.md
@@ -1,0 +1,5 @@
+---
+"apeu": patch
+---
+
+Add spacing between the elements inside the callouts.

--- a/.changeset/ripe-keys-make.md
+++ b/.changeset/ripe-keys-make.md
@@ -2,4 +2,4 @@
 "apeu": patch
 ---
 
-Add spacing between the elements inside the callouts.
+Improves readability by adding spacing between elements inside the callouts.

--- a/src/components/atoms/callout/callout.astro
+++ b/src/components/atoms/callout/callout.astro
@@ -121,5 +121,13 @@ const heading = label || defaultLabel[type];
     .callout > :global(*:last-child:not(:only-child)) {
       margin-block-end: 0;
     }
+
+    .callout > :global(*:not(:first-child)) {
+      margin-block-start: var(--spacing-md);
+    }
+
+    .callout > :global(*:not(:last-child)) {
+      margin-block-end: var(--spacing-md);
+    }
   }
 </style>


### PR DESCRIPTION
## Changes

I don't know when it happened, but it seems I've lost some spacing between the elements inside the callouts, which is affecting readability:

<img width="717" height="251" alt="image" src="https://github.com/user-attachments/assets/dbea46b8-2c5d-44e5-872d-db103ffeb31c" />

## Tests

Manually

## Docs

Changeset added.
