### PR TITLE
feat: always use trailing slash

### DIFF
--- a/.changeset/major-brooms-know.md
+++ b/.changeset/major-brooms-know.md
@@ -6,6 +6,4 @@ Enforces trailing slash on routes.
 
 Previously, trailing slashes were not enforced. This meant that routes could be accessed with or without a trailing slash. This change enforces trailing slashes on all routes (except file endpoints such as `feed.xml`), which can help with SEO and consistency.
 
-However, due to a bug in Astro, `trailingSlash` cannot be set to `always`. This means that while the intention is to have trailing slashes for all routes, it may not be fully enforced until the bug is resolved.
-
 If you have links pointing to routes without trailing slashes, you may need to update them to include the trailing slash or set up redirects at the hosting level to ensure they resolve correctly.

--- a/.changeset/mighty-poems-speak.md
+++ b/.changeset/mighty-poems-speak.md
@@ -1,0 +1,9 @@
+---
+"apeu": minor
+---
+
+Switches `build.format` config from `preserve` to `directory`.
+
+Using `trailingSlash: "always"` in `astro.config.mjs` is not compatible with `build.format: "preserve"` and will cause a build error in some cases.
+
+If you were relying on the build output being, for example, `/dist/client/en/404.html` to localize the 404 page, you will need to update your code to use `/dist/client/en/404/index.html` instead.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -151,9 +151,7 @@ export default defineConfig({
   },
   output: "static",
   site: `https://${CONFIG.HOST}`,
-  /* A bug in Astro prevents us to use this, but the aim is to have trailing
-   * slashes for all routes. */
-  //trailingSlash: "always",
+  trailingSlash: "always",
   vite: {
     server: {
       watch: {

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -25,7 +25,7 @@ export default defineConfig({
     mode: "standalone",
   }),
   build: {
-    format: "preserve",
+    format: "directory",
   },
   env: {
     schema: {

--- a/src/components/atoms/img/img.test.ts
+++ b/src/components/atoms/img/img.test.ts
@@ -8,7 +8,7 @@ type LocalTestContext = {
 };
 
 const getAstroImagePrefix = (src: string) =>
-  `/_image?href=${encodeURIComponent(src)}`;
+  `/_image/?href=${encodeURIComponent(src)}`;
 
 describe("Img", () => {
   beforeEach<LocalTestContext>(async (context) => {

--- a/src/components/organisms/content-page/content-page.test.ts
+++ b/src/components/organisms/content-page/content-page.test.ts
@@ -8,7 +8,7 @@ type LocalTestContext = {
 };
 
 const getAstroImagePrefix = (src: string) =>
-  `/_image?href=${encodeURIComponent(src)}`;
+  `/_image/?href=${encodeURIComponent(src)}`;
 
 describe("ContentPage", () => {
   beforeEach<LocalTestContext>(async (context) => {


### PR DESCRIPTION
## Changes

Enforces a trailing slash at the end of the URLs.

This should help search engine indexing the right page without seeing duplicate content. For example, the Google Webmaster Tools complains because some URLs are identical and, oddly, uses the non-canonical version.

This means we can no longer uses `build.format: "preserve"`; the build fails in some cases. The new config is `directory`. That impacts a few files like `/en/404.html` becoming `/en/404/index.html`. I think it's a fair trade-off...

## Tests

Everything should be green. I had to fix a few tests around the image endpoint.

## Docs

One changeset has been updated and I added a new minor changeset for the `build.format` change.