### PR TITLE
ci: use a matrix to split CI jobs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,5 +59,9 @@ jobs:
       - name: Install dependencies
         run: pnpm i
 
+      - name: Generate Astro types
+        if: matrix.name == 'Scripts'
+        run: pnpm astro sync
+
       - name: Lint
         run: pnpm run ${{ matrix.script }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,9 +26,23 @@ concurrency:
 
 jobs:
   lint:
-    name: Lint
+    name: ${{ matrix.name }}
     timeout-minutes: 15
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Types
+            script: lint:types
+          - name: Scripts
+            script: lint:scripts
+          - name: Styles
+            script: lint:styles
+          - name: Spelling
+            script: lint:spelling
+          - name: Formatting
+            script: lint:formatting
     steps:
       - name: Checkout Repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -45,17 +59,5 @@ jobs:
       - name: Install dependencies
         run: pnpm i
 
-      - name: Lint - Types
-        run: pnpm lint:types
-
-      - name: Lint - Scripts
-        run: pnpm run lint:scripts
-
-      - name: Lint - Styles
-        run: pnpm run lint:styles
-
-      - name: Lint - Spelling
-        run: pnpm run lint:spelling
-
-      - name: Lint - Formatting
-        run: pnpm run lint:formatting
+      - name: Lint
+        run: pnpm run ${{ matrix.script }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,10 +25,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
-    name: Tests
+  tests:
+    name: ${{ matrix.name }}
     timeout-minutes: 15
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Unit
+            script: test:unit
+          - name: E2E
+            script: test:e2e
     steps:
       - name: Checkout Repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -46,16 +54,14 @@ jobs:
         run: pnpm i
 
       - name: "Install Playwright browser"
+        if: matrix.name == 'E2E'
         run: "pnpm exec playwright install --with-deps chromium"
 
-      - name: Unit Tests
-        run: pnpm test:unit
-
-      - name: "E2E tests"
-        run: "pnpm test:e2e"
+      - name: Run tests
+        run: pnpm run ${{ matrix.script }}
 
       - name: "Upload Playwright artifacts"
-        if: ${{ failure() && !cancelled() }}
+        if: ${{ matrix.name == 'E2E' && failure() && !cancelled() }}
         uses: "actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f" # v6.0.0
         with:
           name: "playwright-artifacts"


### PR DESCRIPTION
## Changes

Use a matrix to split jobs in the CI. The goal is to replace the following with a more detailed view:
<img width="402" height="154" alt="Current CI showing `Lint / Lint` and `Test / Test`" src="https://github.com/user-attachments/assets/b2da2dfc-a940-4784-b6e2-43004523c2a7" />

## Tests

Everything green.

## Docs

N/A